### PR TITLE
docs: record tool-description additions and destructive-tool safety notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **MCP-visible tool descriptions on all 45 tools** ([#51](https://github.com/sweetrb/apple-mail-mcp/pull/51)). Every tool now registers a structured description exposed via `tools/list`, in a consistent **Use when: / Returns: / Do not use when:** shape (single↔batch and read↔send variants cross-reference each other, and read/list tools are named as the way to obtain message ids). Write/destructive/external-effect tools additionally carry an explicit **Safety:** line requiring user confirmation: `send-email`, `send-serial-email`, `reply-to-message`, `forward-message` (send real mail immediately, cannot be unsent — confirm recipients/subject/body); `delete-message`, `batch-delete-messages` (confirm and list/search first); `move-message`, `batch-move-messages` (confirm destination and ids); `create-mailbox`, `rename-mailbox`, `delete-mailbox`, `create-rule`, `delete-rule` (external effect on the account); `save-attachment` (writes a file to disk); `save-template`, `delete-template` (mutate the on-disk template store). Metadata only — no handler logic, schemas, or behavior changed.
+
 ### Documentation
 - Added `docs/NODE-RUNTIME-AND-TCC-PERMISSIONS.md`: why macOS re-prompts for Full Disk Access / Automation when the server runs under an ad-hoc-signed (e.g. Homebrew) Node, and the fix — run it under the official Developer-ID-signed Node so the grant survives Node updates. README and CLAUDE.md now point at it.
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ List messages in a mailbox.
 
 Send a new email immediately.
 
+**⚠️ Safety:** Sends real mail immediately and cannot be unsent. Confirm the recipients, subject, and body with the user before calling.
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string[] | Yes | Recipient addresses |
@@ -450,6 +452,8 @@ Each recipient object:
 
 **Returns:** Per-recipient success/failure results with a summary count.
 
+**⚠️ Safety:** Sends real mail immediately to every recipient and cannot be unsent. Confirm the recipient list, subject, and body with the user before calling.
+
 ---
 
 #### `create-draft`
@@ -523,6 +527,8 @@ Reply to an existing message.
 }
 ```
 
+**⚠️ Safety:** With the default `send: true`, sends real mail immediately and cannot be unsent. Confirm the recipients, subject, and body with the user before calling (or pass `send: false` to save a draft for review).
+
 ---
 
 #### `forward-message`
@@ -535,6 +541,8 @@ Forward a message to new recipients.
 | `to` | string[] | Yes | Recipients to forward to |
 | `body` | string | No | Message to prepend |
 | `send` | boolean | No | Send immediately (default: true, false = save as draft) |
+
+**⚠️ Safety:** With the default `send: true`, sends real mail immediately and cannot be unsent. Confirm the recipients, subject, and body with the user before calling (or pass `send: false` to save a draft for review).
 
 ---
 
@@ -565,6 +573,8 @@ Delete a message (move to trash).
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `id` | string | Yes | Message ID |
+
+**⚠️ Safety:** Destructive. Requires explicit user confirmation; search/list first to confirm the message id.
 
 ---
 
@@ -613,6 +623,8 @@ All batch operations accept an array of message IDs (max 100 per batch) and retu
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `ids` | string[] | Yes | Message IDs to delete (max 100) |
+
+**⚠️ Safety:** Destructive. Requires explicit user confirmation; search/list first to confirm the message ids.
 
 #### `batch-move-messages`
 
@@ -680,6 +692,8 @@ Delete a mailbox.
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Mailbox name |
 | `account` | string | No | Account containing mailbox |
+
+**⚠️ Safety:** Destructive — deletes the mailbox and its contents. Requires explicit user confirmation; list mailboxes first to confirm the name.
 
 ---
 
@@ -762,6 +776,8 @@ Delete a mail rule by name.
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Rule name |
 
+**⚠️ Safety:** Destructive. Requires explicit user confirmation; list rules first to confirm the name.
+
 ---
 
 ### Contacts
@@ -823,6 +839,8 @@ Delete a template.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `id` | string | Yes | Template ID |
+
+**⚠️ Safety:** Destructive — removes the template from the on-disk store. Requires explicit user confirmation; list templates first to confirm the id.
 
 ---
 


### PR DESCRIPTION
## Problem

PR #51 added MCP-visible structured descriptions (Use-when / Returns / Do-not-use-when, plus explicit Safety/confirmation wording on write & destructive tools) to all 45 tools, but the user-facing docs were never updated to reflect it.

## Change

Docs-only — no `src/` or tool-behavior changes.

- **CHANGELOG.md** — new `### Added` entry under `[Unreleased]` recording that all 45 tools now register a structured MCP-visible description in the Use-when/Returns/Do-not-use-when shape, with explicit Safety/confirmation wording on the write/external-effect tools. References #51.
- **README.md `## Tool Reference`** — added a `**⚠️ Safety:**` callout (matching the existing `**Returns:**` bold-label format) to the irreversible / external-effect tools: `send-email`, `send-serial-email`, `reply-to-message`, `forward-message` (send real mail immediately, cannot be unsent — confirm recipients/subject/body); `delete-message`, `batch-delete-messages`, `delete-mailbox`, `delete-rule`, `delete-template` (destructive — confirm and list/search first). Param tables and examples left untouched.

## Verification

- `git diff` touches only CHANGELOG.md and README.md (no `src/`, no stray `build/` artifacts).
- `npm run format:check` — pass
- `npm test` — pass (231 tests, 17 files)
- `npm run build` — pass

Self-initiated docs follow-up to #51.