### PR TITLE
fix(imap): delete moves to Trash instead of a no-op expunge (2.8.5)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.4",
+      "version": "2.8.5",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.4",
+      "version": "2.8.5",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.8.4",
+      "version": "2.8.5",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.5] - 2026-07-08
+### Fixed
+- **IMAP delete now actually trashes Gmail mail — it was a silent no-op before.** `delete-message` and `batch-delete-messages` (over IMAP) flagged `\Deleted` + EXPUNGE on the message's own mailbox. On Gmail, expunging from `[Gmail]/All Mail` (where the read path addresses messages) **does not trash the message** — the tool reported success, but the mail stayed put. Delete now **moves the message to the account's Trash** — the server's `\Trash` special-use mailbox when advertised, else a `Trash`/`Deleted Messages`-style folder, else the `[Gmail]/Trash` default — which is both what Gmail treats as "trash" and what these tools' `Returns: … moves it to Trash` contract already promised. Messages already in Trash are expunged (the "empty from Trash" case). Non-Gmail servers that trash via a real Trash folder now behave correctly too, and `delete` is recoverable everywhere instead of being an immediate expunge. **This also fixes the autonomous mail-hygiene flows** (spam sweep / obsolete-prune) that trash Gmail mail through this path.
+
 ## [2.8.4] - 2026-07-08
 ### Changed
 - **`doctor` now points a stuck user (or their AI) at the setup guide.** The two "not configured" messages (IMAP and SMTP) previously listed only the `APPLE_MAIL_MCP_*` env vars to set — which doesn't help the most common failure mode: a **Claude Desktop** user whose `env` block is silently stripped, so the env advice does nothing. Both messages now also name the **`config.json`** file method (`~/Library/Application Support/apple-mail-mcp/config.json`) and link the **[IMAP / SMTP Setup Guide](docs/IMAP-SETUP.md)**, so the fix is discoverable from inside the running server — not only from the repo README.

--- a/build/index.js
+++ b/build/index.js
@@ -80308,6 +80308,28 @@ async function imapMoveMessageById(id, destMailbox, deps = {}) {
     }
   });
 }
+async function resolveTrashPath(client) {
+  try {
+    const boxes = await client.list();
+    const special = boxes.find((b) => b.specialUse === "\\Trash");
+    if (special) return special.path;
+    const named = boxes.find(
+      (b) => /^(trash|deleted messages|deleted items|bin)$/i.test(b.name) || /(^|\/)trash$/i.test(b.path)
+    );
+    if (named) return named.path;
+  } catch {
+  }
+  return resolveMailboxPath("trash", "list");
+}
+async function trashUids(client, uids, srcPath) {
+  const dest = await resolveTrashPath(client);
+  if (srcPath.trim().toLowerCase() === dest.trim().toLowerCase()) {
+    await client.messageDelete(uids, { uid: true });
+    return { dest, expunged: true };
+  }
+  await client.messageMove(uids, dest, { uid: true });
+  return { dest, expunged: false };
+}
 async function imapDeleteMessageById(id, deps = {}) {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
@@ -80316,9 +80338,11 @@ async function imapDeleteMessageById(id, deps = {}) {
     { ...deps, account: deps.account ?? ref.account },
     async (client) => {
       try {
-        const ok = await client.messageDelete([ref.uid], { uid: true });
-        if (!ok) return { success: false, error: `IMAP delete returned false for UID ${ref.uid}.` };
-        return { success: true, info: `Deleted UID ${ref.uid} from "${ref.path}" via IMAP.` };
+        const { dest, expunged } = await trashUids(client, [ref.uid], ref.path);
+        return {
+          success: true,
+          info: expunged ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP.` : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`
+        };
       } catch (e) {
         return { success: false, error: `IMAP delete failed for UID ${ref.uid}: ${errText(e)}` };
       }
@@ -80445,8 +80469,8 @@ var imapBatchFlag = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids) => 
 var imapBatchUnflag = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids) => {
   await c.messageFlagsRemove(uids, ["\\Flagged"], { uid: true });
 });
