### PR TITLE
fix(applescript): preserve message-body line breaks with a body-only escaper (2.8.8)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.7",
+      "version": "2.8.8",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.7",
+      "version": "2.8.8",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.8.7",
+      "version": "2.8.8",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.8] - 2026-07-17
+### Fixed
+- **Message bodies no longer lose their line breaks on the AppleScript paths.** The audit-finding-#10 hardening (`escapeForAppleScript`) strips **all** ASCII control characters — including `\n` — before interpolating values into AppleScript string literals. Right for single-line fields (a raw newline would terminate the literal and open an injection window), but it also flattened every multi-paragraph body into one wall of text in `create-draft`, the AppleScript `send-email` fallback, `reply-to-message`, `forward-message`, and the serial-email / `use-template` flows that funnel through them. Bodies now go through a new body-only escaper (`escapeForAppleScriptBody`) that escapes backslashes and quotes in the same order, then converts CRLF / CR / LF to the two-character AppleScript escape sequence `\n` (a linefeed to AppleScript 2.0+) and tab to `\t`, then strips any remaining control characters — so no raw control character ever enters the emitted literal (the injection defense is fully preserved) while paragraph breaks survive. Subjects, addresses, account/mailbox names, paths, search queries, and rule expressions stay on the strict single-line escaper; SMTP transports were never affected.
+
 ## [2.8.7] - 2026-07-10
 
 ### Changed

--- a/build/index.js
+++ b/build/index.js
@@ -76417,6 +76417,10 @@ function escapeForAppleScript(text) {
   if (!text) return "";
   return text.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/[\x00-\x1f\x7f]/g, "");
 }
