### PR TITLE
feat: add send-serial-email tool (mail merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ On first use, macOS will ask for permission to automate Mail.app. Click "OK" to 
 | **Search Messages** | Search by sender, subject, content, date range, read/flagged status — across all accounts |
 | **Read Messages** | Get full email content (plain text or HTML) |
 | **Send Email** | Compose and send new emails |
+| **Send Serial Email** | Mail merge — send personalized emails to a list of recipients with {{placeholder}} support |
 | **Create Draft** | Save emails to Drafts folder |
 | **Reply** | Reply to messages (with reply-all support) |
 | **Forward** | Forward messages to new recipients |
@@ -200,6 +201,41 @@ Send a new email immediately.
   "account": "Work"
 }
 ```
+
+---
+
+#### `send-serial-email`
+
+Send individual personalized emails to a list of recipients (mail merge). Each recipient receives their own email — recipients don't see each other. Supports `{{placeholder}}` tokens in both subject and body.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `recipients` | object[] | Yes | List of recipients (see below) |
+| `subject` | string | Yes | Email subject — use `{{Key}}` for placeholders |
+| `body` | string | Yes | Email body — use `{{Key}}` for placeholders |
+| `account` | string | No | Send from specific account |
+| `delayMs` | number | No | Delay between sends in ms (default: 500) |
+
+Each recipient object:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `email` | string | Yes | Recipient email address |
+| `variables` | object | Yes | Key-value pairs for placeholder replacement |
+
+**Example:**
+```json
+{
+  "recipients": [
+    { "email": "alice@example.com", "variables": { "Name": "Alice", "Company": "Acme" } },
+    { "email": "bob@example.com", "variables": { "Name": "Bob", "Company": "Globex" } }
+  ],
+  "subject": "Hello {{Name}}!",
+  "body": "Dear {{Name}},\n\nGreat to connect about {{Company}}.\n\nBest regards"
+}
+```
+
+**Returns:** Per-recipient success/failure results with a summary count.
 
 ---
 
@@ -604,6 +640,19 @@ AI: [calls create-draft with to=["team@..."], subject="...", body="..."]
 
 User: "Send it"
 AI: [User opens Mail.app and sends manually, or AI calls send-email]
+```
+
+### Sending Personalized Emails (Mail Merge)
+
+```
+User: "Send a personalized email to Alice (alice@acme.com), Bob (bob@globex.com),
+       and Carol (carol@initech.com). Subject: 'Project Update for {{Company}}',
+       Body: 'Hi {{Name}}, here is the latest update for {{Company}}.'"
+AI: [calls send-serial-email with recipients, subject template, and body template]
+    "Successfully sent 3 email(s):
+      - alice@acme.com: sent
+      - bob@globex.com: sent
+      - carol@initech.com: sent"
 ```
 
 ### Organizing Messages

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,54 @@ server.tool(
   }, "Error sending email")
 );
 