-var imapBatchDelete = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids) => {
-  await c.messageDelete(uids, { uid: true });
+var imapBatchDelete = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids, path) => {
+  await trashUids(c, uids, path);
 });
 function imapBatchMove(ids, destMailbox, deps = {}) {
   return imapBatch(ids, deps, async (c, uids) => {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -491,14 +491,43 @@ describe("IMAP message mutations (#43 Phase 3)", () => {
     expect(rec.moved).toEqual([[1], "Archive"]);
   });
 
-  it("delete expunges the uid", async () => {
+  it("delete moves the uid to Trash (recoverable) rather than expunging", async () => {
+    // Gmail expunge on [Gmail]/All Mail is a no-op, so delete must MOVE to Trash.
+    // With an empty LIST the mailbox resolves to the [Gmail]/Trash default.
     const rec: MsgRec = {};
     const r = await imapDeleteMessageById(MID, {
       config: cfg,
       connect: async () => makeMsgClient(rec),
     });
     expect(r.success).toBe(true);
+    expect(rec.moved).toEqual([[1], "[Gmail]/Trash"]);
+    expect(rec.deleted).toBeUndefined();
+  });
+
+  it("delete resolves the server's \\Trash special-use mailbox", async () => {
+    const rec: MsgRec = {};
+    const client: ImapClientLike = {
+      ...makeMsgClient(rec),
+      list: async () => [
+        { path: "INBOX", name: "INBOX" },
+        { path: "Deleted Messages", name: "Deleted Messages", specialUse: "\\Trash" },
+      ],
+    };
+    const r = await imapDeleteMessageById(MID, { config: cfg, connect: async () => client });
+    expect(r.success).toBe(true);
+    expect(rec.moved).toEqual([[1], "Deleted Messages"]);
+  });
+
+  it("delete from within Trash permanently expunges (empty-from-Trash)", async () => {
+    const rec: MsgRec = {};
+    const trashId = encodeImapId("iCloud", "[Gmail]/Trash", 1);
+    const r = await imapDeleteMessageById(trashId, {
+      config: cfg,
+      connect: async () => makeMsgClient(rec),
+    });
+    expect(r.success).toBe(true);
     expect(rec.deleted).toEqual([1]);
+    expect(rec.moved).toBeUndefined();
   });
 
   it("get-message returns subject + decoded body", async () => {

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -102,6 +102,8 @@ interface MailboxLock {
 interface ImapMailboxListing {
   path: string;
   name: string;
+  /** RFC 6154 special-use flag ("\\Trash", "\\Sent", …) when the server advertises it. */
+  specialUse?: string;
 }
 type FlagOpts = { uid: boolean };
 export interface ImapClientLike {
@@ -1064,6 +1066,52 @@ export async function imapMoveMessageById(
   });
 }
 
+/**
+ * Resolve the account's Trash mailbox path: prefer the server's `\Trash`
+ * special-use folder, then a common name/path, then the Gmail default.
+ *
+ * Deleting moves messages here (recoverable) rather than flagging `\Deleted` +
+ * EXPUNGE, because on Gmail expunging a message from `[Gmail]/All Mail` is a
+ * silent no-op — so the old flag+expunge path *reported success but never
+ * actually trashed Gmail mail*. A move to `[Gmail]/Trash` is what Gmail treats
+ * as "trash" (and matches the tools' documented "moves to Trash" contract).
+ */
+async function resolveTrashPath(client: ImapClientLike): Promise<string> {
+  try {
+    const boxes = await client.list();
+    const special = boxes.find((b) => b.specialUse === "\\Trash");
+    if (special) return special.path;
+    const named = boxes.find(
+      (b) =>
+        /^(trash|deleted messages|deleted items|bin)$/i.test(b.name) || /(^|\/)trash$/i.test(b.path)
+    );
+    if (named) return named.path;
+  } catch {
+    // Fall through to the Gmail default if LIST fails.
+  }
+  return resolveMailboxPath("trash", "list");
+}
+
+/**
+ * Trash a set of UIDs from the currently-selected `srcPath`: move them to the
+ * account's Trash mailbox (recoverable). If the messages are *already* in Trash,
+ * expunge them instead (the "empty from Trash" case). Returns the resolved
+ * destination and whether it expunged.
+ */
+async function trashUids(
+  client: ImapClientLike,
+  uids: number[],
+  srcPath: string
+): Promise<{ dest: string; expunged: boolean }> {
+  const dest = await resolveTrashPath(client);
+  if (srcPath.trim().toLowerCase() === dest.trim().toLowerCase()) {
+    await client.messageDelete(uids, { uid: true });
+    return { dest, expunged: true };
+  }
+  await client.messageMove(uids, dest, { uid: true });
+  return { dest, expunged: false };
+}
+
 export async function imapDeleteMessageById(
   id: string,
   deps: ImapDeps = {}
@@ -1075,9 +1123,13 @@ export async function imapDeleteMessageById(
     { ...deps, account: deps.account ?? ref.account },
     async (client) => {
       try {
-        const ok = await client.messageDelete([ref.uid], { uid: true });
-        if (!ok) return { success: false, error: `IMAP delete returned false for UID ${ref.uid}.` };
-        return { success: true, info: `Deleted UID ${ref.uid} from "${ref.path}" via IMAP.` };
+        const { dest, expunged } = await trashUids(client, [ref.uid], ref.path);
+        return {
+          success: true,
+          info: expunged
+            ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP.`
+            : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`,
+        };
       } catch (e) {
         return { success: false, error: `IMAP delete failed for UID ${ref.uid}: ${errText(e)}` };
       }
@@ -1273,8 +1325,8 @@ export const imapBatchUnflag = (ids: string[], deps: ImapDeps = {}): Promise<Ima
     await c.messageFlagsRemove(uids, ["\\Flagged"], { uid: true });
   });
 export const imapBatchDelete = (ids: string[], deps: ImapDeps = {}): Promise<ImapBatchResult> =>
-  imapBatch(ids, deps, async (c, uids) => {
-    await c.messageDelete(uids, { uid: true });
+  imapBatch(ids, deps, async (c, uids, path) => {
+    await trashUids(c, uids, path);
   });
 export function imapBatchMove(
   ids: string[],


### PR DESCRIPTION
## What

Fixes a silent data-integrity bug: **IMAP `delete` never actually trashed Gmail mail.**

`delete-message` / `batch-delete-messages` (IMAP path) flagged `\Deleted` + EXPUNGE on the message's own mailbox. On Gmail, expunging from `[Gmail]/All Mail` — where the read path addresses messages — **does not trash**; it's a no-op. So the tools returned `success` while the mail stayed put. (Discovered live: a `batch-delete-messages` reported `success: 7` twice, yet the messages never left All Mail; a move to `[Gmail]/Trash` cleared them immediately.)

## Fix

Delete now **moves the message to the account's Trash** instead of flag+expunge:
- the server's **`\Trash` special-use** mailbox when advertised (RFC 6154),
- else a `Trash` / `Deleted Messages` / `Deleted Items` / `Bin` folder by name/path,
- else the `[Gmail]/Trash` default.

Messages **already in Trash** are expunged (the "empty from Trash" case). This is what Gmail treats as trash, matches the tools' documented `Returns: … moves it to Trash` contract, makes delete recoverable on every server, and **fixes the autonomous mail-hygiene flows** (spam-sweep / prune-obsolete) that trash Gmail mail through this path.

## Tests

`imapClient.test.ts`: the old "delete expunges" case became "delete moves to Trash", plus new cases for `\Trash` special-use resolution and delete-from-Trash expunging. **347 tests pass**, typecheck + lint + format:check green.