### PR TITLE
feat: add file attachment support for send-email and create-draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ On first use, macOS will ask for permission to automate Mail.app. Click "OK" to 
 | **List Messages** | List messages with pagination, sender filter, date display |
 | **Search Messages** | Search by sender, subject, content, date range, read/flagged status — across all accounts |
 | **Read Messages** | Get full email content (plain text or HTML) |
-| **Send Email** | Compose and send new emails |
-| **Create Draft** | Save emails to Drafts folder |
+| **Send Email** | Compose and send new emails (with optional file attachments) |
+| **Create Draft** | Save emails to Drafts folder (with optional file attachments) |
 | **Reply** | Reply to messages (with reply-all support) |
 | **Forward** | Forward messages to new recipients |
 | **Mark Read/Unread** | Change read status (single or batch) |
@@ -190,6 +190,7 @@ Send a new email immediately.
 | `cc` | string[] | No | CC recipients |
 | `bcc` | string[] | No | BCC recipients |
 | `account` | string | No | Send from specific account |
+| `attachments` | string[] | No | Absolute file paths to attach (e.g., `["/Users/me/report.pdf"]`) |
 
 **Example:**
 ```json
@@ -197,7 +198,8 @@ Send a new email immediately.
   "to": ["colleague@company.com"],
   "subject": "Meeting Tomorrow",
   "body": "Hi, just confirming our meeting at 2pm tomorrow.",
-  "account": "Work"
+  "account": "Work",
+  "attachments": ["/Users/me/Documents/agenda.pdf"]
 }
 ```
 
@@ -215,6 +217,7 @@ Save an email to Drafts without sending.
 | `cc` | string[] | No | CC recipients |
 | `bcc` | string[] | No | BCC recipients |
 | `account` | string | No | Account for draft |
+| `attachments` | string[] | No | Absolute file paths to attach |
 
 **Returns:** Confirmation that draft was created.
 
@@ -663,7 +666,7 @@ If installed from source, use this configuration:
 |------------|--------|
 | macOS only | Apple Mail and AppleScript are macOS-specific |
 | No sending HTML email | Emails are sent as plain text; reading HTML content is supported |
-| No adding attachments | Can list and save existing attachments, but cannot attach files to outgoing emails |
+| Attachments require absolute paths | File attachments must use full absolute paths (e.g., `/Users/me/file.pdf`) |
 | No smart mailboxes | Cannot access Smart Mailboxes via AppleScript |
 | In-memory templates | Email templates are not persisted across server restarts |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,15 +191,20 @@ server.tool(
     cc: z.array(z.string()).optional().describe("CC recipients"),
     bcc: z.array(z.string()).optional().describe("BCC recipients"),
     account: z.string().optional().describe("Account to send from"),
+    attachments: z
+      .array(z.string())
+      .optional()
+      .describe("Absolute file paths to attach (e.g., ['/Users/me/report.pdf'])"),
   },
