### PR TITLE
fix: resolve build/index.js via ${CLAUDE_PLUGIN_ROOT} so plugin works from any cwd

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "apple-mail": {
       "command": "node",
-      "args": ["build/index.js"]
+      "args": ["${CLAUDE_PLUGIN_ROOT}/build/index.js"]
     }
   }
 }


### PR DESCRIPTION
## Summary

`.mcp.json` declares the server entrypoint as a relative path:

```json
"args": ["build/index.js"]
```

When Claude Code launches the MCP server, it resolves that relative path against the user's **current working directory**, not the plugin's install directory. So from any project other than this repo, the server fails to start with:

```
Error: Cannot find module '/Users/<user>/Projects/<their-project>/build/index.js'
[ERROR] MCP server "plugin:apple-mail:apple-mail" Connection failed: MCP error -32000: Connection closed
```

This makes the plugin effectively unusable for normal end-users — it only works when Claude Code is launched from inside a clone of this repo.

## Fix

Use Claude Code's plugin-root substitution variable so the path always resolves to the cached plugin directory:

```diff
-      "args": ["build/index.js"]
+      "args": ["${CLAUDE_PLUGIN_ROOT}/build/index.js"]
```

`${CLAUDE_PLUGIN_ROOT}` is the documented variable that expands to the plugin's installed location (e.g. `~/.claude/plugins/cache/apple-mail-mcp/apple-mail/1.5.0`).

## Repro

1. Install the plugin in a fresh Claude Code session.
2. Launch Claude Code from any directory that is not a clone of this repo.
3. Observe the MCP connection failure in `~/.claude/debug/<session>.txt`.

## Possible follow-up (not in this PR)

The `prepare` script does run `npm run build`, but the cached plugin in my install was missing the `build/` directory entirely — I had to `npm run build` it manually before this fix took effect. It may be worth either committing the `build/` artifacts or shipping them via the marketplace tarball, but that's a separate concern.

## Test plan

- [x] Edited `.mcp.json` in cached plugin dir with same change — MCP server reconnects successfully from a fresh project cwd.
- [ ] Maintainer to verify in a clean install.