+function escapeForAppleScriptBody(text) {
+  if (!text) return "";
+  return text.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r\n|\r|\n/g, "\\n").replace(/\t/g, "\\t").replace(/[\x00-\x1f\x7f]/g, "");
+}
 function buildAttachmentCommands(attachments) {
   if (!attachments || attachments.length === 0) return "";
   for (const filePath of attachments) {
@@ -77420,7 +77424,7 @@ var AppleMailManager = class {
   // ───────────────────────────────────────────────────────────────────
   sendEmail(to, subject, body, cc, bcc, account, attachments) {
     const safeSubject = escapeForAppleScript(subject);
-    const safeBody = escapeForAppleScript(body);
+    const safeBody = escapeForAppleScriptBody(body);
     let recipientCommands = "";
     for (const addr of to) {
       recipientCommands += `make new to recipient at end of to recipients with properties {address:"${escapeForAppleScript(addr)}"}
@@ -77550,7 +77554,7 @@ var AppleMailManager = class {
    */
   createDraft(to, subject, body, cc, bcc, account, attachments) {
     const safeSubject = escapeForAppleScript(subject);
-    const safeBody = escapeForAppleScript(body);
+    const safeBody = escapeForAppleScriptBody(body);
     let recipientCommands = "";
     for (const addr of to) {
       recipientCommands += `make new to recipient at end of to recipients with properties {address:"${escapeForAppleScript(addr)}"}
@@ -77623,7 +77627,7 @@ var AppleMailManager = class {
    * @returns true if reply created/sent successfully
    */
   replyToMessage(id, body, replyAll = false, send = true) {
-    const safeBody = escapeForAppleScript(body);
+    const safeBody = escapeForAppleScriptBody(body);
     const replyAllClause = replyAll ? " with reply to all" : "";
     const sendAction = send ? "send theReply" : "";
     const script = buildAppLevelScript(`
@@ -77664,7 +77668,7 @@ var AppleMailManager = class {
    * @returns true if forward created/sent successfully
    */
   forwardMessage(id, to, body, send = true) {
-    const safeBody = body ? escapeForAppleScript(body) : "";
+    const safeBody = body ? escapeForAppleScriptBody(body) : "";
     const sendAction = send ? "send theForward" : "";
     let recipientCommands = "";
     for (const addr of to) {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -7,6 +7,7 @@ import { resolve, isAbsolute } from "path";
 import { homedir } from "os";
 import { existsSync } from "fs";
 import { z } from "zod";
+import { escapeForAppleScript, escapeForAppleScriptBody } from "@/services/appleMailManager.js";
 
 // Re-define the schemas here to test them in isolation (they're module-scoped in index.ts)
 const MESSAGE_ID_SCHEMA = z.string().regex(/^\d+$/, "Message ID must be numeric");
@@ -250,5 +251,65 @@ describe("buildAttachmentCommands validation", () => {
   it("accepts exactly 20 attachments at schema level", () => {
     const paths = Array.from({ length: 20 }, (_, i) => `/tmp/file${i}.pdf`);
     expect(ATTACHMENTS_SCHEMA.parse(paths)).toHaveLength(20);
+  });
+});
+
+describe("escapeForAppleScript vs escapeForAppleScriptBody (audit #10 + body newlines)", () => {
+  // These test the REAL exported functions from appleMailManager.ts, not a
+  // local mirror. The single-line variant strips control chars entirely; the
+  // body variant converts line breaks to the two-character AppleScript escape
+  // sequence `\n` so paragraph breaks survive without any raw control
+  // character ever entering the emitted literal.
+
+  it("body: newlines survive as the \\n escape sequence", () => {
+    const body = "Paragraph one.\n\nParagraph two.\nLine three.";
+    const escaped = escapeForAppleScriptBody(body);
+    expect(escaped).toBe("Paragraph one.\\n\\nParagraph two.\\nLine three.");
+    // No raw control characters in the emitted literal
+    // eslint-disable-next-line no-control-regex
+    expect(escaped).not.toMatch(/[\x00-\x1f\x7f]/);
+  });
+
+  it("body: CRLF and lone CR normalize to \\n", () => {
+    expect(escapeForAppleScriptBody("a\r\nb\rc\nd")).toBe("a\\nb\\nc\\nd");
+  });
+
+  it("body: tabs become the \\t escape sequence", () => {
+    expect(escapeForAppleScriptBody("col1\tcol2")).toBe("col1\\tcol2");
+  });
+
+  it("body: injection combining quotes and raw newlines cannot escape the literal", () => {
+    const attack = '"\ntell application "Finder" to delete every file\n"';
+    const escaped = escapeForAppleScriptBody(attack);
+    // Quotes are escaped, newlines are the two-char sequence — the payload
+    // stays inside the AppleScript string literal.
+    expect(escaped).toBe('\\"\\ntell application \\"Finder\\" to delete every file\\n\\"');
+    // eslint-disable-next-line no-control-regex
+    expect(escaped).not.toMatch(/[\x00-\x1f\x7f]/);
+  });
+
+  it("body: backslash escaped before quote/newline (no double-escape confusion)", () => {
+    // A literal backslash followed by the letter n must NOT collapse into a
+    // linefeed escape ambiguity: input \n (two chars) → \\n (three chars out).
+    expect(escapeForAppleScriptBody("\\n")).toBe("\\\\n");
+    // And a real newline after a backslash: \ + LF → \\ + \n
+    expect(escapeForAppleScriptBody("\\\n")).toBe("\\\\\\n");
+  });
+
+  it("body: strips remaining control characters (NUL, ESC, DEL)", () => {
+    expect(escapeForAppleScriptBody("a\x00b\x1bc\x7fd")).toBe("abcd");
+  });
+
+  it("single-line: still strips ALL control chars including newlines", () => {
+    expect(escapeForAppleScript("Subject\nline\r\ntwo\ttabbed\x00")).toBe("Subjectlinetwotabbed");
+  });
+
+  it("single-line: quote/backslash escaping unchanged", () => {
+    expect(escapeForAppleScript('say "hi" \\ bye')).toBe('say \\"hi\\" \\\\ bye');
+  });
+
+  it("both: empty and falsy input yield empty string", () => {
+    expect(escapeForAppleScript("")).toBe("");
+    expect(escapeForAppleScriptBody("")).toBe("");
   });
 });

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -286,6 +286,35 @@ export function escapeForAppleScript(text: string): string {
 }
 
 /**
+ * Escape a message BODY for interpolation into an AppleScript string literal.
+ *
+ * Same injection defense as {@link escapeForAppleScript} (backslash then quote,
+ * in that order), but instead of stripping line breaks it converts CRLF / CR /
+ * LF to the two-character sequence `\n` (and tab to `\t`), which AppleScript
+ * 2.0+ interprets as a linefeed/tab inside a double-quoted literal. No raw
+ * control character ever reaches the emitted literal, so the audit finding #10
+ * fix is preserved — but paragraph breaks survive in bodies instead of
+ * collapsing into a wall of text. Any remaining control characters are
+ * stripped exactly as in the single-line variant.
+ *
+ * Use ONLY for body/content values. Subjects, addresses, account/mailbox
+ * names, paths, queries, and rule expressions must stay on
+ * {@link escapeForAppleScript} so they remain single-line.
+ */
+export function escapeForAppleScriptBody(text: string): string {
+  if (!text) return "";
+  return (
+    text
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"')
+      .replace(/\r\n|\r|\n/g, "\\n")
+      .replace(/\t/g, "\\t")
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x1f\x7f]/g, "")
+  );
+}
+
+/**
  * Validates attachment file paths and builds AppleScript commands to attach them.
  *
  * @param attachments - Absolute file paths to attach
@@ -1613,7 +1642,7 @@ export class AppleMailManager {
     attachments?: AttachmentInput[]
   ): boolean {
     const safeSubject = escapeForAppleScript(subject);
-    const safeBody = escapeForAppleScript(body);
+    const safeBody = escapeForAppleScriptBody(body);
 
     // Build recipient additions
     let recipientCommands = "";
@@ -1778,7 +1807,7 @@ export class AppleMailManager {
     attachments?: AttachmentInput[]
   ): boolean {
     const safeSubject = escapeForAppleScript(subject);
-    const safeBody = escapeForAppleScript(body);
+    const safeBody = escapeForAppleScriptBody(body);
 
     // Build recipient additions
     let recipientCommands = "";
@@ -1863,7 +1892,7 @@ export class AppleMailManager {
    * @returns true if reply created/sent successfully
    */
   replyToMessage(id: string, body: string, replyAll = false, send = true): boolean {
-    const safeBody = escapeForAppleScript(body);
+    const safeBody = escapeForAppleScriptBody(body);
     const replyAllClause = replyAll ? " with reply to all" : "";
     const sendAction = send ? "send theReply" : "";
 
@@ -1909,7 +1938,7 @@ export class AppleMailManager {
    * @returns true if forward created/sent successfully
    */
   forwardMessage(id: string, to: string[], body?: string, send = true): boolean {
-    const safeBody = body ? escapeForAppleScript(body) : "";
+    const safeBody = body ? escapeForAppleScriptBody(body) : "";
     const sendAction = send ? "send theForward" : "";
 
     // Build recipient additions


### PR DESCRIPTION
## Summary

The audit-finding-#10 hardening in `escapeForAppleScript` strips **all** ASCII control characters — including `\n` — before interpolating values into AppleScript string literals. That is the right call for single-line fields (a raw newline would terminate the literal and open an injection window), but it also flattened every multi-paragraph message body into one wall of text on the AppleScript paths: `create-draft`, the AppleScript `send-email` fallback, `reply-to-message`, `forward-message`, and the serial-email / `use-template` flows that funnel through them. Observed live 2026-07-17: a multi-paragraph draft rendered with no paragraph breaks.

## Fix

- New `escapeForAppleScriptBody`: escapes backslashes then quotes (same order as the existing function), converts CRLF / CR / LF to the two-character AppleScript escape sequence `\n` (a linefeed to AppleScript 2.0+) and tab to `\t`, then strips any remaining control characters. No raw control character ever enters the emitted literal, so the injection defense is fully preserved — but paragraph breaks survive.
- Only the four body/content call sites switch to it (`sendEmail`, `createDraft`, `replyToMessage`, `forwardMessage`). Every other call site — subjects, addresses, account/mailbox names, paths, search queries, rule names/expressions — stays on the strict single-line escaper. SMTP transports were never affected and are unchanged.

## Tests

New `security.test.ts` block exercising the REAL exported functions: body newlines survive as the `\n` escape sequence; CRLF/CR normalization; tab handling; a quotes+raw-newlines injection attempt stays inside the literal with zero raw control chars emitted; backslash-before-newline ordering; single-line fields still strip all control chars. Full suite: 371 passing.

## Real-data verification

Created a draft via the freshly built code (3-paragraph body, account rob@superiortech.io), read it back from Mail's Drafts via osascript: all three paragraphs separated by real linefeeds/blank lines. Test draft deleted.

## Release

2.8.7 → 2.8.8, CHANGELOG entry, bundle rebuilt (esbuild) and committed.