### PR TITLE
fix(mail): list-messages gets the Gmail virtual-INBOX redirect search-messages already has

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.10",
+      "version": "2.8.11",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.10",
+      "version": "2.8.11",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.8.10",
+      "version": "2.8.11",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.11] - 2026-07-18
+
+### Fixed
+
+- **`list-messages` now gets the same Gmail virtual-INBOX redirect as `search-messages`.** A Gmail-style account's literal "INBOX" mailbox is an empty shell — real received mail lives under the "All Mail"/"Important" special mailboxes. `search-messages` already redirected an INBOX-scoped call to that receiving set (BUG A1, 2.8.x), but `list-messages`/`listMessagesWithDiagnostics` bound the empty shell directly, so it silently returned a small, shifting subset of the account's real inbox (backed by Mail.app's own internal `id of msg`, which is not a stable identifier and is reassigned when the local envelope cache resyncs). Callers doing `list-messages` then `batch-move-messages`/`batch-flag-messages` on those ids could act on stale/incorrect message references. `list-messages` now scans the same "All Mail"/"Important" receiving set as `search-messages` for an INBOX-scoped call on a Gmail-style account, so the two report consistent results.
+
 ## [2.8.10] - 2026-07-18
 
 ### Security

--- a/build/index.js
+++ b/build/index.js
@@ -77455,7 +77455,38 @@ var AppleMailManager = class {
     let listCommand;
     if (mailbox) {
       const targetMailbox = this.resolveMailbox(mailbox, targetAccount);
-      listCommand = `
+      const gmailInbox = isInboxScope(mailbox) ? gmailReceivingMailboxes(this.getCachedMailboxNames(targetAccount)) : null;
+      if (gmailInbox) {
+        const nameList = appleScriptLowerNameList(gmailInbox);
+        listCommand = `
+      set outputText to ""
+      set _timedOut to false
+      set _notSearched to ""
+      set _wantNames to ${nameList}
+      set msgCount to 0
+      set skipped to 0
+      set seenIds to {}
+      repeat with mb in mailboxes
+        if msgCount >= ${limit} then exit repeat
+        set mbName to ""
+        try
+          set mbName to name of mb
+        end try
+        ignoring case
+          if _wantNames contains mbName then
+            try
+              ${buildMessageRowLoop({ collection: `messages of mb ${fromFilter}`, limit, offset, dedup: true, withAttachments: true, trailing: ` & "${FIELD_SEP}" & mbName` })}
+            on error _errMsg number _errNum
+              set _timedOut to true
+              set _notSearched to _notSearched & mbName & "${DIAG_ITEM_SEP}"
+            end try
+          end if
+        end ignoring
+      end repeat
+      return outputText & "${DIAG_MARKER}timedOut=" & (_timedOut as string) & "${DIAG_FIELD_SEP}skipped=${DIAG_FIELD_SEP}notSearched=" & _notSearched
+    `;
+      } else {
+        listCommand = `
       set outputText to ""
       set _timedOut to false
       set _notSearched to ""
@@ -77470,6 +77501,7 @@ var AppleMailManager = class {
       end try
       return outputText & "${DIAG_MARKER}timedOut=" & (_timedOut as string) & "${DIAG_FIELD_SEP}skipped=${DIAG_FIELD_SEP}notSearched=" & _notSearched
     `;
+      }
     } else {
       const scanGuard = scanThreshold > 0 ? `mbCount > ${scanThreshold}` : "false";
       listCommand = `

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleMailManager.gmailInbox.test.ts
+++ b/src/services/appleMailManager.gmailInbox.test.ts
@@ -10,6 +10,9 @@
  *       so it finds the messages an unscoped call reports; and a NON-Gmail
  *       account keeps the plain single-INBOX scan.
  *   A2) getRecentlyReceivedStats scans "All Mail" for Gmail-style accounts.
+ *   A3) list-messages gets the same INBOX-scoped redirect as search-messages
+ *       (previously it did not, which is why list-messages and search-messages
+ *       disagreed about a Gmail account's INBOX contents).
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -145,6 +148,70 @@ describe("A1: INBOX-scoped search on a NON-Gmail account is unchanged", () => {
     const mgr = new AppleMailManager();
 
     mgr.searchMessages(undefined, "Sent Mail", "robert.b.sweet@gmail.com", 50);
+
+    const scan = lastScript("set outputText to");
+    expect(scan).toMatch(/set theMailbox to mailbox "Sent Mail"/);
+  });
+});
+
+describe("A3: INBOX-scoped list-messages on a Gmail-style account", () => {
+  it("scans the receiving set (All Mail / Important) by name, not the empty INBOX", () => {
+    h.router.fn = makeRouter({ mailboxNames: GMAIL_MAILBOXES });
+    const mgr = new AppleMailManager();
+
+    mgr.listMessages("INBOX", "robert.b.sweet@gmail.com", 50);
+
+    const scan = lastScript("set outputText to");
+    expect(scan).toBeDefined();
+    expect(scan).toMatch(/repeat with mb in mailboxes/);
+    expect(scan).toContain('"all mail"');
+    expect(scan).toContain('"important"');
+    expect(scan).not.toMatch(/set theMailbox to mailbox "INBOX"/);
+  });
+
+  it("case-insensitively treats 'inbox' as the inbox scope", () => {
+    h.router.fn = makeRouter({ mailboxNames: GMAIL_MAILBOXES });
+    const mgr = new AppleMailManager();
+
+    mgr.listMessages("inbox", "robert.b.sweet@gmail.com", 50);
+
+    const scan = lastScript("set outputText to");
+    expect(scan).toContain('"all mail"');
+  });
+
+  it("finds messages the receiving-set scan returns, and agrees with search-messages", () => {
+    // One row: id 100, in All Mail. 7 FIELD_SEP fields (list-messages requests
+    // withAttachments, so the row schema is one field longer than search's).
+    const row = ["100", "Hello", "a@b.com", "2026-7-1-9-0-0", "false", "false", "false"].join(
+      FIELD_SEP
+    );
+    h.router.fn = makeRouter({ mailboxNames: GMAIL_MAILBOXES, searchOutput: row });
+    const mgr = new AppleMailManager();
+
+    const msgs = mgr.listMessages("INBOX", "robert.b.sweet@gmail.com", 50);
+
+    expect(msgs.map((m) => m.id)).toContain("100");
+  });
+});
+
+describe("A3: INBOX-scoped list-messages on a NON-Gmail account is unchanged", () => {
+  it("binds the single INBOX mailbox directly (no receiving-set iteration)", () => {
+    h.router.fn = makeRouter({ mailboxNames: NON_GMAIL_MAILBOXES });
+    const mgr = new AppleMailManager();
+
+    mgr.listMessages("INBOX", "rob@superiortech.io", 50);
+
+    const scan = lastScript("set outputText to");
+    expect(scan).toBeDefined();
+    expect(scan).toMatch(/set theMailbox to mailbox "INBOX"/);
+    expect(scan).not.toContain('"all mail"');
+  });
+
+  it("a non-INBOX scope on a Gmail account still binds that mailbox directly", () => {
+    h.router.fn = makeRouter({ mailboxNames: GMAIL_MAILBOXES });
+    const mgr = new AppleMailManager();
+
+    mgr.listMessages("Sent Mail", "robert.b.sweet@gmail.com", 50);
 
     const scan = lastScript("set outputText to");
     expect(scan).toMatch(/set theMailbox to mailbox "Sent Mail"/);

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -1680,7 +1680,47 @@ export class AppleMailManager {
       // wrap the scan so a timeout is reported as partial, not a false empty.
       const targetMailbox = this.resolveMailbox(mailbox, targetAccount);
 
-      listCommand = `
+      // Gmail virtual-INBOX (BUG A1, ported from searchMessagesWithDiagnostics):
+      // a Gmail-style account's literal "INBOX" mailbox is an empty shell — mail
+      // actually received lives under the "All Mail"/"Important" special
+      // mailboxes. Without this, list-messages (unlike search-messages) silently
+      // returns a small, shifting subset of the account's real inbox contents.
+      // See BUG A / issue: Gmail virtual-INBOX handling.
+      const gmailInbox = isInboxScope(mailbox)
+        ? gmailReceivingMailboxes(this.getCachedMailboxNames(targetAccount))
+        : null;
+
+      if (gmailInbox) {
+        const nameList = appleScriptLowerNameList(gmailInbox);
+        listCommand = `
+      set outputText to ""
+      set _timedOut to false
+      set _notSearched to ""
+      set _wantNames to ${nameList}
+      set msgCount to 0
+      set skipped to 0
+      set seenIds to {}
+      repeat with mb in mailboxes
+        if msgCount >= ${limit} then exit repeat
+        set mbName to ""
+        try
+          set mbName to name of mb
+        end try
+        ignoring case
+          if _wantNames contains mbName then
+            try
+              ${buildMessageRowLoop({ collection: `messages of mb ${fromFilter}`, limit, offset, dedup: true, withAttachments: true, trailing: ` & "${FIELD_SEP}" & mbName` })}
+            on error _errMsg number _errNum
+              set _timedOut to true
+              set _notSearched to _notSearched & mbName & "${DIAG_ITEM_SEP}"
+            end try
+          end if
+        end ignoring
+      end repeat
+      return outputText & "${DIAG_MARKER}timedOut=" & (_timedOut as string) & "${DIAG_FIELD_SEP}skipped=${DIAG_FIELD_SEP}notSearched=" & _notSearched
+    `;
+      } else {
+        listCommand = `
       set outputText to ""
       set _timedOut to false
       set _notSearched to ""
@@ -1695,6 +1735,7 @@ export class AppleMailManager {
       end try
       return outputText & "${DIAG_MARKER}timedOut=" & (_timedOut as string) & "${DIAG_FIELD_SEP}skipped=${DIAG_FIELD_SEP}notSearched=" & _notSearched
     `;
+      }
     } else {
       // List from ALL mailboxes — skip mailboxes over the scan threshold, enforce
       // the per-account budget, capture per-mailbox timeouts; dedup by message ID.


### PR DESCRIPTION
## Summary
- `search-messages` already redirects an INBOX-scoped call on a Gmail-style account to the real receiving set ("All Mail"/"Important"), because the literal "INBOX" mailbox Mail.app exposes for such accounts is an empty shell.
- `list-messages`/`listMessagesWithDiagnostics` never got that same redirect, so it bound the empty shell directly and silently returned a small, shifting subset of the account's real inbox — backed by Mail.app's internal `id of msg`, which is not a stable identifier and gets reassigned when the local envelope cache resyncs.
- Found live: `list-messages` returned 8 messages for a Gmail INBOX while `search-messages` (same account/mailbox) returned 20+ going back over a week, all tagged `"mailbox":"INBOX"`. A `batch-move-messages` call using ids from the stale `list-messages` result then timed out without the move taking effect, because those AppleScript numeric ids had already shifted.
- Ports the existing `isInboxScope`/`gmailReceivingMailboxes` redirect into `listMessagesWithDiagnostics`'s mailbox-scoped branch, mirroring `searchMessagesWithDiagnostics` exactly (dedup, offset, `withAttachments`, per-mailbox timeout diagnostics).
- Bumps 2.8.10 → 2.8.11 (patch) + CHANGELOG per the version-bump rule (src change).

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm test` (397 passed, including 6 new tests mirroring the existing A1 Gmail-INBOX suite for `list-messages`)
- [x] `pnpm run build` (bundle regenerated, contains the fix)