### PR TITLE
feat(contacts): read Contacts DB directly (FDA) instead of AppleScript (2.8.7)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.6",
+      "version": "2.8.7",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.6",
+      "version": "2.8.7",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.8.6",
+      "version": "2.8.7",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.7] - 2026-07-10
+
+### Changed
+- **`search-contacts` now reads the macOS Contacts database directly (Full Disk Access) instead of driving Contacts.app over AppleScript.** The old `tell application "Contacts"` path required an **Automation / Apple-Events** TCC grant for `node` → Contacts; on headless/scheduled hosts missing that grant it raised an **unanswerable permission prompt that hung until timeout**. The new reader (`src/utils/contactsDb.ts`) scans the AddressBook SQLite files — the top-level `~/Library/Application Support/AddressBook/AddressBook-v22.abcddb` plus every `Sources/*/AddressBook-v22.abcddb` — read-only via the built-in **`node:sqlite`**, needs only **Full Disk Access** (a stable grant the Node runtime already holds), and **prompts for nothing**. It matches the query as a case-insensitive substring of full name, organization, nickname, or any email address, returns emails and phone numbers, and de-duplicates across sources. Locked/absent source DBs are skipped rather than failing the search. Requires **Node ≥ 22.5** for `node:sqlite`; on older runtimes it logs one line and returns an empty list (it does **not** fall back to AppleScript, which would reintroduce the prompt). The `search-contacts` tool contract (inputs/outputs) is unchanged.
+
 ## [2.8.6] - 2026-07-09
 End-user docs/discoverability pass: make setup findable for no-clone installs (npm registry, plugin marketplace) and make "not configured" errors actionable.
 

