### PR TITLE
chore: prettier-format src/index.ts + gate formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Run linter
         run: pnpm run lint
 
+      - name: Check formatting
+        run: pnpm run format:check
+
       - name: Type check
         run: pnpm run typecheck
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,10 @@ interface AppleScan {
  * AppleScript side — which, for an all-IMAP user, means ZERO AppleScript work and
  * therefore no reliance on the fragile composite dedup. `scan` runs one account.
  */
-function appleScanForAccounts(accounts: Account[], scan: (accountName: string) => SearchResult): AppleScan {
+function appleScanForAccounts(
+  accounts: Account[],
+  scan: (accountName: string) => SearchResult
+): AppleScan {
   const rows: MessageRow[] = [];
   let diagnostics = emptyDiagnostics();
   for (const acct of accounts) {
@@ -277,7 +280,8 @@ function mergedMessageResponse(
     return successResponse(`${base}${coverageBlock}`, structured);
   }
   const parts: string[] = [];
-  if (fan.accountsQueried.length > 0) parts.push(`IMAP account(s): ${fan.accountsQueried.join(", ")}`);
+  if (fan.accountsQueried.length > 0)
+    parts.push(`IMAP account(s): ${fan.accountsQueried.join(", ")}`);
   if (apple.rows.length > 0) parts.push("AppleScript");
   const accountsNote = parts.length > 0 ? ` (merged across ${parts.join(" + ")})` : "";
   return successResponse(
@@ -2530,7 +2534,8 @@ server.registerTool(
         ``,
         `📁 By Account:`,
         ...perAccount.map(
-          (a) => `  ${a.name}: ${a.totalMessages} messages (${a.unreadMessages} unread) [${a.backend}]`
+          (a) =>
+            `  ${a.name}: ${a.totalMessages} messages (${a.unreadMessages} unread) [${a.backend}]`
         ),
       ];
       return successResponse(lines.join("\n"), {


### PR DESCRIPTION
Addresses the pre-existing prettier nit in `src/index.ts` flagged during the pnpm migration.

- `prettier --write` reflowed **three over-width lines** in `src/index.ts` (all from the v2.6.0 read-flip code: `appleScanForAccounts` signature, a `mergedMessageResponse` push, the mail-stats per-account map). **Cosmetic only** — no behavior change, `build/` unchanged, 308 tests still pass.
- Adds a **`Check formatting` (`pnpm run format:check`) step to the CI test job** so formatting drift can't recur. apple-notes/numbers/photos already gate on it; mail didn't — which is exactly why this slipped in. No version bump (no published-artifact change).