### PR TITLE
docs: surface the IMAP/SMTP setup guide + headless-Keychain gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,18 @@ This file provides guidance for AI agents (Claude, etc.) when using this MCP ser
 
 This MCP server enables AI assistants to interact with Apple Mail on macOS via AppleScript. All operations are local - no data leaves the user's machine.
 
+## Configuring IMAP / SMTP (when a user asks to set it up)
+
+The AppleScript backend needs no config. The **opt-in** IMAP (fast search/counts on
+large mailboxes) and SMTP (clean sending, no macOS 15+ `<blockquote>` wrapping)
+backends are configured via non-secret `APPLE_MAIL_MCP_*` settings — supplied in an
+`env` block **or**, for hosts that strip `env` (e.g. Claude Desktop), a
+`config.json` at `~/Library/Application Support/apple-mail-mcp/config.json` (loaded
+into the environment at startup) — with passwords kept in the macOS Keychain.
+**Don't reverse-engineer it: the full walkthrough is [`docs/IMAP-SETUP.md`](docs/IMAP-SETUP.md)**
+(app passwords, Keychain, both config methods, multi-account, SMTP, headless/SSH
+Keychain gotchas). Verify with the `doctor` tool.
+
 ## Critical: Backslash Escaping
 
 **When sending content with backslashes to any tool, you MUST escape them.**

--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ npm install -g github:sweetrb/apple-mail-mcp
 
 On first use, macOS will ask for permission to automate Mail.app. Click "OK" to allow.
 
+## Configuring email (IMAP & SMTP)
+
+The server works out of the box over AppleScript with **no configuration**. Two
+**opt-in** power features take a one-time setup:
+
+- **Fast IMAP reads** — server-side search, counts, and large-mailbox handling
+  that AppleScript is too slow for (it times out on big Gmail mailboxes).
+- **Clean SMTP sending** — `send-email` submits clean MIME directly, avoiding the
+  macOS 15+ Mail.app `<blockquote>` wrapping that otherwise makes sent mail look
+  quoted/indented like a reply.
+
+Both are driven by non-secret `APPLE_MAIL_MCP_*` settings — supplied via an `env`
+block **or** a `config.json` file (for hosts like Claude Desktop that strip `env`)
+— with passwords kept in the macOS **Keychain**, never in config.
+
+👉 **[IMAP / SMTP Setup Guide](docs/IMAP-SETUP.md)** — step-by-step: app passwords,
+Keychain, both config methods, multi-account, SMTP, verification with the `doctor`
+tool, and troubleshooting. Verify any time by running the **`doctor`** tool.
+
 ## Requirements
 
 - **macOS** - Apple Mail and AppleScript are macOS-only

--- a/docs/IMAP-SETUP.md
+++ b/docs/IMAP-SETUP.md
@@ -261,6 +261,25 @@ block — switch to the `config.json` method (Method B) and confirm the file is 
 - **Workspace:** your admin disabled app passwords (or requires OAuth) — IMAP via
   app password isn't available for that account.
 
+**Storing the Keychain password over SSH / headless fails with `User interaction is not allowed`.**
+`security add-internet-password` — and the server *reading* the password back —
+need the login Keychain **unlocked**, which normally only happens in a **GUI login
+session**. From a plain `ssh` session the Keychain is locked, so the write fails
+with `SecKeychainAddInternetPassword: User interaction is not allowed` (exit 36),
+and a server started there can't read passwords either. Options:
+
+- **Run it in a GUI session** — a Terminal on the Mac itself, or via Screen Sharing.
+- **Unlock over SSH with a tty:**
+  `ssh -t you@host 'security unlock-keychain && security add-internet-password -U -r imap -s imap.gmail.com -a you@gmail.com -w'`
+  — the `-t` lets `unlock-keychain` prompt for your macOS **login** password, after
+  which the add (and later server reads) succeed. A metadata check —
+  `security find-internet-password -s … -a …` with no `-w` — does work over plain
+  ssh, so you can confirm an item *exists* even when you can't unlock it.
+- **Truly headless** (CI, or a server with no GUI login and no unlockable Keychain):
+  skip the Keychain — set `APPLE_MAIL_MCP_SMTP_PASSWORD` / `APPLE_MAIL_MCP_IMAP_PASSWORD`
+  (or a per-account `"password"` inside `APPLE_MAIL_MCP_IMAP_ACCOUNTS`) directly, and
+  restrict the config file's permissions to the service account.
+
 **Calls aren't routing to IMAP even though `doctor` shows connected.**
 The tool's `account` argument must match the configured account's name/login.
 Set `APPLE_MAIL_MCP_IMAP_ACCOUNT` to the exact Mail.app account name from


### PR DESCRIPTION
## What

Improve **discoverability** of the existing IMAP/SMTP setup docs and fill one gap.

The setup content (`docs/IMAP-SETUP.md` + the README SMTP env table) is already thorough and accurate — but the guide was linked from **exactly one place**: deep inside the Tool Reference (`send-email` → SMTP transport → IMAP backend, ~line 365). A user or their AI setting up email had to scroll past ~360 lines to find it.

## Changes (docs-only)

- **README** — new top-level **`## Configuring email (IMAP & SMTP)`** section right after Quick Start, pointing to the guide and explaining the opt-in value (fast IMAP reads; clean SMTP that avoids the macOS-15+ `<blockquote>` wrapping). Surfaces in any TOC.
- **CLAUDE.md** — AI-facing pointer to the guide so agents configure from the docs instead of reverse-engineering the config surface (the `config.json` mechanism, Keychain resolution, etc.).
- **docs/IMAP-SETUP.md** — new Troubleshooting entry for the **SSH/headless Keychain** limitation (`SecKeychainAddInternetPassword: User interaction is not allowed` / exit 36): run in a GUI session, or `ssh -t … 'security unlock-keychain && …'`, or (truly headless) fall back to `APPLE_MAIL_MCP_*_PASSWORD`.

## Notes

- No code change → **no version bump** (version-guard exempt).
- `format:check` is `src`-only, so Markdown isn't gated; verified my branch touches zero `src` files.