--- a/build/index.js
+++ b/build/index.js
@@ -20707,7 +20707,7 @@ var require_thread_stream = __commonJS({
     var { version: version3 } = require_package2();
     var { EventEmitter } = __require("events");
     var { Worker } = __require("worker_threads");
-    var { join: join5 } = __require("path");
+    var { join: join6 } = __require("path");
     var { pathToFileURL } = __require("url");
     var { wait } = require_wait();
     var {
@@ -20758,7 +20758,7 @@ var require_thread_stream = __commonJS({
     function createWorker(stream, opts) {
       const { filename, workerData } = opts;
       const bundlerOverrides = "__bundlerPathsOverrides" in globalThis ? globalThis.__bundlerPathsOverrides : {};
-      const toExecute = bundlerOverrides["thread-stream-worker"] || join5(__dirname, "lib", "worker.js");
+      const toExecute = bundlerOverrides["thread-stream-worker"] || join6(__dirname, "lib", "worker.js");
       const worker = new Worker(toExecute, {
         ...opts.workerOpts,
         name: opts.workerOpts?.name || "thread-stream",
@@ -21224,9 +21224,9 @@ var require_transport = __commonJS({
   "node_modules/.pnpm/pino@10.3.1/node_modules/pino/lib/transport.js"(exports, module) {
     "use strict";
     var { createRequire: createRequire2 } = __require("module");
-    var { existsSync: existsSync5 } = __require("node:fs");
+    var { existsSync: existsSync6 } = __require("node:fs");
     var getCallers = require_caller();
-    var { join: join5, isAbsolute: isAbsolute3, sep: sep2 } = __require("node:path");
+    var { join: join6, isAbsolute: isAbsolute3, sep: sep2 } = __require("node:path");
     var { fileURLToPath } = __require("node:url");
     var sleep2 = require_atomic_sleep();
     var onExit = require_on_exit_leak_free();
@@ -21298,7 +21298,7 @@ var require_transport = __commonJS({
           return false;
         }
       }
-      return isAbsolute3(path) && !existsSync5(path);
+      return isAbsolute3(path) && !existsSync6(path);
     }
     function stripQuotes(value) {
       const first = value[0];
@@ -21379,7 +21379,7 @@ var require_transport = __commonJS({
         throw new Error("only one of target or targets can be specified");
       }
       if (targets) {
-        target = bundlerOverrides["pino-worker"] || join5(__dirname, "worker.js");
+        target = bundlerOverrides["pino-worker"] || join6(__dirname, "worker.js");
         options.targets = targets.filter((dest) => dest.target).map((dest) => {
           return {
             ...dest,
@@ -21397,7 +21397,7 @@ var require_transport = __commonJS({
           });
         });
       } else if (pipeline) {
-        target = bundlerOverrides["pino-worker"] || join5(__dirname, "worker.js");
+        target = bundlerOverrides["pino-worker"] || join6(__dirname, "worker.js");
         options.pipelines = [pipeline.map((dest) => {
           return {
             ...dest,
@@ -21420,7 +21420,7 @@ var require_transport = __commonJS({
           return origin;
         }
         if (origin === "pino/file") {
-          return join5(__dirname, "..", "file.js");
+          return join6(__dirname, "..", "file.js");
         }
         let fixTarget2;
         for (const filePath of callers) {
@@ -22400,7 +22400,7 @@ var require_safe_stable_stringify = __commonJS({
               return circularValue;
             }
             let res = "";
-            let join5 = ",";
+            let join6 = ",";
             const originalIndentation = indentation;
             if (Array.isArray(value)) {
               if (value.length === 0) {
@@ -22414,7 +22414,7 @@ var require_safe_stable_stringify = __commonJS({
                 indentation += spacer;
                 res += `
 ${indentation}`;
-                join5 = `,
+                join6 = `,
 ${indentation}`;
               }
               const maximumValuesToStringify = Math.min(value.length, maximumBreadth);
@@ -22422,13 +22422,13 @@ ${indentation}`;
               for (; i < maximumValuesToStringify - 1; i++) {
                 const tmp2 = stringifyFnReplacer(String(i), value, stack, replacer, spacer, indentation);
                 res += tmp2 !== void 0 ? tmp2 : "null";
-                res += join5;
+                res += join6;
               }
               const tmp = stringifyFnReplacer(String(i), value, stack, replacer, spacer, indentation);
               res += tmp !== void 0 ? tmp : "null";
               if (value.length - 1 > maximumBreadth) {
                 const removedKeys = value.length - maximumBreadth - 1;
-                res += `${join5}"... ${getItemCount(removedKeys)} not stringified"`;
+                res += `${join6}"... ${getItemCount(removedKeys)} not stringified"`;
               }
               if (spacer !== "") {
                 res += `
@@ -22449,7 +22449,7 @@ ${originalIndentation}`;
             let separator = "";
             if (spacer !== "") {
               indentation += spacer;
-              join5 = `,
+              join6 = `,
 ${indentation}`;
               whitespace = " ";
             }
@@ -22463,13 +22463,13 @@ ${indentation}`;
               const tmp = stringifyFnReplacer(key2, value, stack, replacer, spacer, indentation);
               if (tmp !== void 0) {
                 res += `${separator}${strEscape(key2)}:${whitespace}${tmp}`;
-                separator = join5;
+                separator = join6;
               }
             }
             if (keyLength > maximumBreadth) {
               const removedKeys = keyLength - maximumBreadth;
               res += `${separator}"...":${whitespace}"${getItemCount(removedKeys)} not stringified"`;
-              separator = join5;
+              separator = join6;
             }
             if (spacer !== "" && separator.length > 1) {
               res = `
@@ -22510,7 +22510,7 @@ ${originalIndentation}`;
             }
             const originalIndentation = indentation;
             let res = "";
-            let join5 = ",";
+            let join6 = ",";
             if (Array.isArray(value)) {
               if (value.length === 0) {
                 return "[]";
@@ -22523,7 +22523,7 @@ ${originalIndentation}`;
                 indentation += spacer;
                 res += `
 ${indentation}`;
-                join5 = `,
+                join6 = `,
 ${indentation}`;
               }
               const maximumValuesToStringify = Math.min(value.length, maximumBreadth);
@@ -22531,13 +22531,13 @@ ${indentation}`;
               for (; i < maximumValuesToStringify - 1; i++) {
                 const tmp2 = stringifyArrayReplacer(String(i), value[i], stack, replacer, spacer, indentation);
                 res += tmp2 !== void 0 ? tmp2 : "null";
-                res += join5;
+                res += join6;
               }
               const tmp = stringifyArrayReplacer(String(i), value[i], stack, replacer, spacer, indentation);
               res += tmp !== void 0 ? tmp : "null";
               if (value.length - 1 > maximumBreadth) {
                 const removedKeys = value.length - maximumBreadth - 1;
-                res += `${join5}"... ${getItemCount(removedKeys)} not stringified"`;
+                res += `${join6}"... ${getItemCount(removedKeys)} not stringified"`;
               }
               if (spacer !== "") {
                 res += `
@@ -22550,7 +22550,7 @@ ${originalIndentation}`;
             let whitespace = "";
             if (spacer !== "") {
               indentation += spacer;
-              join5 = `,
+              join6 = `,
 ${indentation}`;
               whitespace = " ";
             }
@@ -22559,7 +22559,7 @@ ${indentation}`;
               const tmp = stringifyArrayReplacer(key2, value[key2], stack, replacer, spacer, indentation);
               if (tmp !== void 0) {
                 res += `${separator}${strEscape(key2)}:${whitespace}${tmp}`;
-                separator = join5;
+                separator = join6;
               }
             }
             if (spacer !== "" && separator.length > 1) {
@@ -22617,20 +22617,20 @@ ${originalIndentation}`;
               indentation += spacer;
               let res2 = `
 ${indentation}`;
-              const join6 = `,
+              const join7 = `,
 ${indentation}`;
               const maximumValuesToStringify = Math.min(value.length, maximumBreadth);
               let i = 0;
               for (; i < maximumValuesToStringify - 1; i++) {
                 const tmp2 = stringifyIndent(String(i), value[i], stack, spacer, indentation);
                 res2 += tmp2 !== void 0 ? tmp2 : "null";
-                res2 += join6;
+                res2 += join7;
               }
               const tmp = stringifyIndent(String(i), value[i], stack, spacer, indentation);
               res2 += tmp !== void 0 ? tmp : "null";
               if (value.length - 1 > maximumBreadth) {
                 const removedKeys = value.length - maximumBreadth - 1;
-                res2 += `${join6}"... ${getItemCount(removedKeys)} not stringified"`;
+                res2 += `${join7}"... ${getItemCount(removedKeys)} not stringified"`;
               }
               res2 += `
 ${originalIndentation}`;
@@ -22646,16 +22646,16 @@ ${originalIndentation}`;
               return '"[Object]"';
             }
             indentation += spacer;
-            const join5 = `,
+            const join6 = `,
 ${indentation}`;
             let res = "";
             let separator = "";
             let maximumPropertiesToStringify = Math.min(keyLength, maximumBreadth);
             if (isTypedArrayWithEntries(value)) {
-              res += stringifyTypedArray(value, join5, maximumBreadth);
+              res += stringifyTypedArray(value, join6, maximumBreadth);
               keys = keys.slice(value.length);
               maximumPropertiesToStringify -= value.length;
-              separator = join5;
+              separator = join6;
             }
             if (deterministic) {
               keys = sort(keys, comparator);
@@ -22666,13 +22666,13 @@ ${indentation}`;
               const tmp = stringifyIndent(key2, value[key2], stack, spacer, indentation);
               if (tmp !== void 0) {
                 res += `${separator}${strEscape(key2)}: ${tmp}`;
-                separator = join5;
+                separator = join6;
               }
             }
             if (keyLength > maximumBreadth) {
               const removedKeys = keyLength - maximumBreadth;
               res += `${separator}"...": "${getItemCount(removedKeys)} not stringified"`;
-              separator = join5;
+              separator = join6;
             }
             if (separator !== "") {
               res = `
@@ -76147,9 +76147,9 @@ var StdioServerTransport = class {
 
 // src/services/appleMailManager.ts
 import { spawnSync as spawnSync2 } from "child_process";
-import { existsSync as existsSync2, writeFileSync as writeFileSync3, readFileSync as readFileSync2, mkdtempSync as mkdtempSync2, rmSync as rmSync2 } from "fs";
-import { isAbsolute, resolve, sep, join as join3 } from "path";
-import { homedir as homedir2 } from "os";
+import { existsSync as existsSync3, writeFileSync as writeFileSync3, readFileSync as readFileSync2, mkdtempSync as mkdtempSync2, rmSync as rmSync2 } from "fs";
+import { isAbsolute, resolve, sep, join as join4 } from "path";
+import { homedir as homedir3 } from "os";
 
 // src/utils/applescript.ts
 import { execSync, spawnSync } from "child_process";
@@ -76685,6 +76685,114 @@ function materializeAttachments(attachments) {
   };
 }
 
+// src/utils/contactsDb.ts
+import { existsSync as existsSync2, readdirSync } from "fs";
+import { join as join3 } from "path";
+import { homedir as homedir2 } from "os";
+function loadSqlite() {
+  try {
+    const mod = __require("node:sqlite");
+    if (!mod || typeof mod.DatabaseSync !== "function") {
+      console.error(
+        "[contactsDb] node:sqlite unavailable (no DatabaseSync export); returning no contacts"
+      );
+      return null;
+    }
+    return mod;
+  } catch (err) {
+    console.error(
+      `[contactsDb] node:sqlite not available (requires Node >= 22.5); returning no contacts: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return null;
+  }
+}
+function resolveContactsDbPaths(baseDir) {
+  const root = baseDir ?? join3(homedir2(), "Library", "Application Support", "AddressBook");
+  const paths = [];
+  const topLevel = join3(root, "AddressBook-v22.abcddb");
+  if (existsSync2(topLevel)) paths.push(topLevel);
+  const sourcesDir = join3(root, "Sources");
+  if (existsSync2(sourcesDir)) {
+    let entries = [];
+    try {
+      entries = readdirSync(sourcesDir);
+    } catch {
+      entries = [];
+    }
+    for (const entry of entries) {
+      const candidate = join3(sourcesDir, entry, "AddressBook-v22.abcddb");
+      if (existsSync2(candidate)) paths.push(candidate);
+    }
+  }
+  return paths;
+}
+var RECORD_SQL = `
+  SELECT r.Z_PK pk,
+         TRIM(COALESCE(r.ZFIRSTNAME,'')||' '||COALESCE(r.ZLASTNAME,'')) fullname,
+         r.ZORGANIZATION org, r.ZNICKNAME nick
+  FROM ZABCDRECORD r
+  WHERE lower(TRIM(COALESCE(r.ZFIRSTNAME,'')||' '||COALESCE(r.ZLASTNAME,''))) LIKE ?
+     OR lower(COALESCE(r.ZORGANIZATION,'')) LIKE ?
+     OR lower(COALESCE(r.ZNICKNAME,''))     LIKE ?
+     OR r.Z_PK IN (SELECT ZOWNER FROM ZABCDEMAILADDRESS WHERE lower(COALESCE(ZADDRESS,'')) LIKE ?)
+`;
+var EMAILS_SQL = `SELECT ZADDRESS AS v FROM ZABCDEMAILADDRESS WHERE ZOWNER = ? AND ZADDRESS IS NOT NULL`;
+var PHONES_SQL = `SELECT ZFULLNUMBER AS v FROM ZABCDPHONENUMBER WHERE ZOWNER = ? AND ZFULLNUMBER IS NOT NULL`;
+function displayName(row) {
+  const fullname = typeof row.fullname === "string" ? row.fullname.trim() : "";
+  if (fullname) return fullname;
+  const org = typeof row.org === "string" ? row.org.trim() : "";
+  if (org) return org;
+  const nick = typeof row.nick === "string" ? row.nick.trim() : "";
+  if (nick) return nick;
+  return "(no name)";
+}
+function searchOneDb(sqlite, dbPath, like) {
+  let db = null;
+  try {
+    db = new sqlite.DatabaseSync(dbPath, { readOnly: true });
+    const records = db.prepare(RECORD_SQL).all(like, like, like, like);
+    const emailStmt = db.prepare(EMAILS_SQL);
+    const phoneStmt = db.prepare(PHONES_SQL);
+    const contacts = [];
+    for (const rec of records) {
+      const pk = rec.pk;
+      const emails = emailStmt.all(pk).map((r) => r.v).filter((v) => typeof v === "string" && v.length > 0);
+      const phones = phoneStmt.all(pk).map((r) => r.v).filter((v) => typeof v === "string" && v.length > 0);
+      contacts.push({ name: displayName(rec), emails, phones });
+    }
+    return contacts;
+  } catch (err) {
+    console.error(
+      `[contactsDb] skipping unreadable Contacts DB ${dbPath}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return [];
+  } finally {
+    try {
+      db?.close();
+    } catch {
+    }
+  }
+}
+function searchContactsDb(query, opts) {
+  if (!query || !query.trim()) return [];
+  const sqlite = loadSqlite();
+  if (!sqlite) return [];
+  const dbPaths = opts?.dbPaths ?? resolveContactsDbPaths();
+  const like = `%${query.toLowerCase()}%`;
+  const seen = /* @__PURE__ */ new Set();
+  const results = [];
+  for (const dbPath of dbPaths) {
+    for (const contact of searchOneDb(sqlite, dbPath, like)) {
+      const key = `${contact.name} ${[...contact.emails].sort().join(",")}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      results.push(contact);
+    }
+  }
+  return results;
+}
+
 // src/services/appleMailManager.ts
 function getMailboxScanThreshold() {
   const raw = process.env.APPLE_MAIL_MAX_SEARCH_MAILBOX;
@@ -76740,7 +76848,7 @@ function splitSearchDiagnostics(output, account) {
   }
   return { payload, diagnostics };
 }
-var ALLOWED_SAVE_ROOTS = [homedir2(), "/tmp", "/private/tmp", "/Volumes"];
+var ALLOWED_SAVE_ROOTS = [homedir3(), "/tmp", "/private/tmp", "/Volumes"];
 function isPathWithinAllowedRoots(resolvedPath) {
   return ALLOWED_SAVE_ROOTS.some((root) => {
     const base = root.endsWith(sep) ? root.slice(0, -1) : root;
@@ -76784,7 +76892,7 @@ function buildAttachmentCommands(attachments) {
     if (!isAbsolute(filePath)) {
       throw new Error(`Attachment path must be absolute: "${filePath}"`);
     }
-    if (!existsSync2(filePath)) {
+    if (!existsSync3(filePath)) {
       throw new Error(`Attachment file not found: "${filePath}"`);
     }
   }
@@ -78606,7 +78714,7 @@ var AppleMailManager = class {
     let dir = null;
     try {
       dir = mkdtempSync2("/private/tmp/amcp-fetch-");
-      const dest = join3(dir, attachmentName.replace(/[/\\]/g, "_"));
+      const dest = join4(dir, attachmentName.replace(/[/\\]/g, "_"));
       const ok = this.saveAttachment(id, attachmentName, dest);
       if (!ok) {
         return {
@@ -79040,60 +79148,16 @@ ${actionStmts.join("\n")}
   // Contacts Integration
   // ===========================================================================
   /**
-   * Search contacts by name or email.
+   * Search contacts by name, organization, nickname, or email address.
+   *
+   * Reads the macOS Contacts (AddressBook) SQLite databases directly via Full
+   * Disk Access — it does NOT drive Contacts.app over AppleScript, so it raises
+   * no Automation / Apple-Events permission prompt (the old path would hang on
+   * that unanswerable prompt on headless/scheduled hosts). See
+   * {@link searchContactsDb}.
    */
   searchContacts(query) {
-    const safeQuery = escapeForAppleScript(query);
-    const script = `
-      tell application "Contacts"
-        set matchedContacts to {}
-        set foundPeople to (every person whose name contains "${safeQuery}") & (every person whose value of emails contains "${safeQuery}")
-
-        -- Deduplicate by tracking IDs
-        set seenIds to {}
-        repeat with p in foundPeople
-          set pid to id of p
-          if seenIds does not contain pid then
-            set end of seenIds to pid
-            -- Per-person try: one malformed contact (e.g. no emails) must not
-            -- abort the whole search and return an empty list (audit finding #13).
-            try
-              set pName to name of p
-              set pEmails to ""
-              repeat with e in emails of p
-                if pEmails is not "" then set pEmails to pEmails & ","
-                set pEmails to pEmails & (value of e)
-              end repeat
-              set pPhones to ""
-              repeat with ph in phones of p
-                if pPhones is not "" then set pPhones to pPhones & ","
-                set pPhones to pPhones & (value of ph)
-              end repeat
-              set end of matchedContacts to pName & "${FIELD_SEP}" & pEmails & "${FIELD_SEP}" & pPhones
-            end try
-          end if
-        end repeat
-
-        set AppleScript's text item delimiters to "${RECORD_SEP}"
-        return matchedContacts as text
-      end tell
-    `;
-    const result = executeAppleScript(script);
-    if (!result.success || !result.output.trim()) {
-      return [];
-    }
-    const items = result.output.split(RECORD_SEP);
-    const contacts = [];
-    for (const item of items) {
-      const parts = item.split(FIELD_SEP);
-      if (parts.length < 3) continue;
-      contacts.push({
-        name: parts[0],
-        emails: parts[1] ? parts[1].split(",").filter(Boolean) : [],
-        phones: parts[2] ? parts[2].split(",").filter(Boolean) : []
-      });
-    }
-    return contacts;
+    return searchContactsDb(query);
   }
   // ===========================================================================
   // Email Templates
@@ -79408,7 +79472,7 @@ import { resolve as resolvePath, join as joinPath } from "path";
 var import_nodemailer = __toESM(require_nodemailer(), 1);
 import { execFileSync } from "child_process";
 import { isAbsolute as isAbsolute2 } from "path";
-import { existsSync as existsSync3 } from "fs";
+import { existsSync as existsSync4 } from "fs";
 
 // src/utils/docsUrls.ts
 var SETUP_GUIDE_URL = "https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md";
@@ -79484,7 +79548,7 @@ function buildAttachments(attachments) {
   return attachments.map((a) => {
     if (typeof a === "string") {
       if (!isAbsolute2(a)) throw new Error(`Attachment path must be absolute: "${a}"`);
-      if (!existsSync3(a)) throw new Error(`Attachment file not found: "${a}"`);
+      if (!existsSync4(a)) throw new Error(`Attachment file not found: "${a}"`);
       return { path: a };
     }
     if (!a.filename || !a.contentBase64) {
@@ -81078,18 +81142,18 @@ var ImapIdleWatcher = class {
 };
 
 // src/services/fileConfig.ts
-import { existsSync as existsSync4, readFileSync as readFileSync3 } from "fs";
-import { join as join4 } from "path";
-import { homedir as homedir3 } from "os";
+import { existsSync as existsSync5, readFileSync as readFileSync3 } from "fs";
+import { join as join5 } from "path";
+import { homedir as homedir4 } from "os";
 function fileConfigPath(env = process.env) {
   const override = env.APPLE_MAIL_MCP_CONFIG_FILE;
   if (override && override.trim()) return override.trim();
-  return join4(homedir3(), "Library", "Application Support", "apple-mail-mcp", "config.json");
+  return join5(homedir4(), "Library", "Application Support", "apple-mail-mcp", "config.json");
 }
 function loadFileConfig(env = process.env, path = fileConfigPath(env)) {
   const applied = [];
   try {
-    if (!existsSync4(path)) return applied;
+    if (!existsSync5(path)) return applied;
     const parsed = JSON.parse(readFileSync3(path, "utf8"));
     if (!parsed || typeof parsed !== "object") return applied;
     for (const [k, v] of Object.entries(parsed)) {
@@ -82697,7 +82761,7 @@ server.registerTool(
 server.registerTool(
   "search-contacts",
   {
-    description: "Use when: looking up a person in Contacts.app by name to find their email address(es) before composing or sending mail.\nReturns: matching contacts with their names and email addresses.\nDo not use when: searching email messages (use search-messages) \u2014 this queries Contacts, not the mailbox.",
+    description: "Use when: looking up a person in Contacts by name, organization, nickname, or email to find their email address(es)/phone(s) before composing or sending mail. Reads the macOS Contacts database directly (needs Full Disk Access; does NOT require Contacts.app to be running or an Automation / Apple-Events grant).\nReturns: matching contacts with their names, email addresses, and phone numbers.\nDo not use when: searching email messages (use search-messages) \u2014 this queries Contacts, not the mailbox.",
     inputSchema: {
       query: external_exports.string().min(1, "Search query is required")
     },

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2266,7 +2266,7 @@ server.registerTool(
   "search-contacts",
   {
     description:
-      "Use when: looking up a person in Contacts.app by name to find their email address(es) before composing or sending mail.\nReturns: matching contacts with their names and email addresses.\nDo not use when: searching email messages (use search-messages) — this queries Contacts, not the mailbox.",
+      "Use when: looking up a person in Contacts by name, organization, nickname, or email to find their email address(es)/phone(s) before composing or sending mail. Reads the macOS Contacts database directly (needs Full Disk Access; does NOT require Contacts.app to be running or an Automation / Apple-Events grant).\nReturns: matching contacts with their names, email addresses, and phone numbers.\nDo not use when: searching email messages (use search-messages) — this queries Contacts, not the mailbox.",
     inputSchema: {
       query: z.string().min(1, "Search query is required"),
     },

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -21,6 +21,7 @@ import { executeAppleScript } from "@/utils/applescript.js";
 import { parseMimeAttachments, extractMimeAttachment, extractHtmlBody } from "@/utils/mimeParse.js";
 import { TemplateStore } from "@/services/templateStore.js";
 import { materializeAttachments } from "@/utils/attachmentMaterialize.js";
+import { searchContactsDb } from "@/utils/contactsDb.js";
 import type {
   Message,
   MessageContent,
@@ -3160,66 +3161,16 @@ ${actionStmts.join("\n")}
   // ===========================================================================
 
   /**
-   * Search contacts by name or email.
+   * Search contacts by name, organization, nickname, or email address.
+   *
+   * Reads the macOS Contacts (AddressBook) SQLite databases directly via Full
+   * Disk Access — it does NOT drive Contacts.app over AppleScript, so it raises
+   * no Automation / Apple-Events permission prompt (the old path would hang on
+   * that unanswerable prompt on headless/scheduled hosts). See
+   * {@link searchContactsDb}.
    */
   searchContacts(query: string): Contact[] {
-    const safeQuery = escapeForAppleScript(query);
-
-    const script = `
-      tell application "Contacts"
-        set matchedContacts to {}
-        set foundPeople to (every person whose name contains "${safeQuery}") & (every person whose value of emails contains "${safeQuery}")
-
-        -- Deduplicate by tracking IDs
-        set seenIds to {}
-        repeat with p in foundPeople
-          set pid to id of p
-          if seenIds does not contain pid then
-            set end of seenIds to pid
-            -- Per-person try: one malformed contact (e.g. no emails) must not
-            -- abort the whole search and return an empty list (audit finding #13).
-            try
-              set pName to name of p
-              set pEmails to ""
-              repeat with e in emails of p
-                if pEmails is not "" then set pEmails to pEmails & ","
-                set pEmails to pEmails & (value of e)
-              end repeat
-              set pPhones to ""
-              repeat with ph in phones of p
-                if pPhones is not "" then set pPhones to pPhones & ","
-                set pPhones to pPhones & (value of ph)
-              end repeat
-              set end of matchedContacts to pName & "${FIELD_SEP}" & pEmails & "${FIELD_SEP}" & pPhones
-            end try
-          end if
-        end repeat
-
-        set AppleScript's text item delimiters to "${RECORD_SEP}"
-        return matchedContacts as text
-      end tell
-    `;
-
-    const result = executeAppleScript(script);
-
-    if (!result.success || !result.output.trim()) {
-      return [];
-    }
-
-    const items = result.output.split(RECORD_SEP);
-    const contacts: Contact[] = [];
-
-    for (const item of items) {
-      const parts = item.split(FIELD_SEP);
-      if (parts.length < 3) continue;
-      contacts.push({
-        name: parts[0],
-        emails: parts[1] ? parts[1].split(",").filter(Boolean) : [],
-        phones: parts[2] ? parts[2].split(",").filter(Boolean) : [],
-      });
-    }
-
-    return contacts;
+    return searchContactsDb(query);
   }
 
   // ===========================================================================

--- a/src/utils/contactsDb.test.ts
+++ b/src/utils/contactsDb.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdtempSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { searchContactsDb } from "@/utils/contactsDb.js";
+import { searchContactsDb, resolveContactsDbPaths } from "@/utils/contactsDb.js";
 
 /**
  * Load node:sqlite for building fixtures. If it's unavailable (Node < 22.5),
@@ -97,6 +97,12 @@ describeIfSqlite("searchContactsDb", () => {
       },
       // Contact with no emails and no phones — must still be returned.
       { first: "Bob", last: "Barless" },
+      // Org-only (no first/last/nick) — display name falls back to org.
+      { org: "Globex Widgets Inc" },
+      // Nickname-only — display name falls back to nickname.
+      { nick: "Sparky" },
+      // No name/org/nick at all, matched only by email — display name is "(no name)".
+      { emails: ["mystery@nowhere.test"] },
     ]);
 
     // Second DB duplicates Rob (same name + email) to exercise dedup, and adds
@@ -170,5 +176,61 @@ describeIfSqlite("searchContactsDb", () => {
   it("skips an unreadable/absent DB path without throwing", () => {
     const res = searchContactsDb("sweet", { dbPaths: [join(dir, "does-not-exist.abcddb"), dbA] });
     expect(res.map((c) => c.name)).toContain("Rob Sweet");
+  });
+
+  it("falls back to organization for the display name when there's no person name", () => {
+    const res = searchContactsDb("globex widgets", { dbPaths: [dbA] });
+    expect(res).toHaveLength(1);
+    expect(res[0].name).toBe("Globex Widgets Inc");
+  });
+
+  it("falls back to nickname for the display name", () => {
+    const res = searchContactsDb("sparky", { dbPaths: [dbA] });
+    expect(res).toHaveLength(1);
+    expect(res[0].name).toBe("Sparky");
+  });
+
+  it('uses "(no name)" when a matched contact has no name/org/nickname', () => {
+    const res = searchContactsDb("mystery@nowhere", { dbPaths: [dbA] });
+    expect(res).toHaveLength(1);
+    expect(res[0].name).toBe("(no name)");
+    expect(res[0].emails).toEqual(["mystery@nowhere.test"]);
+  });
+});
+
+describe("resolveContactsDbPaths", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "contactsdb-resolve-"));
+    // Top-level AddressBook file.
+    writeFileSync(join(dir, "AddressBook-v22.abcddb"), "");
+    // Two account sources; one has the DB, one is an unrelated dir without it.
+    const sources = join(dir, "Sources");
+    mkdirSync(join(sources, "AAAA-1111"), { recursive: true });
+    writeFileSync(join(sources, "AAAA-1111", "AddressBook-v22.abcddb"), "");
+    mkdirSync(join(sources, "BBBB-2222"), { recursive: true }); // no DB file inside
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns the top-level DB plus each Sources/*/AddressBook-v22.abcddb", () => {
+    const paths = resolveContactsDbPaths(dir);
+    expect(paths).toContain(join(dir, "AddressBook-v22.abcddb"));
+    expect(paths).toContain(join(dir, "Sources", "AAAA-1111", "AddressBook-v22.abcddb"));
+    // A source dir without the DB file contributes nothing.
+    expect(paths).not.toContain(join(dir, "Sources", "BBBB-2222", "AddressBook-v22.abcddb"));
+    expect(paths).toHaveLength(2);
+  });
+
+  it("returns [] for a base dir with no AddressBook files", () => {
+    const empty = mkdtempSync(join(tmpdir(), "contactsdb-empty-"));
+    try {
+      expect(resolveContactsDbPaths(empty)).toEqual([]);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
   });
 });

--- a/src/utils/contactsDb.test.ts
+++ b/src/utils/contactsDb.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { searchContactsDb } from "@/utils/contactsDb.js";
+
+/**
+ * Load node:sqlite for building fixtures. If it's unavailable (Node < 22.5),
+ * we skip the whole suite rather than fail — mirroring the module's own
+ * graceful degradation.
+ */
+let sqlite: typeof import("node:sqlite") | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  sqlite = require("node:sqlite");
+} catch {
+  sqlite = null;
+}
+
+const describeIfSqlite = sqlite ? describe : describe.skip;
+
+/**
+ * Build a fixture AddressBook DB with the real Core Data ("Z") schema columns
+ * the reader queries, then insert the given contacts.
+ */
+function buildFixtureDb(
+  path: string,
+  contacts: Array<{
+    first?: string;
+    last?: string;
+    org?: string;
+    nick?: string;
+    emails?: string[];
+    phones?: string[];
+  }>
+): void {
+  const db = new sqlite!.DatabaseSync(path);
+  db.exec(`
+    CREATE TABLE ZABCDRECORD (
+      Z_PK INTEGER PRIMARY KEY,
+      ZFIRSTNAME TEXT,
+      ZLASTNAME TEXT,
+      ZORGANIZATION TEXT,
+      ZNICKNAME TEXT
+    );
+    CREATE TABLE ZABCDEMAILADDRESS (
+      Z_PK INTEGER PRIMARY KEY,
+      ZADDRESS TEXT,
+      ZOWNER INTEGER
+    );
+    CREATE TABLE ZABCDPHONENUMBER (
+      Z_PK INTEGER PRIMARY KEY,
+      ZFULLNUMBER TEXT,
+      ZOWNER INTEGER
+    );
+  `);
+
+  const recStmt = db.prepare(
+    `INSERT INTO ZABCDRECORD (Z_PK, ZFIRSTNAME, ZLASTNAME, ZORGANIZATION, ZNICKNAME) VALUES (?, ?, ?, ?, ?)`
+  );
+  const emailStmt = db.prepare(`INSERT INTO ZABCDEMAILADDRESS (ZADDRESS, ZOWNER) VALUES (?, ?)`);
+  const phoneStmt = db.prepare(`INSERT INTO ZABCDPHONENUMBER (ZFULLNUMBER, ZOWNER) VALUES (?, ?)`);
+
+  contacts.forEach((c, i) => {
+    const pk = i + 1;
+    recStmt.run(pk, c.first ?? null, c.last ?? null, c.org ?? null, c.nick ?? null);
+    for (const e of c.emails ?? []) emailStmt.run(e, pk);
+    for (const p of c.phones ?? []) phoneStmt.run(p, pk);
+  });
+
+  db.close();
+}
+
+describeIfSqlite("searchContactsDb", () => {
+  let dir: string;
+  let dbA: string;
+  let dbB: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "contactsdb-test-"));
+    dbA = join(dir, "A.abcddb");
+    dbB = join(dir, "B.abcddb");
+
+    buildFixtureDb(dbA, [
+      {
+        first: "Rob",
+        last: "Sweet",
+        org: "Superior Technologies",
+        emails: ["rob@superiortech.io"],
+        phones: ["906-231-0504"],
+      },
+      {
+        first: "Alice",
+        last: "Anderson",
+        nick: "Ally",
+        emails: ["alice@example.com", "ally@work.com"],
+      },
+      // Contact with no emails and no phones — must still be returned.
+      { first: "Bob", last: "Barless" },
+    ]);
+
+    // Second DB duplicates Rob (same name + email) to exercise dedup, and adds
+    // a distinct contact.
+    buildFixtureDb(dbB, [
+      { first: "Rob", last: "Sweet", emails: ["rob@superiortech.io"] },
+      { first: "Carol", last: "Cavendish", emails: ["carol@globex.com"] },
+    ]);
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("matches by name substring (case-insensitive)", () => {
+    const res = searchContactsDb("sweet", { dbPaths: [dbA] });
+    expect(res).toHaveLength(1);
+    expect(res[0].name).toBe("Rob Sweet");
+    expect(res[0].emails).toEqual(["rob@superiortech.io"]);
+    expect(res[0].phones).toEqual(["906-231-0504"]);
+  });
+
+  it("matches by email substring", () => {
+    const res = searchContactsDb("globex.com", { dbPaths: [dbB] });
+    expect(res).toHaveLength(1);
+    expect(res[0].name).toBe("Carol Cavendish");
+  });
+
+  it("matches by organization", () => {
+    const res = searchContactsDb("superior tech", { dbPaths: [dbA] });
+    expect(res.map((c) => c.name)).toContain("Rob Sweet");
+  });
+
+  it("matches by nickname", () => {
+    const res = searchContactsDb("ally", { dbPaths: [dbA] });
+    // "ally" hits Alice's nickname AND her ally@work.com email — one contact.
+    expect(res).toHaveLength(1);
+    expect(res[0].name).toBe("Alice Anderson");
+    expect(res[0].emails).toEqual(["alice@example.com", "ally@work.com"]);
+  });
+
+  it("returns [] when nothing matches", () => {
+    expect(searchContactsDb("zzz-no-such-person", { dbPaths: [dbA, dbB] })).toEqual([]);
+  });
+
+  it("returns [] for an empty/whitespace query without touching the DBs", () => {
+    expect(searchContactsDb("   ", { dbPaths: [dbA] })).toEqual([]);
+  });
+
+  it("returns a contact that has no emails (emails: [])", () => {
+    const res = searchContactsDb("barless", { dbPaths: [dbA] });
+    expect(res).toHaveLength(1);
+    expect(res[0].name).toBe("Bob Barless");
+    expect(res[0].emails).toEqual([]);
+    expect(res[0].phones).toEqual([]);
+  });
+
+  it("de-duplicates the same contact seen across two DBs", () => {
+    const res = searchContactsDb("rob", { dbPaths: [dbA, dbB] });
+    const robs = res.filter((c) => c.name === "Rob Sweet");
+    expect(robs).toHaveLength(1);
+  });
+
+  it("merges results across multiple DBs", () => {
+    const res = searchContactsDb("c", { dbPaths: [dbA, dbB] });
+    const names = res.map((c) => c.name);
+    // Carol (dbB) + anyone with 'c' in name/org — at minimum Carol is present.
+    expect(names).toContain("Carol Cavendish");
+  });
+
+  it("skips an unreadable/absent DB path without throwing", () => {
+    const res = searchContactsDb("sweet", { dbPaths: [join(dir, "does-not-exist.abcddb"), dbA] });
+    expect(res.map((c) => c.name)).toContain("Rob Sweet");
+  });
+});

--- a/src/utils/contactsDb.ts
+++ b/src/utils/contactsDb.ts
@@ -1,0 +1,187 @@
+/**
+ * Contacts database reader.
+ *
+ * Reads the macOS Contacts (AddressBook) SQLite databases directly, instead of
+ * driving Contacts.app via AppleScript. This needs only **Full Disk Access** (a
+ * stable TCC grant the Node runtime already holds), and — unlike the AppleScript
+ * `tell application "Contacts"` path — raises **no Automation / Apple-Events
+ * permission prompt**. On a headless/scheduled host missing that Automation
+ * grant, the old path would hang on an unanswerable prompt until timeout; this
+ * one just reads the files.
+ *
+ * Data lives in per-source Core Data ("Z" schema) databases:
+ *   ~/Library/Application Support/AddressBook/AddressBook-v22.abcddb              (top-level "On My Mac")
+ *   ~/Library/Application Support/AddressBook/Sources/<UUID>/AddressBook-v22.abcddb  (one per account source)
+ *
+ * @module utils/contactsDb
+ */
+
+import { existsSync, readdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import type { Contact } from "@/types.js";
+
+/** Minimal shape of the `node:sqlite` DatabaseSync we rely on. */
+interface SqliteStatement {
+  all(...params: unknown[]): Record<string, unknown>[];
+}
+interface SqliteDatabase {
+  prepare(sql: string): SqliteStatement;
+  close(): void;
+}
+interface SqliteModule {
+  DatabaseSync: new (path: string, options?: { readOnly?: boolean }) => SqliteDatabase;
+}
+
+/**
+ * Lazily load the built-in `node:sqlite` module. Returns `null` (and logs one
+ * line to stderr) on Node runtimes where it is absent (< 22.5) or experimental
+ * loading throws — callers then return no results rather than falling back to
+ * the AppleScript path (which would reintroduce the permission prompt this
+ * module exists to avoid).
+ */
+function loadSqlite(): SqliteModule | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require("node:sqlite") as SqliteModule;
+    if (!mod || typeof mod.DatabaseSync !== "function") {
+      console.error(
+        "[contactsDb] node:sqlite unavailable (no DatabaseSync export); returning no contacts"
+      );
+      return null;
+    }
+    return mod;
+  } catch (err) {
+    console.error(
+      `[contactsDb] node:sqlite not available (requires Node >= 22.5); returning no contacts: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return null;
+  }
+}
+
+/**
+ * Resolve the set of AddressBook SQLite files to scan: the top-level
+ * `AddressBook-v22.abcddb` (if present) plus every
+ * `Sources/<UUID>/AddressBook-v22.abcddb`.
+ */
+export function resolveContactsDbPaths(baseDir?: string): string[] {
+  const root = baseDir ?? join(homedir(), "Library", "Application Support", "AddressBook");
+  const paths: string[] = [];
+
+  const topLevel = join(root, "AddressBook-v22.abcddb");
+  if (existsSync(topLevel)) paths.push(topLevel);
+
+  const sourcesDir = join(root, "Sources");
+  if (existsSync(sourcesDir)) {
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(sourcesDir);
+    } catch {
+      entries = [];
+    }
+    for (const entry of entries) {
+      const candidate = join(sourcesDir, entry, "AddressBook-v22.abcddb");
+      if (existsSync(candidate)) paths.push(candidate);
+    }
+  }
+
+  return paths;
+}
+
+const RECORD_SQL = `
+  SELECT r.Z_PK pk,
+         TRIM(COALESCE(r.ZFIRSTNAME,'')||' '||COALESCE(r.ZLASTNAME,'')) fullname,
+         r.ZORGANIZATION org, r.ZNICKNAME nick
+  FROM ZABCDRECORD r
+  WHERE lower(TRIM(COALESCE(r.ZFIRSTNAME,'')||' '||COALESCE(r.ZLASTNAME,''))) LIKE ?
+     OR lower(COALESCE(r.ZORGANIZATION,'')) LIKE ?
+     OR lower(COALESCE(r.ZNICKNAME,''))     LIKE ?
+     OR r.Z_PK IN (SELECT ZOWNER FROM ZABCDEMAILADDRESS WHERE lower(COALESCE(ZADDRESS,'')) LIKE ?)
+`;
+
+const EMAILS_SQL = `SELECT ZADDRESS AS v FROM ZABCDEMAILADDRESS WHERE ZOWNER = ? AND ZADDRESS IS NOT NULL`;
+const PHONES_SQL = `SELECT ZFULLNUMBER AS v FROM ZABCDPHONENUMBER WHERE ZOWNER = ? AND ZFULLNUMBER IS NOT NULL`;
+
+function displayName(row: { fullname?: unknown; org?: unknown; nick?: unknown }): string {
+  const fullname = typeof row.fullname === "string" ? row.fullname.trim() : "";
+  if (fullname) return fullname;
+  const org = typeof row.org === "string" ? row.org.trim() : "";
+  if (org) return org;
+  const nick = typeof row.nick === "string" ? row.nick.trim() : "";
+  if (nick) return nick;
+  return "(no name)";
+}
+
+/** Scan a single AddressBook DB (read-only). Returns [] on any open/query error. */
+function searchOneDb(sqlite: SqliteModule, dbPath: string, like: string): Contact[] {
+  let db: SqliteDatabase | null = null;
+  try {
+    db = new sqlite.DatabaseSync(dbPath, { readOnly: true });
+    const records = db.prepare(RECORD_SQL).all(like, like, like, like);
+    const emailStmt = db.prepare(EMAILS_SQL);
+    const phoneStmt = db.prepare(PHONES_SQL);
+
+    const contacts: Contact[] = [];
+    for (const rec of records) {
+      const pk = rec.pk as number;
+      const emails = emailStmt
+        .all(pk)
+        .map((r) => r.v)
+        .filter((v): v is string => typeof v === "string" && v.length > 0);
+      const phones = phoneStmt
+        .all(pk)
+        .map((r) => r.v)
+        .filter((v): v is string => typeof v === "string" && v.length > 0);
+      contacts.push({ name: displayName(rec), emails, phones });
+    }
+    return contacts;
+  } catch (err) {
+    console.error(
+      `[contactsDb] skipping unreadable Contacts DB ${dbPath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return [];
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      /* ignore close errors */
+    }
+  }
+}
+
+/**
+ * Search the macOS Contacts databases for people whose full name, organization,
+ * nickname, or any email address contains `query` (case-insensitive substring).
+ *
+ * @param query    Search string (a substring match; empty query returns []).
+ * @param opts.dbPaths  Explicit DB file paths to scan (tests inject fixtures);
+ *                      when omitted, resolves the real AddressBook files.
+ * @returns De-duplicated contacts (by name + email set), each with emails/phones.
+ */
+export function searchContactsDb(query: string, opts?: { dbPaths?: string[] }): Contact[] {
+  if (!query || !query.trim()) return [];
+
+  const sqlite = loadSqlite();
+  if (!sqlite) return [];
+
+  const dbPaths = opts?.dbPaths ?? resolveContactsDbPaths();
+  const like = `%${query.toLowerCase()}%`;
+
+  const seen = new Set<string>();
+  const results: Contact[] = [];
+
+  for (const dbPath of dbPaths) {
+    for (const contact of searchOneDb(sqlite, dbPath, like)) {
+      const key = `${contact.name} ${[...contact.emails].sort().join(",")}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      results.push(contact);
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## What

Rewrites the `search-contacts` backend to read the macOS Contacts (AddressBook) SQLite databases directly via **Full Disk Access**, replacing the `tell application "Contacts"` AppleScript path.

## Why

The AppleScript path needs an **Automation / Apple-Events** TCC grant for `node` → Contacts. On headless/scheduled hosts missing that grant, it raises an unanswerable permission prompt that hangs until timeout. Reading the DB needs only **Full Disk Access** (a stable grant the Node runtime already holds) and prompts for nothing — same result, no prompt.

## How

- New `src/utils/contactsDb.ts` (`searchContactsDb`) scans the top-level `AddressBook-v22.abcddb` plus every `Sources/*/AddressBook-v22.abcddb`, read-only via the built-in **`node:sqlite`** (no new dependency). Skips any locked/absent source.
- Matches the query as a case-insensitive substring of full name, organization, nickname, or any email; returns emails + phones; de-dups across sources.
- On Node < 22.5 (`node:sqlite` absent) it logs one line and returns `[]` — it does **not** fall back to AppleScript (which would reintroduce the prompt).
- `appleMailManager.searchContacts` now delegates; signature/return type unchanged, so the MCP tool contract is unchanged. Tool description updated to note the FDA/no-Automation behavior.

## Tests

`src/utils/contactsDb.test.ts` builds fixture SQLite DBs (real `ZABCDRECORD`/`ZABCDEMAILADDRESS`/`ZABCDPHONENUMBER` columns) and asserts: name-substring, email-substring, org, and nickname matches; no-match → `[]`; empty query → `[]`; a contact with no emails still returns (`emails: []`); dedup across two DBs; merge across DBs; and that an unreadable/absent path is skipped. Skips gracefully if `node:sqlite` is unavailable. Never touches the real Contacts DB.

Real-DB sanity check (local, read-only): query "Sweet" returns `Rob Sweet` with `rob@superiortech.io` across 6 source DBs. Version bumped to **2.8.7**.