### PR TITLE
feat(doctor): point 'not configured' at the setup guide + config.json (2.8.4)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.3",
+      "version": "2.8.4",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.3",
+      "version": "2.8.4",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.8.3",
+      "version": "2.8.4",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,6 +7,6 @@ pnpm exec lint-staged
 # Keep them fresh: if any staged file is under src/, rebuild and stage build/.
 if git diff --cached --name-only --diff-filter=ACMR | grep -q '^src/'; then
   echo "src/ changed — rebuilding build/ for plugin distribution"
-  pnpm run build --silent
+  pnpm --silent run build
   git add build
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.4] - 2026-07-08
+### Changed
+- **`doctor` now points a stuck user (or their AI) at the setup guide.** The two "not configured" messages (IMAP and SMTP) previously listed only the `APPLE_MAIL_MCP_*` env vars to set — which doesn't help the most common failure mode: a **Claude Desktop** user whose `env` block is silently stripped, so the env advice does nothing. Both messages now also name the **`config.json`** file method (`~/Library/Application Support/apple-mail-mcp/config.json`) and link the **[IMAP / SMTP Setup Guide](docs/IMAP-SETUP.md)**, so the fix is discoverable from inside the running server — not only from the repo README.
+
 ## [2.8.3] - 2026-07-06
 ### Fixed
 - **A bare git clone now runs the server with nothing but Node present (fixes #78).** The committed `build/` gave a fresh clone the entrypoints, but the compiled output still imported its runtime dependencies from `node_modules/`, which a git clone never has. Claude Code's marketplace auto-update re-clones the plugin from scratch, so every refresh left the server dying at session start on `ERR_MODULE_NOT_FOUND: Cannot find package '@modelcontextprotocol/sdk'`, with no install step anywhere between "marketplace refresh" and "server process starts". `npm run build` now typechecks (`tsc --noEmit`) and bundles `src/index.ts` and `src/cli.ts` with esbuild into self-contained `build/index.js` and `build/cli.js` (shebangs preserved, `@/` path aliases resolved from tsconfig, plus a `createRequire` banner so the CJS dependencies' dynamic `require` calls of Node builtins work under ESM). The only runtime file the bundles read is `../package.json` (for the version string), which every distribution layout ships. `tsc-alias` is no longer needed and was dropped; the per-module compiled files and `.d.ts` output under `build/` are gone (the unused `types` field went with them), and only the two bundled entrypoints are tracked in git. (Thanks @oliverames — #79.)

--- a/build/index.js
+++ b/build/index.js
@@ -80733,6 +80733,8 @@ async function routeMessage(id, opts) {
 }
 
 // src/tools/doctor.ts
+var SETUP_GUIDE = "https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md";
+var CONFIG_FILE_HINT = "If your MCP host ignores the server 'env' block (e.g. Claude Desktop), put these in ~/Library/Application Support/apple-mail-mcp/config.json instead";
 async function runDoctor(mailManager2) {
   const checks = [];
   const hc = mailManager2.healthCheck();
@@ -80764,7 +80766,7 @@ async function runDoctor(mailManager2) {
     checks.push({
       name: "IMAP backend",
       status: "warn",
-      detail: `not configured \u2014 AppleScript is used for all accounts. Set ${IMAP_ENV.user} (+ Keychain/password), or ${IMAP_ENV.accounts} for multiple accounts, to enable server-side search and server-mailbox ops.`
+      detail: `not configured \u2014 AppleScript is used for all accounts. Set ${IMAP_ENV.user} (+ Keychain/password), or ${IMAP_ENV.accounts} for multiple accounts, to enable server-side search and server-mailbox ops. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE}`
     });
   } else {
     for (const label of imapAccounts) {
@@ -80780,7 +80782,7 @@ async function runDoctor(mailManager2) {
   checks.push({
     name: "SMTP transport",
     status: isSmtpConfigured() ? "ok" : "warn",
-    detail: isSmtpConfigured() ? `configured (${smtpHost}); send-email auto-prefers clean SMTP (no Mail.app Sent-folder copy; a non-email "account" label still routes to AppleScript). Pass transport:"applescript" to force Mail.app. The apple-mail-send CLI is also available.` : `not configured \u2014 send-email uses AppleScript (subject to macOS 15+ blockquote wrapping). Set ${SMTP_ENV.host} and ${SMTP_ENV.user} (+ password via Keychain) to enable.`
+    detail: isSmtpConfigured() ? `configured (${smtpHost}); send-email auto-prefers clean SMTP (no Mail.app Sent-folder copy; a non-email "account" label still routes to AppleScript). Pass transport:"applescript" to force Mail.app. The apple-mail-send CLI is also available.` : `not configured \u2014 send-email uses AppleScript (subject to macOS 15+ blockquote wrapping). Set ${SMTP_ENV.host} and ${SMTP_ENV.user} (+ password via Keychain) to enable. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE}`
   });
   const healthy = !checks.some((c) => c.status === "fail");
   return { healthy, checks };

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/tools/doctor.ts
+++ b/src/tools/doctor.ts
@@ -21,6 +21,15 @@ export interface DoctorReport {
   checks: DoctorCheck[];
 }
 
+/** Public setup walkthrough, surfaced in the "not configured" messages so a stuck
+ *  user (or their AI) can find it without having the repo checked out. */
+const SETUP_GUIDE = "https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md";
+/** The #1 Claude-Desktop failure mode: the host strips the server `env` block, so
+ *  the env-var advice silently does nothing — point users at the file method. */
+const CONFIG_FILE_HINT =
+  "If your MCP host ignores the server 'env' block (e.g. Claude Desktop), put these " +
+  "in ~/Library/Application Support/apple-mail-mcp/config.json instead";
+
 export async function runDoctor(mailManager: AppleMailManager): Promise<DoctorReport> {
   const checks: DoctorCheck[] = [];
 
@@ -61,7 +70,7 @@ export async function runDoctor(mailManager: AppleMailManager): Promise<DoctorRe
     checks.push({
       name: "IMAP backend",
       status: "warn",
-      detail: `not configured — AppleScript is used for all accounts. Set ${IMAP_ENV.user} (+ Keychain/password), or ${IMAP_ENV.accounts} for multiple accounts, to enable server-side search and server-mailbox ops.`,
+      detail: `not configured — AppleScript is used for all accounts. Set ${IMAP_ENV.user} (+ Keychain/password), or ${IMAP_ENV.accounts} for multiple accounts, to enable server-side search and server-mailbox ops. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE}`,
     });
   } else {
     for (const label of imapAccounts) {
@@ -83,7 +92,7 @@ export async function runDoctor(mailManager: AppleMailManager): Promise<DoctorRe
     status: isSmtpConfigured() ? "ok" : "warn",
     detail: isSmtpConfigured()
       ? `configured (${smtpHost}); send-email auto-prefers clean SMTP (no Mail.app Sent-folder copy; a non-email "account" label still routes to AppleScript). Pass transport:"applescript" to force Mail.app. The apple-mail-send CLI is also available.`
-      : `not configured — send-email uses AppleScript (subject to macOS 15+ blockquote wrapping). Set ${SMTP_ENV.host} and ${SMTP_ENV.user} (+ password via Keychain) to enable.`,
+      : `not configured — send-email uses AppleScript (subject to macOS 15+ blockquote wrapping). Set ${SMTP_ENV.host} and ${SMTP_ENV.user} (+ password via Keychain) to enable. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE}`,
   });
 
   const healthy = !checks.some((c) => c.status === "fail");


### PR DESCRIPTION
## What

Make the IMAP/SMTP setup discoverable from **inside the running server**, not just the repo. Follow-up to #86 (which surfaced the guide in the README).

The remaining gap: a user (or their AI) with the *installed server* but not the repo hits `doctor`, sees **"not configured"**, and gets only env-var advice — which is useless for the #1 failure mode, a **Claude Desktop** user whose `env` block is silently stripped (so the env advice does nothing, with no pointer to the fix).

## Changes

- **`doctor`** — both "not configured" messages (IMAP + SMTP) now also name the **`config.json`** file method (`~/Library/Application Support/apple-mail-mcp/config.json`) and link **[`docs/IMAP-SETUP.md`](docs/IMAP-SETUP.md)**. The map now lives where the stuck person is standing.
- **`.husky/pre-commit` fix** — `pnpm run build --silent` forwarded `--silent` to esbuild (`Invalid build flag: "--silent"`), which aborted **every** `src`-touching commit. Corrected to `pnpm --silent run build`. Dev-infra only (doesn't ship).
- Version **2.8.4** + CHANGELOG + synced plugin manifests + rebuilt bundle.

## Verification

lint / typecheck / **345 tests** / format:check all green; the guide URL is present in the rebuilt `build/index.js`.