### PR TITLE
docs: end-user setup discoverability for no-clone installs + actionable errors (2.8.6)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.5",
+      "version": "2.8.6",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.5",
+      "version": "2.8.6",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.antigravity-plugin/skills/apple-mail/SKILL.md
+++ b/.antigravity-plugin/skills/apple-mail/SKILL.md
@@ -150,7 +150,7 @@ Action: Use delete-message with the message ID
 ## Error Handling
 
 - **"Message not found"**: The message ID may be invalid or the message was deleted. Use search-messages to find it again.
-- **"Permission denied"**: User needs to grant automation permission in System Preferences > Privacy & Security > Automation.
+- **"Permission denied"**: User needs to grant automation permission in System Settings > Privacy & Security > Automation.
 - **"Account not found"**: Account names are case-sensitive. Use list-accounts to see exact names.
 - **"Failed to send"**: Check network connection and Mail.app configuration.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.8.5",
+      "version": "2.8.6",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.6] - 2026-07-09
+End-user docs/discoverability pass: make setup findable for no-clone installs (npm registry, plugin marketplace) and make "not configured" errors actionable.
+
+### Changed
+- **"Not configured" errors now end with the absolute setup-guide URL + a `doctor` hint.** `SMTP transport is not configured…` / `No SMTP password found…` (`smtpMailer`), `IMAP not configured…` (`imapClient`), and the `apple-mail-send` CLI's config-failure hint all now point at `https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md` and suggest running the **`doctor`** tool, instead of referencing README sections the user may not have on disk. The URL lives in a shared `src/utils/docsUrls.ts` module also used by `doctor`.
+- **"System Preferences" → "System Settings > Privacy & Security > Automation"** in permission-denied messages (`applescript.ts`, `appleMailManager.ts` health check) and in the README/SECURITY/skill docs — matching macOS 13+ naming.
+
+### Fixed
+- **README install commands now use the npm registry** (`npm install -g apple-mail-mcp`) instead of `github:sweetrb/apple-mail-mcp`; the GitHub form is kept only as a From-Source note (it builds from source and requires pnpm).
+- **npm tarball is self-contained for docs:** `docs/` now ships in the package (`files` in `package.json`), and every README cross-file link (setup guide, CONTRIBUTING, LICENSE, plugin configs, TCC notes, header screenshot) is an absolute `github.com`/`raw.githubusercontent.com` URL, so links work from npmjs.com and a tarball install.
+- **Stale Known Limitations rows corrected:** templates *are* persisted (`templates.json` via `APPLE_MAIL_MCP_TEMPLATES_FILE` — row removed); message IDs accept `imap:…` tokens as well as numeric ids; HTML sending exists via the `apple-mail-send` CLI `--html-body-file` (the MCP `send-email` tool itself is plain-text).
+- **`docs/IMAP-SETUP.md` corrections:** `APPLE_MAIL_MCP_IMAP_IDLE_MS` default is `30000` (not `60000`); `APPLE_MAIL_MCP_IMAP_ACCOUNTS` is a JSON **array of objects passed as a single string value**; env-var reference gained the missing `APPLE_MAIL_MCP_TEMPLATES_FILE`, `APPLE_MAIL_MCP_MAX_BUFFER`, and `APPLE_MAIL_MAX_SEARCH_MAILBOX` rows.
+
+### Added
+- **Deterministic Claude Code install one-liner** in Quick Start: `claude mcp add apple-mail -s user -- npx -y apple-mail-mcp`.
+- **Plugin-marketplace config note** (README Quick Start + setup guide Step 3): plugin installs have no editable `env` block — configure IMAP/SMTP via `~/Library/Application Support/apple-mail-mcp/config.json` (Method B).
+
 ## [2.8.5] - 2026-07-08
 ### Fixed
 - **IMAP delete now actually trashes Gmail mail — it was a silent no-op before.** `delete-message` and `batch-delete-messages` (over IMAP) flagged `\Deleted` + EXPUNGE on the message's own mailbox. On Gmail, expunging from `[Gmail]/All Mail` (where the read path addresses messages) **does not trash the message** — the tool reported success, but the mail stayed put. Delete now **moves the message to the account's Trash** — the server's `\Trash` special-use mailbox when advertised, else a `Trash`/`Deleted Messages`-style folder, else the `[Gmail]/Trash` default — which is both what Gmail treats as "trash" and what these tools' `Returns: … moves it to Trash` contract already promised. Messages already in Trash are expunged (the "empty from Trash" case). Non-Gmail servers that trash via a real Trash folder now behave correctly too, and `delete` is recoverable everywhere instead of being an immediate expunge. **This also fixes the autonomous mail-hygiene flows** (spam sweep / obsolete-prune) that trash Gmail mail through this path.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that e
 [![MCP](https://img.shields.io/badge/MCP-server-blue)](https://modelcontextprotocol.io)
 
 <p align="center">
-  <img src="codex/assets/screenshot.png" alt="Apple Mail MCP — read, search, send, and organize Apple Mail from Codex, Claude, and other AI assistants" width="680">
+  <img src="https://raw.githubusercontent.com/sweetrb/apple-mail-mcp/main/codex/assets/screenshot.png" alt="Apple Mail MCP — read, search, send, and organize Apple Mail from Codex, Claude, and other AI assistants" width="680">
 </p>
 
 > **Note:** This is the **npm/Node.js** package — install with `npx` or `npm`. There is an unrelated Python project of the same name on PyPI ([`imdinu/apple-mail-mcp`](https://github.com/imdinu/apple-mail-mcp)) installed via `pipx`/`uvx`. If you're using `uvx` and seeing a `cyclopts` dependency error, you're looking for that project, not this one.
@@ -43,6 +43,12 @@ Install the sweetrb/apple-mail-mcp MCP server so you can help me manage my Apple
 
 Claude will handle the installation and configuration automatically.
 
+Or register it deterministically in one command:
+
+```bash
+claude mcp add apple-mail -s user -- npx -y apple-mail-mcp
+```
+
 ### Using the Plugin Marketplace
 
 Install as a Claude Code plugin for automatic configuration and enhanced AI behavior:
@@ -53,6 +59,11 @@ Install as a Claude Code plugin for automatic configuration and enhanced AI beha
 ```
 
 This method also installs a **skill** that teaches Claude when and how to use Apple Mail effectively.
+
+> **Configuring IMAP/SMTP for a plugin install:** a plugin install has no editable `env` block,
+> so supply settings via the config file at `~/Library/Application Support/apple-mail-mcp/config.json`
+> — Method B in the [IMAP / SMTP Setup Guide](https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md).
+> Passwords stay in the macOS Keychain; run the `doctor` tool to verify.
 
 ### Using the Codex Marketplace
 
@@ -69,14 +80,14 @@ The Codex package registers the same `apple-mail` MCP server through `npx -y app
 
 Configuration for two more hosts is included — each registers the same `apple-mail` MCP server (`npx -y apple-mail-mcp`):
 
-- **[Hermes Agent](https://hermes-agent.nousresearch.com/)** (NousResearch) — Hermes has no plugin/marketplace drop-in. Add the server with `hermes mcp add apple-mail --command npx --args -y apple-mail-mcp`, or merge [`.hermes-plugin/config.yaml`](.hermes-plugin/config.yaml) into `~/.hermes/config.yaml`. Details: [`.hermes-plugin/README.md`](.hermes-plugin/README.md).
-- **[Antigravity](https://antigravity.google/)** (Google) — add the server entry from [`.antigravity-plugin/mcp_config.json`](.antigravity-plugin/mcp_config.json) to `~/.gemini/config/mcp_config.json` (or via Antigravity's MCP settings).
+- **[Hermes Agent](https://hermes-agent.nousresearch.com/)** (NousResearch) — Hermes has no plugin/marketplace drop-in. Add the server with `hermes mcp add apple-mail --command npx --args -y apple-mail-mcp`, or merge [`.hermes-plugin/config.yaml`](https://github.com/sweetrb/apple-mail-mcp/blob/main/.hermes-plugin/config.yaml) into `~/.hermes/config.yaml`. Details: [`.hermes-plugin/README.md`](https://github.com/sweetrb/apple-mail-mcp/blob/main/.hermes-plugin/README.md).
+- **[Antigravity](https://antigravity.google/)** (Google) — add the server entry from [`.antigravity-plugin/mcp_config.json`](https://github.com/sweetrb/apple-mail-mcp/blob/main/.antigravity-plugin/mcp_config.json) to `~/.gemini/config/mcp_config.json` (or via Antigravity's MCP settings).
 
 ### Manual Installation
 
 **1. Install the server:**
 ```bash
-npm install -g github:sweetrb/apple-mail-mcp
+npm install -g apple-mail-mcp
 ```
 
 **2. Add to Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
@@ -113,7 +124,7 @@ Both are driven by non-secret `APPLE_MAIL_MCP_*` settings — supplied via an `e
 block **or** a `config.json` file (for hosts like Claude Desktop that strip `env`)
 — with passwords kept in the macOS **Keychain**, never in config.
 
-👉 **[IMAP / SMTP Setup Guide](docs/IMAP-SETUP.md)** — step-by-step: app passwords,
+👉 **[IMAP / SMTP Setup Guide](https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md)** — step-by-step: app passwords,
 Keychain, both config methods, multi-account, SMTP, verification with the `doctor`
 tool, and troubleshooting. Verify any time by running the **`doctor`** tool.
 
@@ -381,7 +392,7 @@ SMTP not configured.
 
 ##### IMAP backend — opt-in
 
-> 📘 **For step-by-step setup (app passwords, Keychain, config methods, multi-account, upgrading, troubleshooting), see the [IMAP / SMTP Setup Guide](docs/IMAP-SETUP.md).** The summary below is the reference; the guide is the walkthrough.
+> 📘 **For step-by-step setup (app passwords, Keychain, config methods, multi-account, upgrading, troubleshooting), see the [IMAP / SMTP Setup Guide](https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md).** The summary below is the reference; the guide is the walkthrough.
 
 AppleScript runs `search`/`list` predicates client-side over the Apple Event
 bridge, which is slow and can time out (false-empty) on large Gmail/IMAP
@@ -1133,7 +1144,7 @@ AI: [calls move-message for each, with mailbox="Archive"]
 ### npm (Recommended)
 
 ```bash
-npm install -g github:sweetrb/apple-mail-mcp
+npm install -g apple-mail-mcp
 ```
 
 ### From Source
@@ -1144,6 +1155,8 @@ cd apple-mail-mcp
 ```
 
 The repo ships prebuilt, dependency-free `build/index.js` and `build/cli.js` bundles, so a bare clone runs with nothing but Node installed. `npm install` and `npm run build` are only needed when you change the source.
+
+> You can also install straight from GitHub with `npm install -g github:sweetrb/apple-mail-mcp`, but that builds from source (requires pnpm) — prefer the registry package above.
 
 If installed from source, use this configuration:
 ```json
@@ -1189,13 +1202,12 @@ The entrypoint is written as:
 | Limitation | Reason |
 |------------|--------|
 | macOS only | Apple Mail and AppleScript are macOS-specific |
-| No sending HTML email | Emails are sent as plain text; reading HTML content is supported |
+| MCP `send-email` is plain-text | The `send-email` tool sends plain text (reading HTML content is supported). To send HTML, use the bundled `apple-mail-send` CLI with `--html-body-file` (sends `multipart/alternative` via SMTP) |
 | Attachments require absolute paths | File attachments must use full absolute paths (e.g., `/Users/me/file.pdf`) |
 | No smart mailboxes | Cannot access Smart Mailboxes via AppleScript |
 | Very large mailboxes not searchable *via AppleScript* | Apple Mail's AppleScript bridge times out on mailboxes with tens of thousands of messages, so unscoped `search-messages` skips mailboxes above `APPLE_MAIL_MAX_SEARCH_MAILBOX` (default 5000) and reports them as a partial result. Scope with `mailbox` + a date window — or configure the [IMAP backend](#imap-backend--opt-in), which searches these server-side in well under a second. ([#24](https://github.com/sweetrb/apple-mail-mcp/issues/24)) |
 | Can't delete/rename server-side mailboxes or mutate drafts *via AppleScript* | Mail.app's AppleScript bridge can only `delete`/`rename` **local "On My Mac"** mailboxes and cannot delete/move drafts — it throws `AppleEvent handler failed` for IMAP/Gmail/Workspace/iCloud/Exchange mailboxes (the GUI can do it). Without IMAP configured, `delete-mailbox`/`rename-mailbox`/`delete-message`/`move-message` return a clear "do it in Mail.app directly" error instead of a generic failure. With the [IMAP backend](#imap-backend--opt-in) configured for the account, these operations run via IMAP and succeed. ([#42](https://github.com/sweetrb/apple-mail-mcp/issues/42)) |
-| In-memory templates | Email templates are not persisted across server restarts |
-| Numeric-only message IDs | Message IDs must contain only digits (validated by schema) |
+| Message ID format | Message IDs must be numeric (AppleScript ids) or `imap:…` tokens from the IMAP read path (validated by schema) |
 | Batch size cap | Batch operations are limited to 100 messages per request |
 | Date filter format | Date filters must be valid parseable dates (e.g., "January 1, 2026" or "2026-03-15"); bare numbers or non-date strings are rejected |
 | Attachment save path restrictions | `save-attachment` only allows saving to home directory, `/tmp`, `/private/tmp`, and `/Volumes`; path traversal is blocked |
@@ -1259,7 +1271,7 @@ The `\\\\` in JSON becomes `\\` in the actual string, which represents a single 
 
 ### "Permission denied"
 - macOS needs automation permission
-- Go to System Preferences > Privacy & Security > Automation
+- Go to System Settings > Privacy & Security > Automation
 - Ensure your terminal/Claude has permission to control Mail
 
 ### "Message not found"
@@ -1315,11 +1327,11 @@ A software consulting, contracting, and development company.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+MIT License - see [LICENSE](https://github.com/sweetrb/apple-mail-mcp/blob/main/LICENSE) for details.
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+Contributions are welcome! Please see [CONTRIBUTING.md](https://github.com/sweetrb/apple-mail-mcp/blob/main/CONTRIBUTING.md) for guidelines.
 
 ## Related Projects
 
@@ -1331,4 +1343,4 @@ Part of a family of macOS MCP servers:
 
 ## Recurring macOS permission prompts
 
-If macOS keeps re-prompting for Full Disk Access or Automation for `node` (often after a `brew upgrade`), see [docs/NODE-RUNTIME-AND-TCC-PERMISSIONS.md](docs/NODE-RUNTIME-AND-TCC-PERMISSIONS.md) — the fix is to run this server under the official, Developer-ID-signed Node so the grant survives Node updates.
+If macOS keeps re-prompting for Full Disk Access or Automation for `node` (often after a `brew upgrade`), see [docs/NODE-RUNTIME-AND-TCC-PERMISSIONS.md](https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/NODE-RUNTIME-AND-TCC-PERMISSIONS.md) — the fix is to run this server under the official, Developer-ID-signed Node so the grant survives Node updates.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,7 @@ This MCP server:
 - Does not store credentials or passwords
 - Requires explicit user confirmation before sending emails (recommended)
 
-The server requires macOS automation permissions to function. These permissions are managed by macOS and can be revoked at any time in System Preferences > Privacy & Security > Automation.
+The server requires macOS automation permissions to function. These permissions are managed by macOS and can be revoked at any time in System Settings > Privacy & Security > Automation.
 
 ## Input Validation & Security Hardening
 

--- a/build/cli.js
+++ b/build/cli.js
@@ -11868,6 +11868,12 @@ var import_nodemailer = __toESM(require_nodemailer(), 1);
 import { execFileSync } from "child_process";
 import { isAbsolute } from "path";
 import { existsSync } from "fs";
+
+// src/utils/docsUrls.ts
+var SETUP_GUIDE_URL = "https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md";
+var SETUP_HINT = `Setup guide: ${SETUP_GUIDE_URL} \u2014 run the "doctor" tool to check your setup.`;
+
+// src/services/smtpMailer.ts
 var SMTP_ENV = {
   host: "APPLE_MAIL_MCP_SMTP_HOST",
   port: "APPLE_MAIL_MCP_SMTP_PORT",
@@ -11900,7 +11906,7 @@ function resolveSmtpConfig(env = process.env) {
   if (!user) missing.push(SMTP_ENV.user);
   if (missing.length > 0) {
     throw new Error(
-      `SMTP transport is not configured. Set ${missing.join(" and ")} (plus a password via ${SMTP_ENV.password} or the Keychain). See the README "SMTP transport" section.`
+      `SMTP transport is not configured. Set ${missing.join(" and ")} (plus a password via ${SMTP_ENV.password} or the Keychain). ` + SETUP_HINT
     );
   }
   const secure = /^(1|true|yes)$/i.test(env[SMTP_ENV.secure]?.trim() ?? "");
@@ -11917,7 +11923,7 @@ function resolveSmtpConfig(env = process.env) {
   }
   if (!pass) {
     throw new Error(
-      `No SMTP password found. Set ${SMTP_ENV.password}, or store an internet password in the Keychain for service "${env[SMTP_ENV.keychainService]?.trim() || host}" / account "${env[SMTP_ENV.keychainAccount]?.trim() || user}".`
+      `No SMTP password found. Set ${SMTP_ENV.password}, or store an internet password in the Keychain for service "${env[SMTP_ENV.keychainService]?.trim() || host}" / account "${env[SMTP_ENV.keychainAccount]?.trim() || user}". ` + SETUP_HINT
     );
   }
   return { host, port, secure, user, pass, from };
@@ -12003,7 +12009,8 @@ Optional:
   --help                Show this help
 
 SMTP connection comes from ${SMTP_ENV.host} / ${SMTP_ENV.user} (+ password via
-${SMTP_ENV.password} or the macOS Keychain). See the README "SMTP transport".`;
+${SMTP_ENV.password} or the macOS Keychain). Setup guide:
+${SETUP_GUIDE_URL}`;
 async function runCli(argv, deps = {}) {
   const send = deps.send ?? sendViaSmtp;
   const resolveConfig = deps.resolveConfig ?? resolveSmtpConfig;
@@ -12052,7 +12059,7 @@ async function runCli(argv, deps = {}) {
     config = resolveConfig(env);
   } catch (e) {
     err(e instanceof Error ? e.message : String(e));
-    err(`See the README "SMTP transport" section.`);
+    err(`Setup guide: ${SETUP_GUIDE_URL}`);
     return EX_CONFIG;
   }
   let body;

--- a/build/index.js
+++ b/build/index.js
@@ -76219,7 +76219,7 @@ var ERROR_MAPPINGS = [
   // Permission errors
   {
     pattern: /not authorized|not permitted|access.*denied/i,
-    message: "Permission denied. Grant automation access in System Preferences > Privacy & Security > Automation."
+    message: "Permission denied. Grant automation access in System Settings > Privacy & Security > Automation."
   },
   // Application not running
   {
@@ -79153,7 +79153,7 @@ ${actionStmts.join("\n")}
         message: "Mail.app is accessible"
       });
     } else {
-      const errorHint = mailCheck.error?.includes("not authorized") ? " (check Automation permissions in System Preferences)" : "";
+      const errorHint = mailCheck.error?.includes("not authorized") ? " (check System Settings > Privacy & Security > Automation)" : "";
       checks.push({
         name: "mail_app",
         passed: false,
@@ -79173,7 +79173,7 @@ ${actionStmts.join("\n")}
       checks.push({
         name: "permissions",
         passed: !isPermError,
-        message: isPermError ? "AppleScript permissions denied. Grant access in System Preferences > Privacy & Security > Automation" : `Permission check returned: ${permCheck.error}`
+        message: isPermError ? "AppleScript permissions denied. Grant access in System Settings > Privacy & Security > Automation" : `Permission check returned: ${permCheck.error}`
       });
       if (isPermError) {
         return { healthy: false, checks };
@@ -79409,6 +79409,12 @@ var import_nodemailer = __toESM(require_nodemailer(), 1);
 import { execFileSync } from "child_process";
 import { isAbsolute as isAbsolute2 } from "path";
 import { existsSync as existsSync3 } from "fs";
+
+// src/utils/docsUrls.ts
+var SETUP_GUIDE_URL = "https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md";
+var SETUP_HINT = `Setup guide: ${SETUP_GUIDE_URL} \u2014 run the "doctor" tool to check your setup.`;
+
+// src/services/smtpMailer.ts
 var SMTP_ENV = {
   host: "APPLE_MAIL_MCP_SMTP_HOST",
   port: "APPLE_MAIL_MCP_SMTP_PORT",
@@ -79451,7 +79457,7 @@ function resolveSmtpConfig(env = process.env) {
   if (!user) missing.push(SMTP_ENV.user);
   if (missing.length > 0) {
     throw new Error(
-      `SMTP transport is not configured. Set ${missing.join(" and ")} (plus a password via ${SMTP_ENV.password} or the Keychain). See the README "SMTP transport" section.`
+      `SMTP transport is not configured. Set ${missing.join(" and ")} (plus a password via ${SMTP_ENV.password} or the Keychain). ` + SETUP_HINT
     );
   }
   const secure = /^(1|true|yes)$/i.test(env[SMTP_ENV.secure]?.trim() ?? "");
@@ -79468,7 +79474,7 @@ function resolveSmtpConfig(env = process.env) {
   }
   if (!pass) {
     throw new Error(
-      `No SMTP password found. Set ${SMTP_ENV.password}, or store an internet password in the Keychain for service "${env[SMTP_ENV.keychainService]?.trim() || host}" / account "${env[SMTP_ENV.keychainAccount]?.trim() || user}".`
+      `No SMTP password found. Set ${SMTP_ENV.password}, or store an internet password in the Keychain for service "${env[SMTP_ENV.keychainService]?.trim() || host}" / account "${env[SMTP_ENV.keychainAccount]?.trim() || user}". ` + SETUP_HINT
     );
   }
   return { host, port, secure, user, pass, from };
@@ -79811,7 +79817,9 @@ function resolveImapConfigs(env = process.env) {
 function resolveImapConfig(env = process.env, account) {
   const specs = listImapAccountSpecs(env);
   if (specs.length === 0) {
-    throw new Error(`IMAP not configured. Set ${IMAP_ENV.user} (login address) to enable it.`);
+    throw new Error(
+      `IMAP not configured. Set ${IMAP_ENV.user} (login address) to enable it. ${SETUP_HINT}`
+    );
   }
   let spec;
   if (account) {
@@ -80757,7 +80765,6 @@ async function routeMessage(id, opts) {
 }
 
 // src/tools/doctor.ts
-var SETUP_GUIDE = "https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md";
 var CONFIG_FILE_HINT = "If your MCP host ignores the server 'env' block (e.g. Claude Desktop), put these in ~/Library/Application Support/apple-mail-mcp/config.json instead";
 async function runDoctor(mailManager2) {
   const checks = [];
@@ -80790,7 +80797,7 @@ async function runDoctor(mailManager2) {
     checks.push({
       name: "IMAP backend",
       status: "warn",
-      detail: `not configured \u2014 AppleScript is used for all accounts. Set ${IMAP_ENV.user} (+ Keychain/password), or ${IMAP_ENV.accounts} for multiple accounts, to enable server-side search and server-mailbox ops. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE}`
+      detail: `not configured \u2014 AppleScript is used for all accounts. Set ${IMAP_ENV.user} (+ Keychain/password), or ${IMAP_ENV.accounts} for multiple accounts, to enable server-side search and server-mailbox ops. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE_URL}`
     });
   } else {
     for (const label of imapAccounts) {
@@ -80806,7 +80813,7 @@ async function runDoctor(mailManager2) {
   checks.push({
     name: "SMTP transport",
     status: isSmtpConfigured() ? "ok" : "warn",
-    detail: isSmtpConfigured() ? `configured (${smtpHost}); send-email auto-prefers clean SMTP (no Mail.app Sent-folder copy; a non-email "account" label still routes to AppleScript). Pass transport:"applescript" to force Mail.app. The apple-mail-send CLI is also available.` : `not configured \u2014 send-email uses AppleScript (subject to macOS 15+ blockquote wrapping). Set ${SMTP_ENV.host} and ${SMTP_ENV.user} (+ password via Keychain) to enable. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE}`
+    detail: isSmtpConfigured() ? `configured (${smtpHost}); send-email auto-prefers clean SMTP (no Mail.app Sent-folder copy; a non-email "account" label still routes to AppleScript). Pass transport:"applescript" to force Mail.app. The apple-mail-send CLI is also available.` : `not configured \u2014 send-email uses AppleScript (subject to macOS 15+ blockquote wrapping). Set ${SMTP_ENV.host} and ${SMTP_ENV.user} (+ password via Keychain) to enable. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE_URL}`
   });
   const healthy = !checks.some((c) => c.status === "fail");
   return { healthy, checks };

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/skills/apple-mail/SKILL.md
+++ b/codex/skills/apple-mail/SKILL.md
@@ -150,7 +150,7 @@ Action: Use delete-message with the message ID
 ## Error Handling
 
 - **"Message not found"**: The message ID may be invalid or the message was deleted. Use search-messages to find it again.
-- **"Permission denied"**: User needs to grant automation permission in System Preferences > Privacy & Security > Automation.
+- **"Permission denied"**: User needs to grant automation permission in System Settings > Privacy & Security > Automation.
 - **"Account not found"**: Account names are case-sensitive. Use list-accounts to see exact names.
 - **"Failed to send"**: Check network connection and Mail.app configuration.
 

--- a/docs/IMAP-SETUP.md
+++ b/docs/IMAP-SETUP.md
@@ -154,6 +154,8 @@ non-secret config goes here — passwords stay in the Keychain.**
 
 > Not sure which method? Configure with Method A; if `doctor` still says "not
 > configured" after a restart, your host strips `env` — switch to Method B.
+> Plugin-marketplace installs (Claude Code `/plugin install apple-mail`) have no
+> editable `env` block at all, so they always use Method B.
 
 ### `APPLE_MAIL_MCP_IMAP_ACCOUNT` and routing
 
@@ -165,7 +167,8 @@ server knows "calls for this account go to IMAP."
 ### Multiple accounts
 
 Configure additional accounts with `APPLE_MAIL_MCP_IMAP_ACCOUNTS`, a JSON **array
-of strings** (each entry's value is itself a JSON object). The legacy single-account
+of objects, passed as a single string value** (the whole array is one env-var /
+config-file string, as in the example below). The legacy single-account
 vars above define the first/default account; the array adds the rest:
 
 ```json
@@ -211,7 +214,7 @@ password for SMTP, as Gmail does.)
 Add `"APPLE_MAIL_MCP_IMAP_IDLE": "1"` to get new-mail notifications for every
 configured IMAP account. See the README's "Push notifications (IMAP IDLE)"
 section for details. Tune the pooled-connection idle timeout with
-`APPLE_MAIL_MCP_IMAP_IDLE_MS` (default `60000`).
+`APPLE_MAIL_MCP_IMAP_IDLE_MS` (default `30000`; `0` = never close).
 
 ---
 
@@ -317,7 +320,7 @@ GUI is ignoring.
 | `APPLE_MAIL_MCP_IMAP_KEYCHAIN_ACCOUNT` | Keychain item account (default = USER). |
 | `APPLE_MAIL_MCP_IMAP_ACCOUNTS` | JSON array of additional accounts (multi-account). |
 | `APPLE_MAIL_MCP_IMAP_IDLE` | `1` to enable IMAP IDLE new-mail push. |
-| `APPLE_MAIL_MCP_IMAP_IDLE_MS` | Pooled-connection idle timeout in ms (default `60000`). |
+| `APPLE_MAIL_MCP_IMAP_IDLE_MS` | Pooled-connection idle timeout in ms (default `30000`; `0` = never close). |
 | `APPLE_MAIL_MCP_SMTP_HOST` | SMTP host; setting it enables `transport:"smtp"`. |
 | `APPLE_MAIL_MCP_SMTP_PORT` | SMTP port (`465` if secure, else `587`). |
 | `APPLE_MAIL_MCP_SMTP_SECURE` | `true` for implicit TLS (465); else STARTTLS. |
@@ -325,3 +328,6 @@ GUI is ignoring.
 | `APPLE_MAIL_MCP_SMTP_PASSWORD` | Password (discouraged; prefer Keychain). |
 | `APPLE_MAIL_MCP_SMTP_KEYCHAIN_SERVICE` / `_KEYCHAIN_ACCOUNT` | SMTP Keychain reference. |
 | `APPLE_MAIL_MCP_CONFIG_FILE` | Path to the config JSON (default app-support dir). |
+| `APPLE_MAIL_MCP_TEMPLATES_FILE` | Email-templates store path (default `~/Library/Application Support/apple-mail-mcp/templates.json`). |
+| `APPLE_MAIL_MCP_MAX_BUFFER` | Max AppleScript (`osascript`) output buffer in bytes (default 64 MiB). |
+| `APPLE_MAIL_MAX_SEARCH_MAILBOX` | Per-mailbox message-count guard for unscoped AppleScript search (default `5000`; `0` disables). Note: no `_MCP` in the name. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",
@@ -11,6 +11,7 @@
   },
   "files": [
     "build",
+    "docs",
     "README.md",
     "LICENSE"
   ],

--- a/skills/apple-mail/skill.md
+++ b/skills/apple-mail/skill.md
@@ -150,7 +150,7 @@ Action: Use delete-message with the message ID
 ## Error Handling
 
 - **"Message not found"**: The message ID may be invalid or the message was deleted. Use search-messages to find it again.
-- **"Permission denied"**: User needs to grant automation permission in System Preferences > Privacy & Security > Automation.
+- **"Permission denied"**: User needs to grant automation permission in System Settings > Privacy & Security > Automation.
 - **"Account not found"**: Account names are case-sensitive. Use list-accounts to see exact names.
 - **"Failed to send"**: Check network connection and Mail.app configuration.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from "url";
 import { parseArgs } from "util";
 import { sendViaSmtp, resolveSmtpConfig, SMTP_ENV } from "@/services/smtpMailer.js";
 import type { AttachmentInput } from "@/types.js";
+import { SETUP_GUIDE_URL } from "@/utils/docsUrls.js";
 
 /** sysexits.h codes used so callers can distinguish failure modes. */
 export const EX_USAGE = 64;
@@ -48,7 +49,8 @@ Optional:
   --help                Show this help
 
 SMTP connection comes from ${SMTP_ENV.host} / ${SMTP_ENV.user} (+ password via
-${SMTP_ENV.password} or the macOS Keychain). See the README "SMTP transport".`;
+${SMTP_ENV.password} or the macOS Keychain). Setup guide:
+${SETUP_GUIDE_URL}`;
 
 /** Injectable dependencies, defaulted to the real implementations. */
 export interface CliDeps {
@@ -132,7 +134,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     config = resolveConfig(env);
   } catch (e) {
     err(e instanceof Error ? e.message : String(e));
-    err(`See the README "SMTP transport" section.`);
+    err(`Setup guide: ${SETUP_GUIDE_URL}`);
     return EX_CONFIG;
   }
 

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -3307,7 +3307,7 @@ ${actionStmts.join("\n")}
       });
     } else {
       const errorHint = mailCheck.error?.includes("not authorized")
-        ? " (check Automation permissions in System Preferences)"
+        ? " (check System Settings > Privacy & Security > Automation)"
         : "";
       checks.push({
         name: "mail_app",
@@ -3332,7 +3332,7 @@ ${actionStmts.join("\n")}
         name: "permissions",
         passed: !isPermError,
         message: isPermError
-          ? "AppleScript permissions denied. Grant access in System Preferences > Privacy & Security > Automation"
+          ? "AppleScript permissions denied. Grant access in System Settings > Privacy & Security > Automation"
           : `Permission check returned: ${permCheck.error}`,
       });
       if (isPermError) {

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -24,6 +24,7 @@
  */
 import { ImapFlow } from "imapflow";
 import { readKeychainPassword } from "@/services/smtpMailer.js";
+import { SETUP_HINT } from "@/utils/docsUrls.js";
 import { extractHtmlBody, extractTextBody } from "@/utils/mimeParse.js";
 
 export const IMAP_ENV = {
@@ -330,7 +331,9 @@ export function resolveImapConfig(
 ): ImapConfig {
   const specs = listImapAccountSpecs(env);
   if (specs.length === 0) {
-    throw new Error(`IMAP not configured. Set ${IMAP_ENV.user} (login address) to enable it.`);
+    throw new Error(
+      `IMAP not configured. Set ${IMAP_ENV.user} (login address) to enable it. ${SETUP_HINT}`
+    );
   }
   let spec: ImapAccountSpec | undefined;
   if (account) {

--- a/src/services/smtpMailer.ts
+++ b/src/services/smtpMailer.ts
@@ -21,6 +21,7 @@ import { execFileSync } from "child_process";
 import { isAbsolute } from "path";
 import { existsSync } from "fs";
 import type { AttachmentInput } from "@/types.js";
+import { SETUP_HINT } from "@/utils/docsUrls.js";
 
 /** Options for an SMTP send, mirroring the AppleScript send-email surface. */
 export interface SmtpSendOptions {
@@ -165,7 +166,7 @@ export function resolveSmtpConfig(env: NodeJS.ProcessEnv = process.env): SmtpCon
     throw new Error(
       `SMTP transport is not configured. Set ${missing.join(" and ")} ` +
         `(plus a password via ${SMTP_ENV.password} or the Keychain). ` +
-        `See the README "SMTP transport" section.`
+        SETUP_HINT
     );
   }
 
@@ -195,7 +196,8 @@ export function resolveSmtpConfig(env: NodeJS.ProcessEnv = process.env): SmtpCon
       `No SMTP password found. Set ${SMTP_ENV.password}, or store an internet ` +
         `password in the Keychain for service "${
           env[SMTP_ENV.keychainService]?.trim() || host
-        }" / account "${env[SMTP_ENV.keychainAccount]?.trim() || user}".`
+        }" / account "${env[SMTP_ENV.keychainAccount]?.trim() || user}". ` +
+        SETUP_HINT
     );
   }
 

--- a/src/tools/doctor.ts
+++ b/src/tools/doctor.ts
@@ -9,6 +9,7 @@
 import type { AppleMailManager } from "@/services/appleMailManager.js";
 import { imapHealthCheck, IMAP_ENV, listImapAccountLabels } from "@/services/imapClient.js";
 import { SMTP_ENV, isSmtpConfigured } from "@/services/smtpMailer.js";
+import { SETUP_GUIDE_URL } from "@/utils/docsUrls.js";
 
 export type CheckStatus = "ok" | "warn" | "fail";
 export interface DoctorCheck {
@@ -21,9 +22,6 @@ export interface DoctorReport {
   checks: DoctorCheck[];
 }
 
-/** Public setup walkthrough, surfaced in the "not configured" messages so a stuck
- *  user (or their AI) can find it without having the repo checked out. */
-const SETUP_GUIDE = "https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md";
 /** The #1 Claude-Desktop failure mode: the host strips the server `env` block, so
  *  the env-var advice silently does nothing — point users at the file method. */
 const CONFIG_FILE_HINT =
@@ -70,7 +68,7 @@ export async function runDoctor(mailManager: AppleMailManager): Promise<DoctorRe
     checks.push({
       name: "IMAP backend",
       status: "warn",
-      detail: `not configured — AppleScript is used for all accounts. Set ${IMAP_ENV.user} (+ Keychain/password), or ${IMAP_ENV.accounts} for multiple accounts, to enable server-side search and server-mailbox ops. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE}`,
+      detail: `not configured — AppleScript is used for all accounts. Set ${IMAP_ENV.user} (+ Keychain/password), or ${IMAP_ENV.accounts} for multiple accounts, to enable server-side search and server-mailbox ops. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE_URL}`,
     });
   } else {
     for (const label of imapAccounts) {
@@ -92,7 +90,7 @@ export async function runDoctor(mailManager: AppleMailManager): Promise<DoctorRe
     status: isSmtpConfigured() ? "ok" : "warn",
     detail: isSmtpConfigured()
       ? `configured (${smtpHost}); send-email auto-prefers clean SMTP (no Mail.app Sent-folder copy; a non-email "account" label still routes to AppleScript). Pass transport:"applescript" to force Mail.app. The apple-mail-send CLI is also available.`
-      : `not configured — send-email uses AppleScript (subject to macOS 15+ blockquote wrapping). Set ${SMTP_ENV.host} and ${SMTP_ENV.user} (+ password via Keychain) to enable. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE}`,
+      : `not configured — send-email uses AppleScript (subject to macOS 15+ blockquote wrapping). Set ${SMTP_ENV.host} and ${SMTP_ENV.user} (+ password via Keychain) to enable. ${CONFIG_FILE_HINT}. Setup guide: ${SETUP_GUIDE_URL}`,
   });
 
   const healthy = !checks.some((c) => c.status === "fail");

--- a/src/utils/applescript.test.ts
+++ b/src/utils/applescript.test.ts
@@ -136,7 +136,7 @@ describe("executeAppleScript", () => {
       const result = executeAppleScript("test");
 
       expect(result.error).toContain("Permission denied");
-      expect(result.error).toContain("System Preferences");
+      expect(result.error).toContain("System Settings");
     });
 
     it("provides helpful message for mailbox not found", () => {

--- a/src/utils/applescript.ts
+++ b/src/utils/applescript.ts
@@ -207,7 +207,7 @@ const ERROR_MAPPINGS: Array<{ pattern: RegExp; message: string }> = [
   {
     pattern: /not authorized|not permitted|access.*denied/i,
     message:
-      "Permission denied. Grant automation access in System Preferences > Privacy & Security > Automation.",
+      "Permission denied. Grant automation access in System Settings > Privacy & Security > Automation.",
   },
   // Application not running
   {

--- a/src/utils/docsUrls.ts
+++ b/src/utils/docsUrls.ts
@@ -1,0 +1,17 @@
+/**
+ * Absolute documentation URLs shared by error messages and the doctor tool.
+ *
+ * Errors that tell a user "X is not configured" must be actionable for someone
+ * who installed from npm or a plugin marketplace and has never seen the repo —
+ * so they end with an absolute setup-guide URL plus a pointer at the `doctor`
+ * tool, instead of referencing files relative to a checkout they don't have.
+ *
+ * @module utils/docsUrls
+ */
+
+/** Step-by-step IMAP/SMTP setup walkthrough (app passwords, Keychain, env vs config.json). */
+export const SETUP_GUIDE_URL =
+  "https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md";
+
+/** Standard tail for "not configured" errors: where to read + how to diagnose. */
+export const SETUP_HINT = `Setup guide: ${SETUP_GUIDE_URL} — run the "doctor" tool to check your setup.`;


### PR DESCRIPTION
End-user documentation audit fixes (bump 2.8.5 → 2.8.6).

## Fix items

1. **Registry installs** — README install commands now use `npm install -g apple-mail-mcp` (both occurrences); the `github:sweetrb/apple-mail-mcp` form is kept only as a From-Source note labeled as building from source (requires pnpm).
2. **Actionable errors** — new shared `src/utils/docsUrls.ts` (`SETUP_GUIDE_URL` / `SETUP_HINT`), reused by `doctor`, `smtpMailer` ("SMTP transport is not configured", "No SMTP password found"), `imapClient` ("IMAP not configured"), and the `apple-mail-send` CLI: each message now ends with the absolute setup-guide URL + a hint to run the `doctor` tool. Also "System Preferences" → "System Settings > Privacy & Security > Automation" in `applescript.ts`, `appleMailManager.ts`, README, SECURITY.md, and all three skill copies.
3. **npm tarball self-containment** — `docs/` added to `package.json` `files`; every README cross-file link (setup guide ×2, CONTRIBUTING, LICENSE, hermes/antigravity plugin configs, TCC notes, header screenshot) converted to absolute `github.com` / `raw.githubusercontent.com` URLs.
4. **Stale-docs corrections** — Known Limitations: in-memory-templates row removed (templates persist to `templates.json` via `APPLE_MAIL_MCP_TEMPLATES_FILE`), message-ID row now covers `imap:…` tokens, HTML-sending row points at the `apple-mail-send` CLI `--html-body-file`. `docs/IMAP-SETUP.md`: `IDLE_MS` default corrected to `30000` (verified against `src/services/imapClient.ts`, 2 places), `IMAP_ACCOUNTS` wording fixed to "JSON array of objects, passed as a single string value", env-var reference gained `APPLE_MAIL_MCP_TEMPLATES_FILE`, `APPLE_MAIL_MCP_MAX_BUFFER`, `APPLE_MAIL_MAX_SEARCH_MAILBOX` (names verified in src).
5. **Plugin-marketplace config note** — README Quick Start: plugin installs have no editable `env` block; configure via `~/Library/Application Support/apple-mail-mcp/config.json` (Method B, absolute URL). Mirrored into IMAP-SETUP.md Step 3.
6. **Deterministic install one-liner** — `claude mcp add apple-mail -s user -- npx -y apple-mail-mcp` added to the Claude Code Quick Start.

## Verification

- `pnpm run lint` / `format:check` / `typecheck` / `test` (347 passed) / `build` — all green
- `npm pack --dry-run`: tarball now ships `docs/` (IMAP-SETUP.md, NODE-RUNTIME-AND-TCC-PERMISSIONS.md, STABILITY-PERF-AUDIT), 8 files total, nothing unexpected
- Rebuilt `build/index.js` + `build/cli.js` contain the new setup-guide URL and doctor hint (grep-verified)
- Version bumped to 2.8.6 + plugin manifests synced (`scripts/sync-plugin-version.mjs`) + CHANGELOG entry dated 2026-07-09