### PR TITLE
chore(ci): pin pnpm minimumReleaseAge (document the supply-chain default)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,7 @@
 # build scripts:" here.
 allowBuilds:
   esbuild: true
+
+# Pin pnpm 11's supply-chain minimum-release-age default explicitly (1440 min = 1 day)
+# so it is documented and stable across pnpm upgrades. See https://pnpm.io/supply-chain-security.
+minimumReleaseAge: 1440


### PR DESCRIPTION
## What

Pin pnpm 11's supply-chain **`minimumReleaseAge`** default explicitly in `pnpm-workspace.yaml`:

```yaml
minimumReleaseAge: 1440   # 1 day (= pnpm 11's built-in default)
```

## Why

pnpm 11 enforces a minimum-release-age supply-chain policy (a package version must be at least this many minutes old before it can be resolved), and today that default is **1440 min = 1 day** — the same cutoff the dependabot 7-day cooldown was tuned against (#83). Pinning it explicitly:

- **documents** the policy in-repo instead of relying on an implicit tool default, and
- keeps the effective cutoff **stable across pnpm upgrades**, so a future pnpm that changes its built-in default can't silently move our supply-chain floor.

See https://pnpm.io/supply-chain-security.

## Config-only — no dependency or version change

- Value `1440` **equals the default already in effect**, so this changes **no resolved dependency versions**. Verified with `git diff pnpm-lock.yaml`: **the lockfile is unchanged** (no re-resolution, no settings-block churn — pnpm doesn't serialize a value equal to its own default).
- `pnpm install --frozen-lockfile` still passes (exit 0, "Already up to date") against the unchanged lockfile, so CI's install step stays green.
- No `src/**` change, so `version-guard` is satisfied without a version bump (docs/config-only), and the committed `build/` bundle is untouched.
- Confirmed pnpm 11.9.0 genuinely honors the key (a probe with an inflated value triggers `ERR_PNPM_NO_MATURE_MATCHING_VERSION`), so this is a real, recognized setting — not a silently-ignored comment.

## Gates

`lint`, `typecheck`, `test` (345 passed), `format:check`, and `build` all pass; `git status build/` is clean.
