### PR TITLE
fix: enforce mail operation boundaries

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.9",
+      "version": "2.8.10",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.9",
+      "version": "2.8.10",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.9",
+  "version": "2.8.10",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.8.9",
+  "version": "2.8.10",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.8.9",
+      "version": "2.8.10",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.9",
+  "version": "2.8.10",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Attachment reads and saves now enforce filesystem and size boundaries.** Saved attachments are resolved beneath the requested destination directory, reject traversal and existing symlink targets, and route temporary Base64 extraction through a directory rather than a caller-influenced file path. Inline attachments are capped at 25 MiB decoded, partial temporary materialization is cleaned up on failure, and standards-wrapped Base64 is measured without counting decoder-ignored whitespace.
+- **SMTP From overrides are restricted to configured sender identities.** `send-email` email-form `account` values and `apple-mail-send --from` must match the SMTP login user, `APPLE_MAIL_MCP_SMTP_FROM`, or an address in `APPLE_MAIL_MCP_SMTP_ALLOWED_FROM`; rejected identities fail before a transport connection is created.
+
+### Fixed
+
+- **IMAP composite ids cannot be silently routed through a different account.** Single-message, thread, and batch operations now reject a genuinely mismatched account selector while treating a configured account label and its login email as equivalent aliases.
+- **Message-ID lookup uses the shared AppleScript string escaper.** RFC Message-ID values are escaped consistently before interpolation into Mail.app queries.
+
 ## [2.8.9] - 2026-07-18
 ### Fixed
 - **`get-message` now returns the stable RFC Message-ID on the AppleScript path, not just over IMAP.** A prior change surfaced `rfcMessageId` only in the IMAP branch; the Mail.app/AppleScript path still returned `null`, leaving callers with no stable `<…@…>` identifier for dedup/threading. It now reads Mail.app's native `message id` property (normalized, angle brackets stripped) so both backends return the Message-ID. Thanks to @Goaleve1 (#93).

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Send a new email immediately.
 | `body` | string | Yes | Email body (plain text) |
 | `cc` | string[] | No | CC recipients |
 | `bcc` | string[] | No | BCC recipients |