+// --- send-serial-email ---
+
+server.tool(
+  "send-serial-email",
+  {
+    recipients: z
+      .array(
+        z.object({
+          email: z.string().min(1, "Recipient email is required"),
+          variables: z
+            .record(z.string())
+            .describe("Placeholder values, e.g. { Name: 'Alice', Company: 'Acme' }"),
+        })
+      )
+      .min(1, "At least one recipient is required")
+      .describe("List of recipients with personalization variables"),
+    subject: z
+      .string()
+      .min(1, "Subject is required")
+      .describe("Subject line — use {{Key}} for placeholders"),
+    body: z
+      .string()
+      .min(1, "Body is required")
+      .describe("Email body — use {{Key}} for placeholders"),
+    account: z.string().optional().describe("Account to send from"),
+    delayMs: z.number().optional().describe("Delay between sends in ms (default: 500)"),
+  },
+  withErrorHandling(({ recipients, subject, body, account, delayMs }) => {
+    const results = mailManager.sendSerialEmail(recipients, subject, body, account, delayMs);
+    const successCount = results.filter((r) => r.success).length;
+    const failCount = results.length - successCount;
+
+    const details = results
+      .map((r) => `  - ${r.email}: ${r.success ? "sent" : `FAILED (${r.error})`}`)
+      .join("\n");
+
+    if (failCount === 0) {
+      return successResponse(`Successfully sent ${successCount} email(s):\n${details}`);
+    } else if (successCount === 0) {
+      return errorResponse(`Failed to send all ${failCount} email(s):\n${details}`);
+    } else {
+      return successResponse(
+        `Sent ${successCount} of ${results.length} email(s), ${failCount} failed:\n${details}`
+      );
+    }
+  }, "Error sending serial emails")
+);
+
 // --- create-draft ---
 
 server.tool(

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -29,6 +29,8 @@ import type {
   MailRule,
   Contact,
   EmailTemplate,
+  SerialEmailRecipient,
+  SerialEmailResult,
 } from "@/types.js";
 
 // =============================================================================
@@ -645,6 +647,75 @@ export class AppleMailManager {
     }
 
     return result.output.includes("sent");
+  }
+
+  /**
+   * Send individual personalized emails to a list of recipients (mail merge).
+   *
+   * Replaces {{placeholder}} tokens in subject and body with per-recipient values.
+   * Each recipient receives their own individual email.
+   *
+   * @param recipients - List of recipient objects with email and variable values
+   * @param subject - Email subject (may contain {{placeholders}})
+   * @param body - Email body (may contain {{placeholders}})
+   * @param account - Account to send from
+   * @param attachments - Optional file paths to attach to each email
+   * @param delayMs - Delay between sends in milliseconds (default: 500)
+   * @returns Array of per-recipient results
+   */
+  sendSerialEmail(
+    recipients: SerialEmailRecipient[],
+    subject: string,
+    body: string,
+    account?: string,
+    delayMs: number = 500
+  ): SerialEmailResult[] {
+    const results: SerialEmailResult[] = [];
+
+    for (const recipient of recipients) {
+      try {
+        // Replace all {{Key}} placeholders with recipient's values
+        let personalizedSubject = subject;
+        let personalizedBody = body;
+        for (const [key, value] of Object.entries(recipient.variables)) {
+          const safeKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          const placeholder = new RegExp(`\\{\\{${safeKey}\\}\\}`, "g");
+          personalizedSubject = personalizedSubject.replace(placeholder, value);
+          personalizedBody = personalizedBody.replace(placeholder, value);
+        }
+
+        const success = this.sendEmail(
+          [recipient.email],
+          personalizedSubject,
+          personalizedBody,
+          undefined,
+          undefined,
+          account
+        );
+
+        results.push({
+          email: recipient.email,
+          success,
+          error: success ? undefined : "Failed to send email",
+        });
+      } catch (error) {
+        results.push({
+          email: recipient.email,
+          success: false,
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+
+      // Brief delay between sends to avoid overwhelming Mail.app
+      if (delayMs > 0 && recipients.indexOf(recipient) < recipients.length - 1) {
+        const start = Date.now();
+        while (Date.now() - start < delayMs) {
+          /* busy wait - sync context */
+        }
+      }
+    }
+
+    return results;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,6 +287,35 @@ export interface MoveMessageParams {
 }
 
 // =============================================================================
+// Serial Email (Mail Merge)
+// =============================================================================
+
+/**
+ * A single recipient in a serial email (mail merge) operation.
+ */
+export interface SerialEmailRecipient {
+  /** Recipient email address */
+  email: string;
+
+  /** Variable values for placeholder replacement (e.g., { Name: "Alice", Company: "Acme" }) */
+  variables: Record<string, string>;
+}
+
+/**
+ * Result of sending a serial email to a single recipient.
+ */
+export interface SerialEmailResult {
+  /** Recipient email address */
+  email: string;
+
+  /** Whether the email was sent successfully */
+  success: boolean;
+
+  /** Error message if sending failed */
+  error?: string;
+}
+
+// =============================================================================
 // Health Check
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Adds a new `send-serial-email` tool that enables mail merge functionality:

- Sends **individual personalized emails** to a list of recipients (one email per recipient — recipients don't see each other)
- Supports **{{placeholder}} tokens** in both subject and body, replaced with per-recipient variable values
- Includes a configurable **delay between sends** (default: 500ms) to avoid overwhelming Mail.app's AppleScript bridge
- Returns **per-recipient success/failure results**

### Example usage

```json
{
  "recipients": [
    { "email": "alice@example.com", "variables": { "Name": "Alice", "Company": "Acme" } },
    { "email": "bob@example.com", "variables": { "Name": "Bob", "Company": "Globex" } }
  ],
  "subject": "Hello {{Name}}!",
  "body": "Dear {{Name}},\n\nGreat to connect about {{Company}}.\n\nBest regards"
}
```

### Changes

- **`src/types.ts`**: Added `SerialEmailRecipient` and `SerialEmailResult` interfaces
- **`src/services/appleMailManager.ts`**: Added `sendSerialEmail()` method that iterates recipients, replaces placeholders, and calls existing `sendEmail()` for each
- **`src/index.ts`**: Added `send-serial-email` tool definition with Zod schema

### Design decisions

- Reuses existing `sendEmail()` internally — no duplicate AppleScript logic
- Regex-safe placeholder key escaping for robustness
- Missing placeholders are left as-is (fail-open) rather than blocking the batch
- Synchronous busy-wait delay matches the existing sync architecture (`execFileSync`)

## Test plan

- [ ] Verify `send-serial-email` tool appears in `tools/list` response
- [ ] Test with 2+ recipients and distinct placeholder values
- [ ] Confirm each recipient gets their own individual email
- [ ] Verify placeholder replacement works in both subject and body
- [ ] Test with missing variables to confirm graceful handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)