### PR TITLE
fix: add id in search, list message tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,10 @@ server.tool(
     }
 
     const messageList = messages
-      .map((m) => `  - ${m.subject} (from: ${m.sender}) [${m.isRead ? "read" : "unread"}]`)
+      .map(
+        (m) =>
+          `  - ID: ${m.id} | ${m.subject} (from: ${m.sender}) [${m.isRead ? "read" : "unread"}]`
+      )
       .join("\n");
 
     return successResponse(`Found ${messages.length} message(s):\n${messageList}`);
@@ -157,7 +160,9 @@ server.tool(
       return successResponse("No messages found");
     }
 
-    const messageList = messages.map((m) => `  - ${m.subject} (from: ${m.sender})`).join("\n");
+    const messageList = messages
+      .map((m) => `  - ID: ${m.id} | ${m.subject} (from: ${m.sender})`)
+      .join("\n");
 
     return successResponse(`Found ${messages.length} message(s):\n${messageList}`);
   }, "Error listing messages")


### PR DESCRIPTION
get-message can't read message without ids...
pls merge this pr

## Description
Add id response in search, list message


## Type of Change

- [x] Bug fix

## Testing

- [x] Tests pass locally (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style
- [x] I have updated documentation if needed