-| `account` | string | No | Send from specific account (with `transport: "smtp"`, overrides the From address) |
+| `account` | string | No | Mail.app account label, or an email-form SMTP From override. An SMTP override must match `APPLE_MAIL_MCP_SMTP_USER`, `APPLE_MAIL_MCP_SMTP_FROM`, or an address in `APPLE_MAIL_MCP_SMTP_ALLOWED_FROM` |
 | `attachments` | (string \| {filename, contentBase64})[] | No | Up to 20 attachments: absolute file paths (e.g., `"/Users/me/report.pdf"`) and/or inline `{filename, contentBase64}` objects up to 25 MiB decoded each |
 | `transport` | `"applescript"` \| `"smtp"` | No | Send transport. If omitted, **SMTP is used automatically when configured** (otherwise AppleScript). Pass `"smtp"` to require clean MIME, or `"applescript"` to force the Mail.app path — see [SMTP transport](#smtp-transport) |
 
@@ -326,7 +326,11 @@ Two differences to know when SMTP is auto-preferred:
   is used as the From address only when it is an email address; a Mail.app
   account *label* (e.g. `"Work"`) can't select an account over SMTP, so a call
   that passes one is left on the AppleScript path automatically. To force
-  account selection, pass `transport: "applescript"` explicitly.
+  account selection, pass `transport: "applescript"` explicitly. For sender
+  safety, an email-form override must match the SMTP login user, the configured
+  `APPLE_MAIL_MCP_SMTP_FROM`, or an address listed in the comma-separated
+  `APPLE_MAIL_MCP_SMTP_ALLOWED_FROM`; any other From address is rejected before
+  connecting.
 
 Both plain-text and HTML bodies are supported — over SMTP an HTML body (CLI
 `--html-body-file`) is sent as `multipart/alternative` with the plain-text

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Send a new email immediately.
 | `cc` | string[] | No | CC recipients |
 | `bcc` | string[] | No | BCC recipients |
 | `account` | string | No | Send from specific account (with `transport: "smtp"`, overrides the From address) |
-| `attachments` | (string \| {filename, contentBase64})[] | No | Up to 20 attachments: absolute file paths (e.g., `"/Users/me/report.pdf"`) and/or inline `{filename, contentBase64}` objects for content not on disk |
+| `attachments` | (string \| {filename, contentBase64})[] | No | Up to 20 attachments: absolute file paths (e.g., `"/Users/me/report.pdf"`) and/or inline `{filename, contentBase64}` objects up to 25 MiB decoded each |
 | `transport` | `"applescript"` \| `"smtp"` | No | Send transport. If omitted, **SMTP is used automatically when configured** (otherwise AppleScript). Pass `"smtp"` to require clean MIME, or `"applescript"` to force the Mail.app path — see [SMTP transport](#smtp-transport) |
 
 **Example:**
@@ -342,6 +342,7 @@ read from the macOS **Keychain** by default, so no secret goes in config:
 | `APPLE_MAIL_MCP_SMTP_PORT` | No | `465` if secure, else `587` | SMTP port |
 | `APPLE_MAIL_MCP_SMTP_SECURE` | No | `false` | `true` for implicit TLS (port 465); otherwise STARTTLS |
 | `APPLE_MAIL_MCP_SMTP_FROM` | No | = user | From address |
+| `APPLE_MAIL_MCP_SMTP_ALLOWED_FROM` | No | — | Comma-separated sender aliases permitted as per-message From overrides |
 | `APPLE_MAIL_MCP_SMTP_PASSWORD` | No | — | Password (if set, used instead of the Keychain) |
 | `APPLE_MAIL_MCP_SMTP_KEYCHAIN_SERVICE` | No | = host | Keychain item service/server name |
 | `APPLE_MAIL_MCP_SMTP_KEYCHAIN_ACCOUNT` | No | = user | Keychain item account |
@@ -625,7 +626,7 @@ Save an email to Drafts without sending.
 | `cc` | string[] | No | CC recipients |
 | `bcc` | string[] | No | BCC recipients |
 | `account` | string | No | Account for draft |
-| `attachments` | (string \| {filename, contentBase64})[] | No | Up to 20 attachments: absolute file paths and/or inline `{filename, contentBase64}` objects |
+| `attachments` | (string \| {filename, contentBase64})[] | No | Up to 20 attachments: absolute file paths and/or inline `{filename, contentBase64}` objects up to 25 MiB decoded each |
 
 **Returns:** Confirmation that draft was created.
 

--- a/build/cli.js
+++ b/build/cli.js
@@ -11869,6 +11869,20 @@ import { execFileSync } from "child_process";
 import { isAbsolute } from "path";
 import { existsSync } from "fs";
 
+// src/utils/attachmentLimits.ts
+var MAX_INLINE_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+var MAX_INLINE_ATTACHMENT_BASE64_CHARS = Math.ceil(MAX_INLINE_ATTACHMENT_BYTES / 3) * 4;
+function decodeInlineAttachment(contentBase64) {
+  if (contentBase64.length > MAX_INLINE_ATTACHMENT_BASE64_CHARS) {
+    throw new Error("Inline attachment exceeds the 25 MiB decoded size limit.");
+  }
+  const content = Buffer.from(contentBase64, "base64");
+  if (content.length > MAX_INLINE_ATTACHMENT_BYTES) {
+    throw new Error("Inline attachment exceeds the 25 MiB decoded size limit.");
+  }
+  return content;
+}
+
 // src/utils/docsUrls.ts
 var SETUP_GUIDE_URL = "https://github.com/sweetrb/apple-mail-mcp/blob/main/docs/IMAP-SETUP.md";
 var SETUP_HINT = `Setup guide: ${SETUP_GUIDE_URL} \u2014 run the "doctor" tool to check your setup.`;
@@ -11880,6 +11894,7 @@ var SMTP_ENV = {
   secure: "APPLE_MAIL_MCP_SMTP_SECURE",
   user: "APPLE_MAIL_MCP_SMTP_USER",
   from: "APPLE_MAIL_MCP_SMTP_FROM",
+  allowedFrom: "APPLE_MAIL_MCP_SMTP_ALLOWED_FROM",
   password: "APPLE_MAIL_MCP_SMTP_PASSWORD",
   keychainService: "APPLE_MAIL_MCP_SMTP_KEYCHAIN_SERVICE",
   keychainAccount: "APPLE_MAIL_MCP_SMTP_KEYCHAIN_ACCOUNT"
@@ -11915,6 +11930,7 @@ function resolveSmtpConfig(env = process.env) {
     throw new Error(`Invalid ${SMTP_ENV.port}: "${env[SMTP_ENV.port]}" is not a valid port.`);
   }
   const from = env[SMTP_ENV.from]?.trim() || user;
+  const allowedFrom = (env[SMTP_ENV.allowedFrom] ?? "").split(",").map((value) => value.trim()).filter(Boolean);
   let pass = env[SMTP_ENV.password];
   if (!pass) {
     const service = env[SMTP_ENV.keychainService]?.trim() || host;
@@ -11926,7 +11942,7 @@ function resolveSmtpConfig(env = process.env) {
       `No SMTP password found. Set ${SMTP_ENV.password}, or store an internet password in the Keychain for service "${env[SMTP_ENV.keychainService]?.trim() || host}" / account "${env[SMTP_ENV.keychainAccount]?.trim() || user}". ` + SETUP_HINT
     );
   }
-  return { host, port, secure, user, pass, from };
+  return { host, port, secure, user, pass, from, allowedFrom };
 }
 function buildAttachments(attachments) {
   if (!attachments || attachments.length === 0) return void 0;
@@ -11939,7 +11955,7 @@ function buildAttachments(attachments) {
     if (!a.filename || !a.contentBase64) {
       throw new Error("Inline attachment requires both filename and contentBase64.");
     }
-    return { filename: a.filename, content: Buffer.from(a.contentBase64, "base64") };
+    return { filename: a.filename, content: decodeInlineAttachment(a.contentBase64) };
   });
 }
 async function sendViaSmtp(opts, config, createTransport = import_nodemailer.default.createTransport) {
@@ -11948,6 +11964,16 @@ async function sendViaSmtp(opts, config, createTransport = import_nodemailer.def
     cfg = config ?? resolveSmtpConfig();
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+  const requestedFrom = opts.from?.trim();
+  const allowedFrom = new Set(
+    [cfg.user, cfg.from, ...cfg.allowedFrom ?? []].map((value) => value.trim().toLowerCase())
+  );
+  if (requestedFrom && !allowedFrom.has(requestedFrom.toLowerCase())) {
+    return {
+      success: false,
+      error: `SMTP From "${requestedFrom}" is not a configured sender identity.`
+    };
   }
   let attachments;
   try {
@@ -11964,7 +11990,7 @@ async function sendViaSmtp(opts, config, createTransport = import_nodemailer.def
   const html = opts.htmlBody?.trim() ? opts.htmlBody : void 0;
   try {
     const info = await transporter.sendMail({
-      from: opts.from?.trim() || cfg.from,
+      from: requestedFrom || cfg.from,
       to: opts.to,
       cc: opts.cc,
       bcc: opts.bcc,

--- a/build/cli.js
+++ b/build/cli.js
@@ -11872,8 +11872,17 @@ import { existsSync } from "fs";
 // src/utils/attachmentLimits.ts
 var MAX_INLINE_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 var MAX_INLINE_ATTACHMENT_BASE64_CHARS = Math.ceil(MAX_INLINE_ATTACHMENT_BYTES / 3) * 4;
+var MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS = MAX_INLINE_ATTACHMENT_BASE64_CHARS * 2;
+function isInlineAttachmentBase64WithinLimit(contentBase64) {
+  if (contentBase64.length > MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS) return false;
+  let encodedChars = 0;
+  for (const char of contentBase64) {
+    if (!/\s/u.test(char) && ++encodedChars > MAX_INLINE_ATTACHMENT_BASE64_CHARS) return false;
+  }
+  return true;
+}
 function decodeInlineAttachment(contentBase64) {
-  if (contentBase64.length > MAX_INLINE_ATTACHMENT_BASE64_CHARS) {
+  if (!isInlineAttachmentBase64WithinLimit(contentBase64)) {
     throw new Error("Inline attachment exceeds the 25 MiB decoded size limit.");
   }
   const content = Buffer.from(contentBase64, "base64");
@@ -12021,7 +12030,8 @@ var EX_CONFIG = 78;
 var USAGE = `apple-mail-send \u2014 send a clean email via SMTP (no Mail.app blockquote wrapping).
 
 Required:
-  --from <addr>         Sender address (must be allowed by the SMTP server)
+  --from <addr>         Sender address (SMTP user/configured From, or an alias in
+                        ${SMTP_ENV.allowedFrom})
   --to <addr>           Recipient (repeatable)
   --subject <text>      Subject line
   --body-file <path>    UTF-8 file with the plain-text body

--- a/build/index.js
+++ b/build/index.js
@@ -76212,8 +76212,17 @@ import { tmpdir } from "os";
 // src/utils/attachmentLimits.ts
 var MAX_INLINE_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 var MAX_INLINE_ATTACHMENT_BASE64_CHARS = Math.ceil(MAX_INLINE_ATTACHMENT_BYTES / 3) * 4;
+var MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS = MAX_INLINE_ATTACHMENT_BASE64_CHARS * 2;
+function isInlineAttachmentBase64WithinLimit(contentBase64) {
+  if (contentBase64.length > MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS) return false;
+  let encodedChars = 0;
+  for (const char of contentBase64) {
+    if (!/\s/u.test(char) && ++encodedChars > MAX_INLINE_ATTACHMENT_BASE64_CHARS) return false;
+  }
+  return true;
+}
 function decodeInlineAttachment(contentBase64) {
-  if (contentBase64.length > MAX_INLINE_ATTACHMENT_BASE64_CHARS) {
+  if (!isInlineAttachmentBase64WithinLimit(contentBase64)) {
     throw new Error("Inline attachment exceeds the 25 MiB decoded size limit.");
   }
   const content = Buffer.from(contentBase64, "base64");
@@ -79506,8 +79515,20 @@ function decodeImapId(id) {
     return null;
   }
 }
+function sameImapAccount(left, right, deps) {
+  if (left === right) return true;
+  if (deps.config) {
+    const aliases = /* @__PURE__ */ new Set([deps.config.accountLabel, deps.config.user]);
+    if (aliases.has(left) && aliases.has(right)) return true;
+  }
+  const specs = listImapAccountSpecs();
+  const matches = (selector, spec) => spec.accountLabel === selector || spec.user === selector;
+  const leftSpec = specs.find((spec) => matches(left, spec));
+  const rightSpec = specs.find((spec) => matches(right, spec));
+  return leftSpec !== void 0 && leftSpec === rightSpec;
+}
 function depsForAccount(account, deps) {
-  if (deps.account && deps.account !== account) {
+  if (deps.account && !sameImapAccount(account, deps.account, deps)) {
     throw new Error(`IMAP message id belongs to account "${account}", not "${deps.account}".`);
   }
   return { ...deps, account };
@@ -80905,7 +80926,10 @@ var ATTACHMENTS_SCHEMA = external_exports.array(
     external_exports.object({
       filename: external_exports.string().min(1).max(255).describe("Filename to give the attachment"),
       contentBase64: external_exports.string().min(1).max(
-        MAX_INLINE_ATTACHMENT_BASE64_CHARS,
+        MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS,
+        "Inline attachment exceeds the 25 MiB decoded size limit"
+      ).refine(
+        isInlineAttachmentBase64WithinLimit,
         "Inline attachment exceeds the 25 MiB decoded size limit"
       ).describe("Base64-encoded file content (maximum 25 MiB decoded)")
     })

--- a/build/index.js
+++ b/build/index.js
@@ -75678,7 +75678,15 @@ var StdioServerTransport = class {
 
 // src/services/appleMailManager.ts
 import { spawnSync as spawnSync2 } from "child_process";
-import { existsSync as existsSync3, writeFileSync as writeFileSync3, readFileSync as readFileSync2, mkdtempSync as mkdtempSync2, rmSync as rmSync2 } from "fs";
+import {
+  existsSync as existsSync3,
+  writeFileSync as writeFileSync3,
+  readFileSync as readFileSync2,
+  mkdtempSync as mkdtempSync2,
+  rmSync as rmSync2,
+  realpathSync,
+  lstatSync
+} from "fs";
 import { isAbsolute, resolve, sep, join as join4 } from "path";
 import { homedir as homedir3 } from "os";
 
@@ -76200,22 +76208,44 @@ var TemplateStore = class {
 import { writeFileSync as writeFileSync2, rmSync, mkdtempSync } from "fs";
 import { join as join2 } from "path";
 import { tmpdir } from "os";
+
+// src/utils/attachmentLimits.ts
+var MAX_INLINE_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+var MAX_INLINE_ATTACHMENT_BASE64_CHARS = Math.ceil(MAX_INLINE_ATTACHMENT_BYTES / 3) * 4;
+function decodeInlineAttachment(contentBase64) {
+  if (contentBase64.length > MAX_INLINE_ATTACHMENT_BASE64_CHARS) {
+    throw new Error("Inline attachment exceeds the 25 MiB decoded size limit.");
+  }
+  const content = Buffer.from(contentBase64, "base64");
+  if (content.length > MAX_INLINE_ATTACHMENT_BYTES) {
+    throw new Error("Inline attachment exceeds the 25 MiB decoded size limit.");
+  }
+  return content;
+}
+
+// src/utils/attachmentMaterialize.ts
 function materializeAttachments(attachments) {
   if (!attachments || attachments.length === 0) {
     return { paths: [], cleanup: () => void 0 };
   }
   let dir = null;
-  const paths = attachments.map((a) => {
-    if (typeof a === "string") return a;
-    if (!a.filename || !a.contentBase64) {
-      throw new Error("Inline attachment requires both filename and contentBase64.");
-    }
-    if (!dir) dir = mkdtempSync(join2(tmpdir(), "amcp-att-"));
-    const safeName = a.filename.replace(/[/\\]/g, "_");
-    const p = join2(dir, safeName);
-    writeFileSync2(p, Buffer.from(a.contentBase64, "base64"));
-    return p;
-  });
+  let paths;
+  try {
+    paths = attachments.map((a) => {
+      if (typeof a === "string") return a;
+      if (!a.filename || !a.contentBase64) {
+        throw new Error("Inline attachment requires both filename and contentBase64.");
+      }
+      if (!dir) dir = mkdtempSync(join2(tmpdir(), "amcp-att-"));
+      const safeName = a.filename.replace(/[/\\]/g, "_");
+      const p = join2(dir, safeName);
+      writeFileSync2(p, decodeInlineAttachment(a.contentBase64));
+      return p;
+    });
+  } catch (error2) {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    throw error2;
+  }
   return {
     paths,
     cleanup: () => {
@@ -76397,6 +76427,25 @@ function isPathWithinAllowedRoots(resolvedPath) {
     const base = root.endsWith(sep) ? root.slice(0, -1) : root;
     return resolvedPath === base || resolvedPath.startsWith(base + sep);
   });
+}
+function resolveAttachmentSaveTarget(savePath, attachmentName) {
+  let saveDirectory;
+  try {
+    saveDirectory = realpathSync(resolve(savePath));
+  } catch {
+    throw new Error(`Save directory "${savePath}" does not exist`);
+  }
+  if (!isPathWithinAllowedRoots(saveDirectory)) {
+    throw new Error(`Save path "${savePath}" is outside allowed directories`);
+  }
+  const savedPath = resolve(saveDirectory, attachmentName);
+  if (!isPathWithinAllowedRoots(savedPath)) {
+    throw new Error(`Output path "${savedPath}" is outside allowed directories`);
+  }
+  if (existsSync3(savedPath) && lstatSync(savedPath).isSymbolicLink()) {
+    throw new Error(`Refusing to overwrite symbolic link "${savedPath}"`);
+  }
+  return { saveDirectory, savedPath };
 }
 var UNSUPPORTED_APPLESCRIPT_OP = /AppleEvent handler failed|-10000/i;
 function describeMailboxOpError(op, raw) {
@@ -77917,7 +77966,7 @@ var AppleMailManager = class {
   findNumericIdByMessageId(messageId, accountName) {
     const mid = messageId.trim().replace(/^<+/, "").replace(/>+$/, "").trim();
     if (!mid) return null;
-    const q = (s) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    const q = (s) => escapeForAppleScript(s);
     const midLit = `"${q(mid)}"`;
     const bracketedLit = `"${q(`<${mid}>`)}"`;
     const matchClause = (mbVar) => `(messages of ${mbVar} whose message id is ${midLit} or message id is ${bracketedLit})`;
@@ -78304,13 +78353,15 @@ var AppleMailManager = class {
       console.error(`Invalid attachment name: "${attachmentName}"`);
       return false;
     }
-    const resolvedPath = resolve(savePath);
-    if (!isPathWithinAllowedRoots(resolvedPath)) {
-      console.error(`Save path "${savePath}" is outside allowed directories`);
+    let target;
+    try {
+      target = resolveAttachmentSaveTarget(savePath, attachmentName);
+    } catch (error2) {
+      console.error(error2 instanceof Error ? error2.message : String(error2));
       return false;
     }
     const safeName = escapeForAppleScript(attachmentName);
-    const safePath = escapeForAppleScript(resolvedPath);
+    const safePath = escapeForAppleScript(target.saveDirectory);
     const numericId = Number(id);
     const script = buildAppLevelScript(`
       try
@@ -78352,12 +78403,7 @@ var AppleMailManager = class {
       return false;
     }
     try {
-      const outPath = resolve(resolvedPath, attachmentName);
-      if (!isPathWithinAllowedRoots(outPath)) {
-        console.error(`Output path "${outPath}" is outside allowed directories`);
-        return false;
-      }
-      writeFileSync3(outPath, attachment.data);
+      writeFileSync3(target.savedPath, attachment.data);
       return true;
     } catch (err) {
       console.error(`Failed to write attachment to disk: ${err}`);
@@ -78374,7 +78420,7 @@ var AppleMailManager = class {
     try {
       dir = mkdtempSync2("/private/tmp/amcp-fetch-");
       const dest = join4(dir, attachmentName.replace(/[/\\]/g, "_"));
-      const ok = this.saveAttachment(id, attachmentName, dest);
+      const ok = this.saveAttachment(id, attachmentName, dir);
       if (!ok) {
         return {
           success: false,
@@ -79125,7 +79171,7 @@ ${actionStmts.join("\n")}
 
 // src/index.ts
 import { writeFileSync as writeFileSync4 } from "fs";
-import { resolve as resolvePath, join as joinPath } from "path";
+import { join as joinPath } from "path";
 
 // src/services/smtpMailer.ts
 var import_nodemailer = __toESM(require_nodemailer(), 1);
@@ -79144,6 +79190,7 @@ var SMTP_ENV = {
   secure: "APPLE_MAIL_MCP_SMTP_SECURE",
   user: "APPLE_MAIL_MCP_SMTP_USER",
   from: "APPLE_MAIL_MCP_SMTP_FROM",
+  allowedFrom: "APPLE_MAIL_MCP_SMTP_ALLOWED_FROM",
   password: "APPLE_MAIL_MCP_SMTP_PASSWORD",
   keychainService: "APPLE_MAIL_MCP_SMTP_KEYCHAIN_SERVICE",
   keychainAccount: "APPLE_MAIL_MCP_SMTP_KEYCHAIN_ACCOUNT"
@@ -79189,6 +79236,7 @@ function resolveSmtpConfig(env = process.env) {
     throw new Error(`Invalid ${SMTP_ENV.port}: "${env[SMTP_ENV.port]}" is not a valid port.`);
   }
   const from = env[SMTP_ENV.from]?.trim() || user;
+  const allowedFrom = (env[SMTP_ENV.allowedFrom] ?? "").split(",").map((value) => value.trim()).filter(Boolean);
   let pass = env[SMTP_ENV.password];
   if (!pass) {
     const service = env[SMTP_ENV.keychainService]?.trim() || host;
@@ -79200,7 +79248,7 @@ function resolveSmtpConfig(env = process.env) {
       `No SMTP password found. Set ${SMTP_ENV.password}, or store an internet password in the Keychain for service "${env[SMTP_ENV.keychainService]?.trim() || host}" / account "${env[SMTP_ENV.keychainAccount]?.trim() || user}". ` + SETUP_HINT
     );
   }
-  return { host, port, secure, user, pass, from };
+  return { host, port, secure, user, pass, from, allowedFrom };
 }
 function buildAttachments(attachments) {
   if (!attachments || attachments.length === 0) return void 0;
@@ -79213,7 +79261,7 @@ function buildAttachments(attachments) {
     if (!a.filename || !a.contentBase64) {
       throw new Error("Inline attachment requires both filename and contentBase64.");
     }
-    return { filename: a.filename, content: Buffer.from(a.contentBase64, "base64") };
+    return { filename: a.filename, content: decodeInlineAttachment(a.contentBase64) };
   });
 }
 async function sendViaSmtp(opts, config2, createTransport = import_nodemailer.default.createTransport) {
@@ -79222,6 +79270,16 @@ async function sendViaSmtp(opts, config2, createTransport = import_nodemailer.de
     cfg = config2 ?? resolveSmtpConfig();
   } catch (error2) {
     return { success: false, error: error2 instanceof Error ? error2.message : String(error2) };
+  }
+  const requestedFrom = opts.from?.trim();
+  const allowedFrom = new Set(
+    [cfg.user, cfg.from, ...cfg.allowedFrom ?? []].map((value) => value.trim().toLowerCase())
+  );
+  if (requestedFrom && !allowedFrom.has(requestedFrom.toLowerCase())) {
+    return {
+      success: false,
+      error: `SMTP From "${requestedFrom}" is not a configured sender identity.`
+    };
   }
   let attachments;
   try {
@@ -79238,7 +79296,7 @@ async function sendViaSmtp(opts, config2, createTransport = import_nodemailer.de
   const html = opts.htmlBody?.trim() ? opts.htmlBody : void 0;
   try {
     const info = await transporter.sendMail({
-      from: opts.from?.trim() || cfg.from,
+      from: requestedFrom || cfg.from,
       to: opts.to,
       cc: opts.cc,
       bcc: opts.bcc,
@@ -79447,6 +79505,15 @@ function decodeImapId(id) {
   } catch {
     return null;
   }
+}
+function depsForAccount(account, deps) {
+  if (deps.account && deps.account !== account) {
+    throw new Error(`IMAP message id belongs to account "${account}", not "${deps.account}".`);
+  }
+  return { ...deps, account };
+}
+function depsForMessageRef(ref, deps) {
+  return depsForAccount(ref.account, deps);
 }
 function str(v) {
   return typeof v === "string" && v.trim() ? v.trim() : void 0;
@@ -79955,25 +80022,21 @@ async function withMailbox(path, deps, fn) {
 async function imapGetMessage(id, preferHtml, deps = {}) {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
-  return withMailbox(
-    ref.path,
-    { ...deps, account: deps.account ?? ref.account },
-    async (client) => {
-      const msg = await client.fetchOne(
-        String(ref.uid),
-        { envelope: true, source: true },
-        { uid: true }
-      );
-      if (!msg)
-        return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
-      const subject = msg.envelope?.subject || "(no subject)";
-      const src = msg.source ? msg.source.toString() : "";
-      const body = (preferHtml ? extractHtmlBody(src) : extractTextBody(src)) ?? extractTextBody(src) ?? extractHtmlBody(src) ?? "(no readable body)";
-      return { success: true, info: `Subject: ${subject}
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    const msg = await client.fetchOne(
+      String(ref.uid),
+      { envelope: true, source: true },
+      { uid: true }
+    );
+    if (!msg)
+      return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
+    const subject = msg.envelope?.subject || "(no subject)";
+    const src = msg.source ? msg.source.toString() : "";
+    const body = (preferHtml ? extractHtmlBody(src) : extractTextBody(src)) ?? extractTextBody(src) ?? extractHtmlBody(src) ?? "(no readable body)";
+    return { success: true, info: `Subject: ${subject}
 
 ${body}` };
-    }
-  );
+  });
 }
 function normalizeMessageId(mid) {
   return mid.trim().replace(/^<+/, "").replace(/>+$/, "").trim();
@@ -79982,15 +80045,11 @@ async function imapFetchMessageId(id, deps = {}) {
   const ref = decodeImapId(id);
   if (!ref) return null;
   try {
-    return await withMailbox(
-      ref.path,
-      { ...deps, account: deps.account ?? ref.account },
-      async (client) => {
-        const msg = await client.fetchOne(String(ref.uid), { envelope: true }, { uid: true });
-        const mid = msg && msg.envelope?.messageId;
-        return mid ? normalizeMessageId(mid) : null;
-      }
-    );
+    return await withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+      const msg = await client.fetchOne(String(ref.uid), { envelope: true }, { uid: true });
+      const mid = msg && msg.envelope?.messageId;
+      return mid ? normalizeMessageId(mid) : null;
+    });
   } catch {
     return null;
   }
@@ -79998,23 +80057,19 @@ async function imapFetchMessageId(id, deps = {}) {
 function flagOp(id, flag, add, deps) {
   const ref = decodeImapId(id);
   if (!ref) return Promise.resolve({ success: false, error: `Not an IMAP message id: "${id}".` });
-  return withMailbox(
-    ref.path,
-    { ...deps, account: deps.account ?? ref.account },
-    async (client) => {
-      try {
-        const ok = add ? await client.messageFlagsAdd([ref.uid], [flag], { uid: true }) : await client.messageFlagsRemove([ref.uid], [flag], { uid: true });
-        if (!ok)
-          return { success: false, error: `IMAP flag update returned false for UID ${ref.uid}.` };
-        return { success: true };
-      } catch (e) {
-        return {
-          success: false,
-          error: `IMAP flag update failed for UID ${ref.uid}: ${errText(e)}`
-        };
-      }
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    try {
+      const ok = add ? await client.messageFlagsAdd([ref.uid], [flag], { uid: true }) : await client.messageFlagsRemove([ref.uid], [flag], { uid: true });
+      if (!ok)
+        return { success: false, error: `IMAP flag update returned false for UID ${ref.uid}.` };
+      return { success: true };
+    } catch (e) {
+      return {
+        success: false,
+        error: `IMAP flag update failed for UID ${ref.uid}: ${errText(e)}`
+      };
     }
-  );
+  });
 }
 var imapMarkRead = (id, deps = {}) => flagOp(id, "\\Seen", true, deps);
 var imapMarkUnread = (id, deps = {}) => flagOp(id, "\\Seen", false, deps);
@@ -80023,7 +80078,7 @@ var imapUnflagMessage = (id, deps = {}) => flagOp(id, "\\Flagged", false, deps);
 async function imapMoveMessageById(id, destMailbox, deps = {}) {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
-  return withClient({ ...deps, account: deps.account ?? ref.account }, async (client) => {
+  return withClient(depsForMessageRef(ref, deps), async (client) => {
     const destPath = await findMailboxPath(client, destMailbox) ?? resolveMailboxPath(destMailbox, "list");
     const lock = await client.getMailboxLock(ref.path);
     try {
@@ -80064,21 +80119,17 @@ async function trashUids(client, uids, srcPath) {
 async function imapDeleteMessageById(id, deps = {}) {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
-  return withMailbox(
-    ref.path,
-    { ...deps, account: deps.account ?? ref.account },
-    async (client) => {
-      try {
-        const { dest, expunged } = await trashUids(client, [ref.uid], ref.path);
-        return {
-          success: true,
-          info: expunged ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP.` : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`
-        };
-      } catch (e) {
-        return { success: false, error: `IMAP delete failed for UID ${ref.uid}: ${errText(e)}` };
-      }
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    try {
+      const { dest, expunged } = await trashUids(client, [ref.uid], ref.path);
+      return {
+        success: true,
+        info: expunged ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP.` : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`
+      };
+    } catch (e) {
+      return { success: false, error: `IMAP delete failed for UID ${ref.uid}: ${errText(e)}` };
     }
-  );
+  });
 }
 function collectAttachments(node, out = []) {
   if (!node) return out;
@@ -80104,54 +80155,46 @@ async function streamToBuffer(content) {
 async function imapListAttachments(id, deps = {}) {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
-  return withMailbox(
-    ref.path,
-    { ...deps, account: deps.account ?? ref.account },
-    async (client) => {
-      const msg = await client.fetchOne(String(ref.uid), { bodyStructure: true }, { uid: true });
-      if (!msg || !msg.bodyStructure) {
-        return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
-      }
-      const attachments = collectAttachments(msg.bodyStructure).map((a) => ({
-        id: `${id}#${a.part}`,
-        name: a.filename,
-        mimeType: a.mimeType,
-        size: a.size
-      }));
-      return { success: true, attachments };
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    const msg = await client.fetchOne(String(ref.uid), { bodyStructure: true }, { uid: true });
+    if (!msg || !msg.bodyStructure) {
+      return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
     }
-  );
+    const attachments = collectAttachments(msg.bodyStructure).map((a) => ({
+      id: `${id}#${a.part}`,
+      name: a.filename,
+      mimeType: a.mimeType,
+      size: a.size
+    }));
+    return { success: true, attachments };
+  });
 }
 async function imapFetchAttachment(id, attachmentName, deps = {}) {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
-  return withMailbox(
-    ref.path,
-    { ...deps, account: deps.account ?? ref.account },
-    async (client) => {
-      const msg = await client.fetchOne(String(ref.uid), { bodyStructure: true }, { uid: true });
-      if (!msg || !msg.bodyStructure) {
-        return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
-      }
-      const atts = collectAttachments(msg.bodyStructure);
-      const match = atts.find((a) => a.filename === attachmentName);
-      if (!match) {
-        const names = atts.map((a) => a.filename).join(", ") || "none";
-        return {
-          success: false,
-          error: `Attachment "${attachmentName}" not found on UID ${ref.uid}. Available: ${names}.`
-        };
-      }
-      const dl = await client.download(String(ref.uid), match.part, { uid: true });
-      const buf = await streamToBuffer(dl.content);
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    const msg = await client.fetchOne(String(ref.uid), { bodyStructure: true }, { uid: true });
+    if (!msg || !msg.bodyStructure) {
+      return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
+    }
+    const atts = collectAttachments(msg.bodyStructure);
+    const match = atts.find((a) => a.filename === attachmentName);
+    if (!match) {
+      const names = atts.map((a) => a.filename).join(", ") || "none";
       return {
-        success: true,
-        base64: buf.toString("base64"),
-        bytes: buf.length,
-        mimeType: match.mimeType
+        success: false,
+        error: `Attachment "${attachmentName}" not found on UID ${ref.uid}. Available: ${names}.`
       };
     }
-  );
+    const dl = await client.download(String(ref.uid), match.part, { uid: true });
+    const buf = await streamToBuffer(dl.content);
+    return {
+      success: true,
+      base64: buf.toString("base64"),
+      bytes: buf.length,
+      mimeType: match.mimeType
+    };
+  });
 }
 async function imapBatch(ids, deps, op) {
   const groups = /* @__PURE__ */ new Map();
@@ -80172,7 +80215,7 @@ async function imapBatch(ids, deps, op) {
   let success = 0;
   for (const g of groups.values()) {
     try {
-      await useClient({ ...deps, account: deps.account ?? g.account }, async (client) => {
+      await useClient(depsForAccount(g.account, deps), async (client) => {
         const lock = await client.getMailboxLock(g.path);
         try {
           await op(client, g.uids, g.path);
@@ -80221,7 +80264,7 @@ async function imapThread(id, deps = {}, limit = 50) {
   const ref = decodeImapId(id);
   if (!ref) return null;
   return useClient(
-    { ...deps, account: deps.account ?? ref.account },
+    depsForMessageRef(ref, deps),
     async (client) => {
       const lock = await client.getMailboxLock(ref.path);
       try {
@@ -80860,12 +80903,15 @@ var ATTACHMENTS_SCHEMA = external_exports.array(
   external_exports.union([
     external_exports.string().describe("Absolute path to an existing file"),
     external_exports.object({
-      filename: external_exports.string().min(1).describe("Filename to give the attachment"),
-      contentBase64: external_exports.string().min(1).describe("Base64-encoded file content")
+      filename: external_exports.string().min(1).max(255).describe("Filename to give the attachment"),
+      contentBase64: external_exports.string().min(1).max(
+        MAX_INLINE_ATTACHMENT_BASE64_CHARS,
+        "Inline attachment exceeds the 25 MiB decoded size limit"
+      ).describe("Base64-encoded file content (maximum 25 MiB decoded)")
     })
   ])
 ).max(20, "Cannot attach more than 20 files").optional().describe(
-  "Files to attach: absolute paths (e.g. '/Users/me/report.pdf') and/or inline {filename, contentBase64} objects for content not on disk."
+  "Files to attach: absolute paths (e.g. '/Users/me/report.pdf') and/or inline {filename, contentBase64} objects up to 25 MiB decoded each."
 );
 var MESSAGE_ROW_SCHEMA = external_exports.object({}).passthrough();
 var LIST_OUTPUT_SCHEMA = {
@@ -82009,20 +82055,21 @@ server.registerTool(
       if (/[/\\\0]/.test(attachmentName) || attachmentName.includes("..")) {
         return errorResponse(`Invalid attachment name: "${attachmentName}"`);
       }
-      const resolvedDir = resolvePath(savePath);
-      if (!isPathWithinAllowedRoots(resolvedDir)) {
-        return errorResponse(`Save path "${savePath}" is outside allowed directories`);
+      let target;
+      try {
+        target = resolveAttachmentSaveTarget(savePath, attachmentName);
+      } catch (error2) {
+        return errorResponse(error2 instanceof Error ? error2.message : String(error2));
       }
       const r = await imapFetchAttachment(id, attachmentName);
       if (!r.success || !r.base64) {
         return errorResponse(r.error || `Failed to fetch attachment "${attachmentName}"`);
       }
-      const savedPath = joinPath(resolvedDir, attachmentName);
-      writeFileSync4(savedPath, Buffer.from(r.base64, "base64"));
+      writeFileSync4(target.savedPath, Buffer.from(r.base64, "base64"));
       return successResponse(`Attachment "${attachmentName}" saved to ${savePath}`, {
         ok: true,
         attachmentName,
-        savedPath
+        savedPath: target.savedPath
       });
     }
     const success = mailManager.saveAttachment(id, attachmentName, savePath);

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.9",
+  "version": "2.8.10",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/docs/IMAP-SETUP.md
+++ b/docs/IMAP-SETUP.md
@@ -199,6 +199,7 @@ the macOS 15+ blockquote wrapping. SMTP is single-account (the default sender):
   "APPLE_MAIL_MCP_SMTP_PORT": "587",
   "APPLE_MAIL_MCP_SMTP_USER": "you@gmail.com",
   "APPLE_MAIL_MCP_SMTP_FROM": "you@gmail.com",
+  "APPLE_MAIL_MCP_SMTP_ALLOWED_FROM": "alias@example.com",
   "APPLE_MAIL_MCP_SMTP_KEYCHAIN_SERVICE": "imap.gmail.com",
   "APPLE_MAIL_MCP_SMTP_KEYCHAIN_ACCOUNT": "you@gmail.com"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.8.9",
+  "version": "2.8.10",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -168,5 +168,6 @@ describe("runCli", () => {
     expect(code).toBe(0);
     expect(send).not.toHaveBeenCalled();
     expect(out.join("\n")).toMatch(/apple-mail-send/);
+    expect(out.join("\n")).toContain("APPLE_MAIL_MCP_SMTP_ALLOWED_FROM");
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,8 @@ export const EX_CONFIG = 78;
 const USAGE = `apple-mail-send — send a clean email via SMTP (no Mail.app blockquote wrapping).
 
 Required:
-  --from <addr>         Sender address (must be allowed by the SMTP server)
+  --from <addr>         Sender address (SMTP user/configured From, or an alias in
+                        ${SMTP_ENV.allowedFrom})
   --to <addr>           Recipient (repeatable)
   --subject <text>      Subject line
   --body-file <path>    UTF-8 file with the plain-text body

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,10 @@ import type { Account, SearchDiagnostics, SearchResult } from "@/types.js";
 import { routeMessage } from "@/services/messageRouter.js";
 import { runDoctor, formatDoctorReport } from "@/tools/doctor.js";
 import { registerResourcesAndPrompts } from "@/tools/resourcesAndPrompts.js";
-import { MAX_INLINE_ATTACHMENT_BASE64_CHARS } from "@/utils/attachmentLimits.js";
+import {
+  isInlineAttachmentBase64WithinLimit,
+  MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS,
+} from "@/utils/attachmentLimits.js";
 import { normalizeSubject, subjectFromGetMessage } from "@/tools/thread.js";
 import { extractRfcMessageIdFromSource } from "@/utils/mimeParse.js";
 import { ImapIdleWatcher } from "@/services/imapIdle.js";
@@ -167,7 +170,11 @@ const ATTACHMENTS_SCHEMA = z
           .string()
           .min(1)
           .max(
-            MAX_INLINE_ATTACHMENT_BASE64_CHARS,
+            MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS,
+            "Inline attachment exceeds the 25 MiB decoded size limit"
+          )
+          .refine(
+            isInlineAttachmentBase64WithinLimit,
             "Inline attachment exceeds the 25 MiB decoded size limit"
           )
           .describe("Base64-encoded file content (maximum 25 MiB decoded)"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,9 @@ import { createRequire } from "module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { AppleMailManager, isPathWithinAllowedRoots } from "@/services/appleMailManager.js";
+import { AppleMailManager, resolveAttachmentSaveTarget } from "@/services/appleMailManager.js";
 import { writeFileSync } from "fs";
-import { resolve as resolvePath, join as joinPath } from "path";
+import { join as joinPath } from "path";
 import {
   sendViaSmtp,
   sendSerialViaSmtp,
@@ -92,6 +92,7 @@ import type { Account, SearchDiagnostics, SearchResult } from "@/types.js";
 import { routeMessage } from "@/services/messageRouter.js";
 import { runDoctor, formatDoctorReport } from "@/tools/doctor.js";
 import { registerResourcesAndPrompts } from "@/tools/resourcesAndPrompts.js";
+import { MAX_INLINE_ATTACHMENT_BASE64_CHARS } from "@/utils/attachmentLimits.js";
 import { normalizeSubject, subjectFromGetMessage } from "@/tools/thread.js";
 import { extractRfcMessageIdFromSource } from "@/utils/mimeParse.js";
 import { ImapIdleWatcher } from "@/services/imapIdle.js";
@@ -161,8 +162,15 @@ const ATTACHMENTS_SCHEMA = z
     z.union([
       z.string().describe("Absolute path to an existing file"),
       z.object({
-        filename: z.string().min(1).describe("Filename to give the attachment"),
-        contentBase64: z.string().min(1).describe("Base64-encoded file content"),
+        filename: z.string().min(1).max(255).describe("Filename to give the attachment"),
+        contentBase64: z
+          .string()
+          .min(1)
+          .max(
+            MAX_INLINE_ATTACHMENT_BASE64_CHARS,
+            "Inline attachment exceeds the 25 MiB decoded size limit"
+          )
+          .describe("Base64-encoded file content (maximum 25 MiB decoded)"),
       }),
     ])
   )
@@ -170,7 +178,7 @@ const ATTACHMENTS_SCHEMA = z
   .optional()
   .describe(
     "Files to attach: absolute paths (e.g. '/Users/me/report.pdf') and/or " +
-      "inline {filename, contentBase64} objects for content not on disk."
+      "inline {filename, contentBase64} objects up to 25 MiB decoded each."
   );
 
 // =============================================================================
@@ -1748,20 +1756,21 @@ server.registerTool(
       if (/[/\\\0]/.test(attachmentName) || attachmentName.includes("..")) {
         return errorResponse(`Invalid attachment name: "${attachmentName}"`);
       }
-      const resolvedDir = resolvePath(savePath);
-      if (!isPathWithinAllowedRoots(resolvedDir)) {
-        return errorResponse(`Save path "${savePath}" is outside allowed directories`);
+      let target: { saveDirectory: string; savedPath: string };
+      try {
+        target = resolveAttachmentSaveTarget(savePath, attachmentName);
+      } catch (error) {
+        return errorResponse(error instanceof Error ? error.message : String(error));
       }
       const r = await imapFetchAttachment(id, attachmentName);
       if (!r.success || !r.base64) {
         return errorResponse(r.error || `Failed to fetch attachment "${attachmentName}"`);
       }
-      const savedPath = joinPath(resolvedDir, attachmentName);
-      writeFileSync(savedPath, Buffer.from(r.base64, "base64"));
+      writeFileSync(target.savedPath, Buffer.from(r.base64, "base64"));
       return successResponse(`Attachment "${attachmentName}" saved to ${savePath}`, {
         ok: true,
         attachmentName,
-        savedPath,
+        savedPath: target.savedPath,
       });
     }
 

--- a/src/services/appleMailManager.attachmentPath.test.ts
+++ b/src/services/appleMailManager.attachmentPath.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { homedir, tmpdir } from "os";
+import { join } from "path";
+
+const h = vi.hoisted(() => ({ calls: 0 }));
+
+vi.mock("@/utils/applescript.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/applescript.js")>();
+  return {
+    ...actual,
+    executeAppleScript: () => {
+      h.calls += 1;
+      return { success: false, output: "", error: "unexpected call" };
+    },
+  };
+});
+
+import { AppleMailManager } from "@/services/appleMailManager.js";
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanup.splice(0)) rmSync(path, { recursive: true, force: true });
+  h.calls = 0;
+});
+
+describe("saveAttachment path boundary", () => {
+  it("rejects an allowed-root symlink that resolves outside the allowed roots", () => {
+    const root = mkdtempSync(join(homedir(), ".apple-mail-mcp-test-"));
+    cleanup.push(root);
+    const link = join(root, "outside");
+    symlinkSync("/etc", link, "dir");
+
+    const mgr = new AppleMailManager();
+    expect(mgr.saveAttachment("1", "hosts", link)).toBe(false);
+    expect(h.calls).toBe(0);
+  });
+
+  it("rejects an existing symbolic-link destination", () => {
+    const root = mkdtempSync(join(tmpdir(), "apple-mail-mcp-test-"));
+    cleanup.push(root);
+    symlinkSync("/etc/hosts", join(root, "hosts"));
+
+    const mgr = new AppleMailManager();
+    expect(mgr.saveAttachment("1", "hosts", root)).toBe(false);
+    expect(h.calls).toBe(0);
+  });
+
+  it("uses a temporary directory when fetching attachment bytes", () => {
+    const mgr = new AppleMailManager();
+    const save = vi.spyOn(mgr, "saveAttachment").mockImplementation((_id, name, directory) => {
+      writeFileSync(join(directory, name), "payload");
+      return true;
+    });
+
+    const result = mgr.getAttachmentBase64("1", "report.txt");
+
+    expect(result.success).toBe(true);
+    expect(Buffer.from(result.base64 as string, "base64").toString()).toBe("payload");
+    expect(save.mock.calls[0][2]).not.toMatch(/report\.txt$/);
+  });
+});

--- a/src/services/appleMailManager.resolve.test.ts
+++ b/src/services/appleMailManager.resolve.test.ts
@@ -70,4 +70,14 @@ describe("findNumericIdByMessageId (imap→numeric bridge)", () => {
     const s = lastScript();
     expect(s).toContain('a\\"b\\\\c@ex.com');
   });
+
+  it("strips control characters from Message-ID and account literals", () => {
+    h.output = "1";
+    mgr.findNumericIdByMessageId("abc\n@ex.com", "work\raccount");
+    const s = lastScript();
+    expect(s).not.toContain("abc\n@ex.com");
+    expect(s).not.toContain("work\raccount");
+    expect(s).toContain("abc@ex.com");
+    expect(s).toContain("workaccount");
+  });
 });

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -14,7 +14,15 @@
  */
 
 import { spawnSync } from "child_process";
-import { existsSync, writeFileSync, readFileSync, mkdtempSync, rmSync } from "fs";
+import {
+  existsSync,
+  writeFileSync,
+  readFileSync,
+  mkdtempSync,
+  rmSync,
+  realpathSync,
+  lstatSync,
+} from "fs";
 import { isAbsolute, resolve, sep, join } from "path";
 import { homedir } from "os";
 import { executeAppleScript } from "@/utils/applescript.js";
@@ -218,6 +226,33 @@ export function isPathWithinAllowedRoots(resolvedPath: string): boolean {
     const base = root.endsWith(sep) ? root.slice(0, -1) : root;
     return resolvedPath === base || resolvedPath.startsWith(base + sep);
   });
+}
+
+/** Resolve and validate an attachment save directory and its final output path. */
+export function resolveAttachmentSaveTarget(
+  savePath: string,
+  attachmentName: string
+): { saveDirectory: string; savedPath: string } {
+  let saveDirectory: string;
+  try {
+    saveDirectory = realpathSync(resolve(savePath));
+  } catch {
+    throw new Error(`Save directory "${savePath}" does not exist`);
+  }
+
+  if (!isPathWithinAllowedRoots(saveDirectory)) {
+    throw new Error(`Save path "${savePath}" is outside allowed directories`);
+  }
+
+  const savedPath = resolve(saveDirectory, attachmentName);
+  if (!isPathWithinAllowedRoots(savedPath)) {
+    throw new Error(`Output path "${savedPath}" is outside allowed directories`);
+  }
+  if (existsSync(savedPath) && lstatSync(savedPath).isSymbolicLink()) {
+    throw new Error(`Refusing to overwrite symbolic link "${savedPath}"`);
+  }
+
+  return { saveDirectory, savedPath };
 }
 
 /**
@@ -2259,7 +2294,7 @@ export class AppleMailManager {
     const mid = messageId.trim().replace(/^<+/, "").replace(/>+$/, "").trim();
     if (!mid) return null;
 
-    const q = (s: string) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    const q = (s: string) => escapeForAppleScript(s);
     const midLit = `"${q(mid)}"`;
     const bracketedLit = `"${q(`<${mid}>`)}"`;
     const matchClause = (mbVar: string) =>
@@ -2718,15 +2753,16 @@ export class AppleMailManager {
       return false;
     }
 
-    // Resolve the save path to prevent symlink / ".." traversal bypass
-    const resolvedPath = resolve(savePath);
-    if (!isPathWithinAllowedRoots(resolvedPath)) {
-      console.error(`Save path "${savePath}" is outside allowed directories`);
+    let target: { saveDirectory: string; savedPath: string };
+    try {
+      target = resolveAttachmentSaveTarget(savePath, attachmentName);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
       return false;
     }
 
     const safeName = escapeForAppleScript(attachmentName);
-    const safePath = escapeForAppleScript(resolvedPath);
+    const safePath = escapeForAppleScript(target.saveDirectory);
     const numericId = Number(id);
 
     // Attempt 1: AppleScript save
@@ -2776,13 +2812,7 @@ export class AppleMailManager {
     }
 
     try {
-      const outPath = resolve(resolvedPath, attachmentName);
-      // Verify the resolved output path is still within allowed directories
-      if (!isPathWithinAllowedRoots(outPath)) {
-        console.error(`Output path "${outPath}" is outside allowed directories`);
-        return false;
-      }
-      writeFileSync(outPath, attachment.data);
+      writeFileSync(target.savedPath, attachment.data);
       return true;
     } catch (err) {
       console.error(`Failed to write attachment to disk: ${err}`);
@@ -2803,7 +2833,7 @@ export class AppleMailManager {
     try {
       dir = mkdtempSync("/private/tmp/amcp-fetch-");
       const dest = join(dir, attachmentName.replace(/[/\\]/g, "_"));
-      const ok = this.saveAttachment(id, attachmentName, dest);
+      const ok = this.saveAttachment(id, attachmentName, dir);
       if (!ok) {
         return {
           success: false,

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -551,6 +551,23 @@ describe("IMAP message mutations (#43 Phase 3)", () => {
     ).rejects.toThrow(/belongs to account "iCloud", not "Work"/);
   });
 
+  it("accepts the login-address selector for a label-encoded message id", async () => {
+    const aliasCfg = {
+      ...cfg,
+      user: "person@example.com",
+      accountLabel: "Personal",
+    };
+    const id = encodeImapId("Personal", "INBOX", 1);
+    const result = await imapGetMessage(id, false, {
+      account: "person@example.com",
+      config: aliasCfg,
+      connect: async () => makeMsgClient({}, "Content-Type: text/plain\r\n\r\nAlias body"),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.info).toContain("Alias body");
+  });
+
   it("rejects a non-IMAP id", async () => {
     const r = await imapDeleteMessageById("57820");
     expect(r.success).toBe(false);
@@ -670,6 +687,28 @@ describe("batch ops via UID STORE/MOVE (I2)", () => {
     expect(r.failed).toBe(1);
     expect(r.errors[0]).toMatch(/belongs to account "Personal", not "Work"/);
     expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("batch-moves a label-encoded id when the account selector is its login address", async () => {
+    const aliasCfg = {
+      ...cfg,
+      user: "person@example.com",
+      accountLabel: "Personal",
+    };
+    const rec: MsgRec = {};
+    const client: ImapClientLike = {
+      ...makeMsgClient(rec),
+      list: async () => [{ path: "Archive", name: "Archive" }],
+    };
+
+    const result = await imapBatchMove([encodeImapId("Personal", "INBOX", 1)], "Archive", {
+      account: "person@example.com",
+      config: aliasCfg,
+      connect: async () => client,
+    });
+
+    expect(result).toMatchObject({ success: 1, failed: 0, errors: [] });
+    expect(rec.moved).toEqual([[1], "Archive"]);
   });
 
   it("moves a UID set to a resolved destination mailbox", async () => {

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -541,6 +541,16 @@ describe("IMAP message mutations (#43 Phase 3)", () => {
     expect(r.info).toContain("Hello body line");
   });
 
+  it("rejects an account override that disagrees with the composite message id", async () => {
+    await expect(
+      imapGetMessage(MID, false, {
+        account: "Work",
+        config: cfg,
+        connect: async () => makeMsgClient({}),
+      })
+    ).rejects.toThrow(/belongs to account "iCloud", not "Work"/);
+  });
+
   it("rejects a non-IMAP id", async () => {
     const r = await imapDeleteMessageById("57820");
     expect(r.success).toBe(false);
@@ -646,6 +656,20 @@ describe("batch ops via UID STORE/MOVE (I2)", () => {
     expect(r.success).toBe(0);
     expect(r.failed).toBe(1);
     expect(r.errors[0]).toMatch(/Not an IMAP id/);
+  });
+
+  it("fails a group whose composite ids disagree with the requested account", async () => {
+    const connect = vi.fn(async () => makeClient([], {}));
+    const r = await imapBatchMarkRead([encodeImapId("Personal", "INBOX", 1)], {
+      account: "Work",
+      config: cfg,
+      connect,
+    });
+
+    expect(r.success).toBe(0);
+    expect(r.failed).toBe(1);
+    expect(r.errors[0]).toMatch(/belongs to account "Personal", not "Work"/);
+    expect(connect).not.toHaveBeenCalled();
   });
 
   it("moves a UID set to a resolved destination mailbox", async () => {

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -176,6 +176,19 @@ export interface ImapDeps {
   account?: string;
 }
 
+type ImapMessageRef = NonNullable<ReturnType<typeof decodeImapId>>;
+
+function depsForAccount(account: string, deps: ImapDeps): ImapDeps {
+  if (deps.account && deps.account !== account) {
+    throw new Error(`IMAP message id belongs to account "${account}", not "${deps.account}".`);
+  }
+  return { ...deps, account };
+}
+
+function depsForMessageRef(ref: ImapMessageRef, deps: ImapDeps): ImapDeps {
+  return depsForAccount(ref.account, deps);
+}
+
 /**
  * A configured IMAP account *without* its password resolved — cheap to
  * enumerate (no Keychain access), used for routing/listing (C2).
@@ -955,27 +968,23 @@ export async function imapGetMessage(
 ): Promise<ImapOpResult> {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
-  return withMailbox(
-    ref.path,
-    { ...deps, account: deps.account ?? ref.account },
-    async (client) => {
-      const msg = await client.fetchOne(
-        String(ref.uid),
-        { envelope: true, source: true },
-        { uid: true }
-      );
-      if (!msg)
-        return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
-      const subject = msg.envelope?.subject || "(no subject)";
-      const src = msg.source ? msg.source.toString() : "";
-      const body =
-        (preferHtml ? extractHtmlBody(src) : extractTextBody(src)) ??
-        extractTextBody(src) ??
-        extractHtmlBody(src) ??
-        "(no readable body)";
-      return { success: true, info: `Subject: ${subject}\n\n${body}` };
-    }
-  );
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    const msg = await client.fetchOne(
+      String(ref.uid),
+      { envelope: true, source: true },
+      { uid: true }
+    );
+    if (!msg)
+      return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
+    const subject = msg.envelope?.subject || "(no subject)";
+    const src = msg.source ? msg.source.toString() : "";
+    const body =
+      (preferHtml ? extractHtmlBody(src) : extractTextBody(src)) ??
+      extractTextBody(src) ??
+      extractHtmlBody(src) ??
+      "(no readable body)";
+    return { success: true, info: `Subject: ${subject}\n\n${body}` };
+  });
 }
 
 /** Normalize an RFC822 Message-ID for backend-independent matching: trim and
@@ -997,15 +1006,11 @@ export async function imapFetchMessageId(id: string, deps: ImapDeps = {}): Promi
   const ref = decodeImapId(id);
   if (!ref) return null;
   try {
-    return await withMailbox(
-      ref.path,
-      { ...deps, account: deps.account ?? ref.account },
-      async (client) => {
-        const msg = await client.fetchOne(String(ref.uid), { envelope: true }, { uid: true });
-        const mid = msg && msg.envelope?.messageId;
-        return mid ? normalizeMessageId(mid) : null;
-      }
-    );
+    return await withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+      const msg = await client.fetchOne(String(ref.uid), { envelope: true }, { uid: true });
+      const mid = msg && msg.envelope?.messageId;
+      return mid ? normalizeMessageId(mid) : null;
+    });
   } catch {
     return null;
   }
@@ -1014,25 +1019,21 @@ export async function imapFetchMessageId(id: string, deps: ImapDeps = {}): Promi
 function flagOp(id: string, flag: string, add: boolean, deps: ImapDeps): Promise<ImapOpResult> {
   const ref = decodeImapId(id);
   if (!ref) return Promise.resolve({ success: false, error: `Not an IMAP message id: "${id}".` });
-  return withMailbox(
-    ref.path,
-    { ...deps, account: deps.account ?? ref.account },
-    async (client) => {
-      try {
-        const ok = add
-          ? await client.messageFlagsAdd([ref.uid], [flag], { uid: true })
-          : await client.messageFlagsRemove([ref.uid], [flag], { uid: true });
-        if (!ok)
-          return { success: false, error: `IMAP flag update returned false for UID ${ref.uid}.` };
-        return { success: true };
-      } catch (e) {
-        return {
-          success: false,
-          error: `IMAP flag update failed for UID ${ref.uid}: ${errText(e)}`,
-        };
-      }
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    try {
+      const ok = add
+        ? await client.messageFlagsAdd([ref.uid], [flag], { uid: true })
+        : await client.messageFlagsRemove([ref.uid], [flag], { uid: true });
+      if (!ok)
+        return { success: false, error: `IMAP flag update returned false for UID ${ref.uid}.` };
+      return { success: true };
+    } catch (e) {
+      return {
+        success: false,
+        error: `IMAP flag update failed for UID ${ref.uid}: ${errText(e)}`,
+      };
     }
-  );
+  });
 }
 
 export const imapMarkRead = (id: string, deps = {}): Promise<ImapOpResult> =>
@@ -1051,7 +1052,7 @@ export async function imapMoveMessageById(
 ): Promise<ImapOpResult> {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
-  return withClient({ ...deps, account: deps.account ?? ref.account }, async (client) => {
+  return withClient(depsForMessageRef(ref, deps), async (client) => {
     const destPath =
       (await findMailboxPath(client, destMailbox)) ?? resolveMailboxPath(destMailbox, "list");
     const lock = await client.getMailboxLock(ref.path);
@@ -1121,23 +1122,19 @@ export async function imapDeleteMessageById(
 ): Promise<ImapOpResult> {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
-  return withMailbox(
-    ref.path,
-    { ...deps, account: deps.account ?? ref.account },
-    async (client) => {
-      try {
-        const { dest, expunged } = await trashUids(client, [ref.uid], ref.path);
-        return {
-          success: true,
-          info: expunged
-            ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP.`
-            : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`,
-        };
-      } catch (e) {
-        return { success: false, error: `IMAP delete failed for UID ${ref.uid}: ${errText(e)}` };
-      }
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    try {
+      const { dest, expunged } = await trashUids(client, [ref.uid], ref.path);
+      return {
+        success: true,
+        info: expunged
+          ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP.`
+          : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`,
+      };
+    } catch (e) {
+      return { success: false, error: `IMAP delete failed for UID ${ref.uid}: ${errText(e)}` };
     }
-  );
+  });
 }
 
 // ===========================================================================
@@ -1195,23 +1192,19 @@ export async function imapListAttachments(
 ): Promise<{ success: boolean; attachments?: ImapAttachmentInfo[]; error?: string }> {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
-  return withMailbox(
-    ref.path,
-    { ...deps, account: deps.account ?? ref.account },
-    async (client) => {
-      const msg = await client.fetchOne(String(ref.uid), { bodyStructure: true }, { uid: true });
-      if (!msg || !msg.bodyStructure) {
-        return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
-      }
-      const attachments = collectAttachments(msg.bodyStructure).map((a) => ({
-        id: `${id}#${a.part}`,
-        name: a.filename,
-        mimeType: a.mimeType,
-        size: a.size,
-      }));
-      return { success: true, attachments };
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    const msg = await client.fetchOne(String(ref.uid), { bodyStructure: true }, { uid: true });
+    if (!msg || !msg.bodyStructure) {
+      return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
     }
-  );
+    const attachments = collectAttachments(msg.bodyStructure).map((a) => ({
+      id: `${id}#${a.part}`,
+      name: a.filename,
+      mimeType: a.mimeType,
+      size: a.size,
+    }));
+    return { success: true, attachments };
+  });
 }
 
 /** Fetch one attachment's bytes (base64) via IMAP, matched by filename. */
@@ -1228,33 +1221,29 @@ export async function imapFetchAttachment(
 }> {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
-  return withMailbox(
-    ref.path,
-    { ...deps, account: deps.account ?? ref.account },
-    async (client) => {
-      const msg = await client.fetchOne(String(ref.uid), { bodyStructure: true }, { uid: true });
-      if (!msg || !msg.bodyStructure) {
-        return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
-      }
-      const atts = collectAttachments(msg.bodyStructure);
-      const match = atts.find((a) => a.filename === attachmentName);
-      if (!match) {
-        const names = atts.map((a) => a.filename).join(", ") || "none";
-        return {
-          success: false,
-          error: `Attachment "${attachmentName}" not found on UID ${ref.uid}. Available: ${names}.`,
-        };
-      }
-      const dl = await client.download(String(ref.uid), match.part, { uid: true });
-      const buf = await streamToBuffer(dl.content);
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    const msg = await client.fetchOne(String(ref.uid), { bodyStructure: true }, { uid: true });
+    if (!msg || !msg.bodyStructure) {
+      return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
+    }
+    const atts = collectAttachments(msg.bodyStructure);
+    const match = atts.find((a) => a.filename === attachmentName);
+    if (!match) {
+      const names = atts.map((a) => a.filename).join(", ") || "none";
       return {
-        success: true,
-        base64: buf.toString("base64"),
-        bytes: buf.length,
-        mimeType: match.mimeType,
+        success: false,
+        error: `Attachment "${attachmentName}" not found on UID ${ref.uid}. Available: ${names}.`,
       };
     }
-  );
+    const dl = await client.download(String(ref.uid), match.part, { uid: true });
+    const buf = await streamToBuffer(dl.content);
+    return {
+      success: true,
+      base64: buf.toString("base64"),
+      bytes: buf.length,
+      mimeType: match.mimeType,
+    };
+  });
 }
 
 // ===========================================================================
@@ -1294,7 +1283,7 @@ async function imapBatch(
   let success = 0;
   for (const g of groups.values()) {
     try {
-      await useClient({ ...deps, account: deps.account ?? g.account }, async (client) => {
+      await useClient(depsForAccount(g.account, deps), async (client) => {
         const lock = await client.getMailboxLock(g.path);
         try {
           await op(client, g.uids, g.path);
@@ -1382,7 +1371,7 @@ export async function imapThread(
   const ref = decodeImapId(id);
   if (!ref) return null;
   return useClient(
-    { ...deps, account: deps.account ?? ref.account },
+    depsForMessageRef(ref, deps),
     async (client) => {
       const lock = await client.getMailboxLock(ref.path);
       try {

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -178,8 +178,29 @@ export interface ImapDeps {
 
 type ImapMessageRef = NonNullable<ReturnType<typeof decodeImapId>>;
 
+function sameImapAccount(left: string, right: string, deps: ImapDeps): boolean {
+  if (left === right) return true;
+
+  // Injected configs are the normal test seam and also give us both aliases
+  // without consulting process.env or the Keychain.
+  if (deps.config) {
+    const aliases = new Set([deps.config.accountLabel, deps.config.user]);
+    if (aliases.has(left) && aliases.has(right)) return true;
+  }
+
+  // Composite ids encode the stable account label, while callers may select
+  // that same account by its login address. Resolve both selectors against the
+  // same config list before deciding that the id belongs to another account.
+  const specs = listImapAccountSpecs();
+  const matches = (selector: string, spec: ImapAccountSpec) =>
+    spec.accountLabel === selector || spec.user === selector;
+  const leftSpec = specs.find((spec) => matches(left, spec));
+  const rightSpec = specs.find((spec) => matches(right, spec));
+  return leftSpec !== undefined && leftSpec === rightSpec;
+}
+
 function depsForAccount(account: string, deps: ImapDeps): ImapDeps {
-  if (deps.account && deps.account !== account) {
+  if (deps.account && !sameImapAccount(account, deps.account, deps)) {
     throw new Error(`IMAP message id belongs to account "${account}", not "${deps.account}".`);
   }
   return { ...deps, account };

--- a/src/services/smtpMailer.test.ts
+++ b/src/services/smtpMailer.test.ts
@@ -32,6 +32,7 @@ const testConfig: SmtpConfig = {
   user: "alice@example.com",
   pass: "s3cret",
   from: "alice@example.com",
+  allowedFrom: ["team@example.com"],
 };
 
 describe("resolveSmtpConfig", () => {
@@ -59,6 +60,14 @@ describe("resolveSmtpConfig", () => {
     });
     expect(cfg.port).toBe(2525);
     expect(cfg.from).toBe("noreply@example.com");
+  });
+
+  it("parses an explicit comma-separated sender alias allowlist", () => {
+    const cfg = resolveSmtpConfig({
+      ...baseEnv,
+      [SMTP_ENV.allowedFrom]: "team@example.com, billing@example.com",
+    });
+    expect(cfg.allowedFrom).toEqual(["team@example.com", "billing@example.com"]);
   });
 
   it("throws an actionable error when host/user are missing", () => {
@@ -134,6 +143,24 @@ describe("shouldUseSmtp (send-email transport decision)", () => {
 });
 
 describe("sendViaSmtp", () => {
+  it("rejects a From override outside the configured SMTP identities", async () => {
+    const createTransport = vi.fn();
+    const result = await sendViaSmtp(
+      {
+        to: ["bob@example.com"],
+        subject: "Hi",
+        body: "Body",
+        from: "spoofed@example.net",
+      },
+      testConfig,
+      createTransport as never
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not a configured sender identity/);
+    expect(createTransport).not.toHaveBeenCalled();
+  });
+
   it("sends clean MIME via the injected transporter and reports success", async () => {
     const sendMail = vi.fn().mockResolvedValue({ messageId: "<abc@example.com>" });
     const close = vi.fn();

--- a/src/services/smtpMailer.ts
+++ b/src/services/smtpMailer.ts
@@ -21,6 +21,7 @@ import { execFileSync } from "child_process";
 import { isAbsolute } from "path";
 import { existsSync } from "fs";
 import type { AttachmentInput } from "@/types.js";
+import { decodeInlineAttachment } from "@/utils/attachmentLimits.js";
 import { SETUP_HINT } from "@/utils/docsUrls.js";
 
 /** Options for an SMTP send, mirroring the AppleScript send-email surface. */
@@ -63,6 +64,7 @@ export interface SmtpConfig {
   user: string;
   pass: string;
   from: string;
+  allowedFrom?: string[];
 }
 
 /** Result of an SMTP send. */
@@ -82,6 +84,7 @@ export const SMTP_ENV = {
   secure: "APPLE_MAIL_MCP_SMTP_SECURE",
   user: "APPLE_MAIL_MCP_SMTP_USER",
   from: "APPLE_MAIL_MCP_SMTP_FROM",
+  allowedFrom: "APPLE_MAIL_MCP_SMTP_ALLOWED_FROM",
   password: "APPLE_MAIL_MCP_SMTP_PASSWORD",
   keychainService: "APPLE_MAIL_MCP_SMTP_KEYCHAIN_SERVICE",
   keychainAccount: "APPLE_MAIL_MCP_SMTP_KEYCHAIN_ACCOUNT",
@@ -182,6 +185,10 @@ export function resolveSmtpConfig(env: NodeJS.ProcessEnv = process.env): SmtpCon
   }
 
   const from = env[SMTP_ENV.from]?.trim() || (user as string);
+  const allowedFrom = (env[SMTP_ENV.allowedFrom] ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
 
   // Password: explicit env var wins, otherwise Keychain (service/account
   // default to the host/user but can be overridden).
@@ -201,7 +208,7 @@ export function resolveSmtpConfig(env: NodeJS.ProcessEnv = process.env): SmtpCon
     );
   }
 
-  return { host: host as string, port, secure, user: user as string, pass, from };
+  return { host: host as string, port, secure, user: user as string, pass, from, allowedFrom };
 }
 
 /**
@@ -219,7 +226,7 @@ function buildAttachments(attachments?: AttachmentInput[]) {
     if (!a.filename || !a.contentBase64) {
       throw new Error("Inline attachment requires both filename and contentBase64.");
     }
-    return { filename: a.filename, content: Buffer.from(a.contentBase64, "base64") };
+    return { filename: a.filename, content: decodeInlineAttachment(a.contentBase64) };
   });
 }
 
@@ -242,6 +249,17 @@ export async function sendViaSmtp(
     return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
 
+  const requestedFrom = opts.from?.trim();
+  const allowedFrom = new Set(
+    [cfg.user, cfg.from, ...(cfg.allowedFrom ?? [])].map((value) => value.trim().toLowerCase())
+  );
+  if (requestedFrom && !allowedFrom.has(requestedFrom.toLowerCase())) {
+    return {
+      success: false,
+      error: `SMTP From "${requestedFrom}" is not a configured sender identity.`,
+    };
+  }
+
   let attachments;
   try {
     attachments = buildAttachments(opts.attachments);
@@ -260,7 +278,7 @@ export async function sendViaSmtp(
 
   try {
     const info = await transporter.sendMail({
-      from: opts.from?.trim() || cfg.from,
+      from: requestedFrom || cfg.from,
       to: opts.to,
       cc: opts.cc,
       bcc: opts.bcc,

--- a/src/utils/attachmentLimits.test.ts
+++ b/src/utils/attachmentLimits.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   decodeInlineAttachment,
   MAX_INLINE_ATTACHMENT_BASE64_CHARS,
+  MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS,
   MAX_INLINE_ATTACHMENT_BYTES,
 } from "@/utils/attachmentLimits.js";
 
@@ -17,7 +18,7 @@ describe("inline attachment size limits", () => {
       {},
       {
         get: (_target, property) =>
-          property === "length" ? MAX_INLINE_ATTACHMENT_BASE64_CHARS + 1 : undefined,
+          property === "length" ? MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS + 1 : undefined,
       }
     ) as string;
 
@@ -27,5 +28,18 @@ describe("inline attachment size limits", () => {
   it("defines the base64 ceiling from the decoded byte ceiling", () => {
     expect(MAX_INLINE_ATTACHMENT_BYTES).toBe(25 * 1024 * 1024);
     expect(MAX_INLINE_ATTACHMENT_BASE64_CHARS).toBe(Math.ceil(MAX_INLINE_ATTACHMENT_BYTES / 3) * 4);
+    expect(MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS).toBe(MAX_INLINE_ATTACHMENT_BASE64_CHARS * 2);
+  });
+
+  it("accepts RFC-2045-wrapped base64 near the decoded limit", () => {
+    const byteLength = Math.floor(MAX_INLINE_ATTACHMENT_BYTES * 0.98);
+    const encoded = Buffer.alloc(byteLength, 0x61).toString("base64");
+    const wrapped = encoded.replace(/.{76}/g, "$&\r\n");
+
+    expect(wrapped.length).toBeGreaterThan(MAX_INLINE_ATTACHMENT_BASE64_CHARS);
+    const decoded = decodeInlineAttachment(wrapped);
+    expect(decoded.length).toBe(byteLength);
+    expect(decoded[0]).toBe(0x61);
+    expect(decoded[decoded.length - 1]).toBe(0x61);
   });
 });

--- a/src/utils/attachmentLimits.test.ts
+++ b/src/utils/attachmentLimits.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeInlineAttachment,
+  MAX_INLINE_ATTACHMENT_BASE64_CHARS,
+  MAX_INLINE_ATTACHMENT_BYTES,
+} from "@/utils/attachmentLimits.js";
+
+describe("inline attachment size limits", () => {
+  it("decodes content below the limit", () => {
+    expect(decodeInlineAttachment(Buffer.from("payload").toString("base64")).toString()).toBe(
+      "payload"
+    );
+  });
+
+  it("rejects encoded input above the limit before decoding", () => {
+    const oversized = new Proxy(
+      {},
+      {
+        get: (_target, property) =>
+          property === "length" ? MAX_INLINE_ATTACHMENT_BASE64_CHARS + 1 : undefined,
+      }
+    ) as string;
+
+    expect(() => decodeInlineAttachment(oversized)).toThrow(/25 MiB decoded size limit/);
+  });
+
+  it("defines the base64 ceiling from the decoded byte ceiling", () => {
+    expect(MAX_INLINE_ATTACHMENT_BYTES).toBe(25 * 1024 * 1024);
+    expect(MAX_INLINE_ATTACHMENT_BASE64_CHARS).toBe(Math.ceil(MAX_INLINE_ATTACHMENT_BYTES / 3) * 4);
+  });
+});

--- a/src/utils/attachmentLimits.ts
+++ b/src/utils/attachmentLimits.ts
@@ -4,9 +4,27 @@ export const MAX_INLINE_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 /** Maximum base64 length capable of representing the decoded byte limit. */
 export const MAX_INLINE_ATTACHMENT_BASE64_CHARS = Math.ceil(MAX_INLINE_ATTACHMENT_BYTES / 3) * 4;
 
+/**
+ * Bound the raw input too, while allowing RFC-2045 line wrapping and other
+ * decoder-ignored whitespace. The authoritative encoded-size check below
+ * counts only non-whitespace characters.
+ */
+export const MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS = MAX_INLINE_ATTACHMENT_BASE64_CHARS * 2;
+
+/** True when raw and non-whitespace base64 lengths remain safely bounded. */
+export function isInlineAttachmentBase64WithinLimit(contentBase64: string): boolean {
+  if (contentBase64.length > MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS) return false;
+
+  let encodedChars = 0;
+  for (const char of contentBase64) {
+    if (!/\s/u.test(char) && ++encodedChars > MAX_INLINE_ATTACHMENT_BASE64_CHARS) return false;
+  }
+  return true;
+}
+
 /** Decode an inline attachment without allowing an unbounded buffer allocation. */
 export function decodeInlineAttachment(contentBase64: string): Buffer {
-  if (contentBase64.length > MAX_INLINE_ATTACHMENT_BASE64_CHARS) {
+  if (!isInlineAttachmentBase64WithinLimit(contentBase64)) {
     throw new Error("Inline attachment exceeds the 25 MiB decoded size limit.");
   }
 

--- a/src/utils/attachmentLimits.ts
+++ b/src/utils/attachmentLimits.ts
@@ -1,0 +1,18 @@
+/** Maximum decoded size of one inline attachment (25 MiB). */
+export const MAX_INLINE_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
+/** Maximum base64 length capable of representing the decoded byte limit. */
+export const MAX_INLINE_ATTACHMENT_BASE64_CHARS = Math.ceil(MAX_INLINE_ATTACHMENT_BYTES / 3) * 4;
+
+/** Decode an inline attachment without allowing an unbounded buffer allocation. */
+export function decodeInlineAttachment(contentBase64: string): Buffer {
+  if (contentBase64.length > MAX_INLINE_ATTACHMENT_BASE64_CHARS) {
+    throw new Error("Inline attachment exceeds the 25 MiB decoded size limit.");
+  }
+
+  const content = Buffer.from(contentBase64, "base64");
+  if (content.length > MAX_INLINE_ATTACHMENT_BYTES) {
+    throw new Error("Inline attachment exceeds the 25 MiB decoded size limit.");
+  }
+  return content;
+}

--- a/src/utils/attachmentMaterialize.test.ts
+++ b/src/utils/attachmentMaterialize.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, readdirSync } from "fs";
 import { isAbsolute } from "path";
+import { tmpdir } from "os";
 import { materializeAttachments } from "@/utils/attachmentMaterialize.js";
 
 describe("materializeAttachments (B4)", () => {
@@ -37,6 +38,23 @@ describe("materializeAttachments (B4)", () => {
     expect(() => materializeAttachments([{ filename: "x.txt", contentBase64: "" }])).toThrow(
       /filename and contentBase64/
     );
+  });
+
+  it("cleans up earlier temp files when a later inline attachment is rejected", () => {
+    const before = new Set(readdirSync(tmpdir()).filter((name) => name.startsWith("amcp-att-")));
+    const boundaryOversize = Buffer.alloc(25 * 1024 * 1024 + 1).toString("base64");
+
+    expect(() =>
+      materializeAttachments([
+        { filename: "first.txt", contentBase64: Buffer.from("written first").toString("base64") },
+        { filename: "too-large.bin", contentBase64: boundaryOversize },
+      ])
+    ).toThrow(/25 MiB decoded size limit/);
+
+    const after = readdirSync(tmpdir()).filter(
+      (name) => name.startsWith("amcp-att-") && !before.has(name)
+    );
+    expect(after).toEqual([]);
   });
 
   it("handles the empty/undefined case (incl. its no-op cleanup)", () => {

--- a/src/utils/attachmentMaterialize.ts
+++ b/src/utils/attachmentMaterialize.ts
@@ -11,6 +11,7 @@ import { writeFileSync, rmSync, mkdtempSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import type { AttachmentInput } from "@/types.js";
+import { decodeInlineAttachment } from "@/utils/attachmentLimits.js";
 
 export interface MaterializedAttachments {
   /** Absolute file paths ready to hand to the AppleScript attachment builder. */
@@ -24,17 +25,23 @@ export function materializeAttachments(attachments?: AttachmentInput[]): Materia
     return { paths: [], cleanup: () => undefined };
   }
   let dir: string | null = null;
-  const paths = attachments.map((a) => {
-    if (typeof a === "string") return a;
-    if (!a.filename || !a.contentBase64) {
-      throw new Error("Inline attachment requires both filename and contentBase64.");
-    }
-    if (!dir) dir = mkdtempSync(join(tmpdir(), "amcp-att-"));
-    const safeName = a.filename.replace(/[/\\]/g, "_");
-    const p = join(dir, safeName);
-    writeFileSync(p, Buffer.from(a.contentBase64, "base64"));
-    return p;
-  });
+  let paths: string[];
+  try {
+    paths = attachments.map((a) => {
+      if (typeof a === "string") return a;
+      if (!a.filename || !a.contentBase64) {
+        throw new Error("Inline attachment requires both filename and contentBase64.");
+      }
+      if (!dir) dir = mkdtempSync(join(tmpdir(), "amcp-att-"));
+      const safeName = a.filename.replace(/[/\\]/g, "_");
+      const p = join(dir, safeName);
+      writeFileSync(p, decodeInlineAttachment(a.contentBase64));
+      return p;
+    });
+  } catch (error) {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    throw error;
+  }
   return {
     paths,
     cleanup: () => {


### PR DESCRIPTION
## Summary

- Bind every composite IMAP message ID to its resolved account identity for reads, attachments, threading, and single/batch mutations. Configured account labels and login addresses remain equivalent selectors; genuinely different accounts fail before any IMAP connection.
- Restrict SMTP `From` overrides to the authenticated user, configured default sender, or aliases explicitly listed in `APPLE_MAIL_MCP_SMTP_ALLOWED_FROM`, with the contract documented in the README, CLI help, and changelog.
- Cap inline Base64 attachments at 25 MiB decoded while accepting standards-wrapped input, clean partial temporary materialization on every exception, strip control characters from Message-ID/account AppleScript literals, and resolve attachment save directories through `realpath` while rejecting existing symlink destinations.
- Rebase onto v2.8.9, bump the package and synchronized plugin manifests to v2.8.10, add complete `[Unreleased]` notes, and rebuild both committed bundles.

These changes harden existing local trust boundaries. They do not claim unauthenticated remote code execution; the relevant cases require a configured mail account and a caller able to invoke the MCP tools.

## Verification

- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm test` — 28 files, 392 tests passed
- `pnpm run test:coverage` — 28 files, 392 tests passed
- `pnpm run test:integration` — 47 tests passed, 10 skipped against configured Mail.app
- `RUN_IMAP_IT=1 GREENMAIL_HOST=127.0.0.1 GREENMAIL_IMAP_PORT=3143 GREENMAIL_USER=tester GREENMAIL_PASS=secret pnpm run test:imap` — checksum-verified GreenMail 2.1.0, 10/10 tests passed
- Focused review suite — 6 files, 120/120 tests passed
- `pnpm run build`, followed by `git diff --exit-code -- build/`
- Second deterministic build produced identical `build/index.js` and `build/cli.js` hashes
- `pnpm pack --dry-run`
- `pnpm audit --audit-level=high` — no known vulnerabilities
- Local version guard — 2.8.9 -> 2.8.10
- `git diff --check`
- Push hook — typecheck and 392 tests passed

## Risk / Notes

- Public-facing and release files changed: `README.md`, `CHANGELOG.md`, `docs/IMAP-SETUP.md`, package/plugin version manifests, and committed `build/` bundles.
- Existing SMTP authenticated-user and configured-default `From` values remain allowed. Calls that relied on arbitrary per-message sender overrides must explicitly configure the intended aliases.
- Attachment save containment rejects stable symlink destinations and canonicalizes the parent directory. As with pathname-based filesystem APIs generally, callers should use directories they control rather than attacker-writable shared directories.
- The fork's `main` branch was synchronized to upstream v2.8.9 (`3d91310`) outside this PR commit. No GitHub repository settings were changed.
- No issue is linked because the current open issue list has no matching report.

## Checklist

- [x] Bug fix
- [x] Tests pass locally
- [x] Linting passes
- [x] Build succeeds
- [x] I have read the contributing guidelines
- [x] The code follows the project's style
- [x] Documentation is updated