-  withErrorHandling(({ to, subject, body, cc, bcc, account }) => {
-    const success = mailManager.sendEmail(to, subject, body, cc, bcc, account);
+  withErrorHandling(({ to, subject, body, cc, bcc, account, attachments }) => {
+    const success = mailManager.sendEmail(to, subject, body, cc, bcc, account, attachments);
 
     if (!success) {
       return errorResponse("Failed to send email. Check Mail.app configuration.");
     }
 
-    return successResponse(`Email sent to ${to.join(", ")}`);
+    const attachInfo = attachments?.length ? ` with ${attachments.length} attachment(s)` : "";
+    return successResponse(`Email sent to ${to.join(", ")}${attachInfo}`);
   }, "Error sending email")
 );
 
@@ -214,15 +219,20 @@ server.tool(
     cc: z.array(z.string()).optional().describe("CC recipients"),
     bcc: z.array(z.string()).optional().describe("BCC recipients"),
     account: z.string().optional().describe("Account to create draft in"),
+    attachments: z
+      .array(z.string())
+      .optional()
+      .describe("Absolute file paths to attach (e.g., ['/Users/me/report.pdf'])"),
   },
-  withErrorHandling(({ to, subject, body, cc, bcc, account }) => {
-    const success = mailManager.createDraft(to, subject, body, cc, bcc, account);
+  withErrorHandling(({ to, subject, body, cc, bcc, account, attachments }) => {
+    const success = mailManager.createDraft(to, subject, body, cc, bcc, account, attachments);
 
     if (!success) {
       return errorResponse("Failed to create draft. Check Mail.app configuration.");
     }
 
-    return successResponse(`Draft created for ${to.join(", ")}`);
+    const attachInfo = attachments?.length ? ` with ${attachments.length} attachment(s)` : "";
+    return successResponse(`Draft created for ${to.join(", ")}${attachInfo}`);
   }, "Error creating draft")
 );
 

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -592,7 +592,8 @@ export class AppleMailManager {
     body: string,
     cc?: string[],
     bcc?: string[],
-    account?: string
+    account?: string,
+    attachments?: string[]
   ): boolean {
     const safeSubject = escapeForAppleScript(subject);
     const safeBody = escapeForAppleScript(body);
@@ -613,6 +614,15 @@ export class AppleMailManager {
       }
     }
 
+    // Build attachment additions
+    let attachmentCommands = "";
+    if (attachments) {
+      for (const filePath of attachments) {
+        const safePath = escapeForAppleScript(filePath);
+        attachmentCommands += `make new attachment with properties {file name:POSIX file "${safePath}"} at after the last paragraph\n`;
+      }
+    }
+
     let sendCommand: string;
     if (account) {
       const safeAccount = escapeForAppleScript(account);
@@ -621,6 +631,7 @@ export class AppleMailManager {
         tell newMessage
           ${recipientCommands}
           set sender to "${safeAccount}"
+          ${attachmentCommands}
         end tell
         send newMessage
         return "sent"
@@ -630,6 +641,7 @@ export class AppleMailManager {
         set newMessage to make new outgoing message with properties {subject:"${safeSubject}", content:"${safeBody}", visible:true}
         tell newMessage
           ${recipientCommands}
+          ${attachmentCommands}
         end tell
         send newMessage
         return "sent"
@@ -664,7 +676,8 @@ export class AppleMailManager {
     body: string,
     cc?: string[],
     bcc?: string[],
-    account?: string
+    account?: string,
+    attachments?: string[]
   ): boolean {
     const safeSubject = escapeForAppleScript(subject);
     const safeBody = escapeForAppleScript(body);
@@ -685,6 +698,15 @@ export class AppleMailManager {
       }
     }
 
+    // Build attachment additions
+    let attachmentCommands = "";
+    if (attachments) {
+      for (const filePath of attachments) {
+        const safePath = escapeForAppleScript(filePath);
+        attachmentCommands += `make new attachment with properties {file name:POSIX file "${safePath}"} at after the last paragraph\n`;
+      }
+    }
+
     let draftCommand: string;
     if (account) {
       const safeAccount = escapeForAppleScript(account);
@@ -693,6 +715,7 @@ export class AppleMailManager {
         tell newMessage
           ${recipientCommands}
           set sender to "${safeAccount}"
+          ${attachmentCommands}
         end tell
         return "draft created"
       `;
@@ -701,6 +724,7 @@ export class AppleMailManager {
         set newMessage to make new outgoing message with properties {subject:"${safeSubject}", content:"${safeBody}", visible:false}
         tell newMessage
           ${recipientCommands}
+          ${attachmentCommands}
         end tell
         return "draft created"
       `;


### PR DESCRIPTION
## Summary

- Adds optional `attachments` parameter (array of absolute file paths) to `send-email` and `create-draft` tools
- Enables AI assistants to compose and send emails with file attachments directly from Apple Mail
- Uses AppleScript's `make new attachment with properties {file name:POSIX file "..."}` for reliable attachment handling

## Use Case

This is a key missing feature: AI assistants like Claude can generate files (PDFs, spreadsheets, presentations) but cannot currently attach them to outgoing emails. Users must manually add attachments in Mail.app.

With this change:
```
"Create a quarterly report PDF and email it to the team"
```
...works end-to-end without manual intervention.

## Changes

- `src/services/appleMailManager.ts`: Added `attachments?: string[]` parameter to `sendEmail()` and `createDraft()` methods
- `src/index.ts`: Added `attachments` to the Zod schemas for `send-email` and `create-draft` tools

## Test plan

- [x] Tested sending email with attachment via Apple Mail on macOS
- [x] Tested creating draft with attachment
- [x] Verified MCP server starts and exposes `attachments` parameter in tool schemas
- [x] Verified backward compatibility (no attachments = works as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)