### PR TITLE
Use published npm package for Hermes and Antigravity runtime

### DIFF
--- a/.antigravity-plugin/mcp_config.json
+++ b/.antigravity-plugin/mcp_config.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "github:sweetrb/apple-mail-mcp"
+        "apple-mail-mcp"
       ]
     }
   }

--- a/.hermes-plugin/mcp.json
+++ b/.hermes-plugin/mcp.json
@@ -3,7 +3,7 @@
     "command": "npx",
     "args": [
       "-y",
-      "github:sweetrb/apple-mail-mcp"
+      "apple-mail-mcp"
     ]
   }
 }


### PR DESCRIPTION
## What

Switch the Hermes and Antigravity plugin MCP runtime from `npx -y github:sweetrb/apple-mail-mcp` to the published npm package `npx -y apple-mail-mcp`.

## Why

The `github:` form re-clones the repository and runs the `prepare` build on every launch. For always-on agent hosts (Hermes, Antigravity) that adds startup latency and depends on the build succeeding in the npx cache. The published package (`apple-mail-mcp`, latest `2.1.3`) is prebuilt and is the canonical distribution, so startup is faster and more reliable.

## Changes

- `.hermes-plugin/mcp.json`: `github:sweetrb/apple-mail-mcp` → `apple-mail-mcp`
- `.antigravity-plugin/mcp_config.json`: `github:sweetrb/apple-mail-mcp` → `apple-mail-mcp`

## Scope / follow-up

Limited to Hermes and Antigravity. The Codex (`codex/.mcp.json`) and Claude (`.mcp.json`) entries still use the github / local-path forms; happy to unify those the same way in a follow-up if you'd prefer consistency across all hosts.