### PR TITLE
docs(skills): root SKILL.md canonical (case-rename) + sync-skills drift guard

### DIFF
--- a/.antigravity-plugin/skills/apple-mail/SKILL.md
+++ b/.antigravity-plugin/skills/apple-mail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apple-mail
-description: Use this skill when the user wants to interact with Apple Mail on macOS - reading, searching, sending, replying to, forwarding, or organizing emails and mailboxes. This skill provides access to the full Apple Mail app through MCP tools.
+description: Use this skill when the user wants to manage Apple Mail on macOS - reading, searching, sending, replying to, forwarding, and organizing emails and mailboxes. This skill provides access to Apple Mail through MCP tools.
 ---
 
 # Apple Mail Skill
@@ -27,19 +27,36 @@ Use this skill when the user:
 
 | Tool | Purpose |
 |------|---------|
-| `list-messages` | List messages in a mailbox (default: INBOX) |
+| `list-messages` | List messages in a mailbox (all mailboxes if omitted) |
 | `search-messages` | Find messages by sender, subject, or content |
 | `get-message` | Read the full content of a message |
+| `get-thread` | Get the full conversation thread for a message |
 | `send-email` | Send a new email immediately |
+| `send-serial-email` | Send personalized copies to many recipients (mail merge with `{{Key}}` placeholders) |
 | `create-draft` | Save an email to Drafts for review |
 | `reply-to-message` | Reply to a message (supports reply-all) |
 | `forward-message` | Forward a message to new recipients |
 | `mark-as-read` | Mark a message as read |
 | `mark-as-unread` | Mark a message as unread |
-| `flag-message` | Flag a message for follow-up |
+| `flag-message` | Flag a message for follow-up (optional color) |
 | `unflag-message` | Remove flag from a message |
 | `delete-message` | Move a message to Trash |
 | `move-message` | Move a message to a different mailbox |
+| `resolve-message-id` | Convert `imap:` ids to numeric Mail.app ids (needed for flag colors) |
+| `list-attachments` | List a message's attachments (name, MIME type, size) |
+| `save-attachment` | Save an attachment to disk |
+| `fetch-attachment` | Fetch an attachment's bytes inline as base64 |
+
+### Batch Operations (1-100 ids per call)
+
+| Tool | Purpose |
+|------|---------|
+| `batch-delete-messages` | Move multiple messages to Trash |
+| `batch-move-messages` | Move multiple messages to a mailbox |
+| `batch-mark-as-read` | Mark multiple messages as read |
+| `batch-mark-as-unread` | Mark multiple messages as unread |
+| `batch-flag-messages` | Flag multiple messages (optional color) |
+| `batch-unflag-messages` | Remove flags from multiple messages |
 
 ### Mailbox Operations
 
@@ -47,6 +64,9 @@ Use this skill when the user:
 |------|---------|
 | `list-mailboxes` | List all mailboxes/folders in an account |
 | `get-unread-count` | Get count of unread messages |
+| `create-mailbox` | Create a new mailbox/folder |
+| `delete-mailbox` | Delete a mailbox |
+| `rename-mailbox` | Rename a mailbox |
 
 ### Account Operations
 
@@ -54,12 +74,40 @@ Use this skill when the user:
 |------|---------|
 | `list-accounts` | List configured email accounts |
 
+### Rules
+
+| Tool | Purpose |
+|------|---------|
+| `list-rules` | List Mail rules and their enabled state |
+| `create-rule` | Create a Mail rule (conditions + actions) |
+| `enable-rule` | Enable a rule by name |
+| `disable-rule` | Disable a rule by name |
+| `delete-rule` | Delete a rule by name |
+
+### Contacts
+
+| Tool | Purpose |
+|------|---------|
+| `search-contacts` | Look up people in macOS Contacts to find their email addresses |
+
+### Templates
+
+| Tool | Purpose |
+|------|---------|
+| `save-template` | Create or update a reusable email template |
+| `list-templates` | List saved templates |
+| `get-template` | Read a template's full contents |
+| `use-template` | Compose a draft from a template (with overrides) |
+| `delete-template` | Delete a template |
+
 ### Diagnostics
 
 | Tool | Purpose |
 |------|---------|
 | `health-check` | Verify Mail.app connectivity |
+| `doctor` | Diagnose setup problems (permissions, accounts, IMAP/SMTP) with remediation steps |
 | `get-mail-stats` | Get message and unread statistics |
+| `get-sync-status` | Check whether Mail.app is running and syncing |
 
 ## Usage Patterns
 
@@ -142,7 +190,7 @@ Action: Use delete-message with the message ID
 
 1. **Message IDs**: All message operations require an ID. Get IDs from `list-messages` or `search-messages` first.
 2. **Recipient Arrays**: The `to`, `cc`, and `bcc` parameters must be arrays, even for single recipients: `["email@example.com"]`
-3. **Default Account**: Operations default to the first configured account. Use `account` parameter for others.
+3. **Account Selection**: Read tools (`list-messages`, `search-messages`) cover all accounts when `account` is omitted; other operations default to Mail's default account (first enabled account as fallback). Use the `account` parameter to target a specific one.
 4. **Draft vs Send**: Use `create-draft` when the user wants to review before sending. Recommend this for important emails.
 5. **Backslash Escaping**: When email content contains backslashes, escape them as `\\` in the JSON.
 6. **macOS Only**: This skill only works on macOS systems.
@@ -150,7 +198,7 @@ Action: Use delete-message with the message ID
 ## Error Handling
 
 - **"Message not found"**: The message ID may be invalid or the message was deleted. Use search-messages to find it again.
-- **"Permission denied"**: User needs to grant automation permission in System Settings > Privacy & Security > Automation.
+- **"Permission denied"**: User needs to grant automation permission in System Settings > Privacy & Security > Automation. Run the `doctor` tool for a full diagnosis.
 - **"Account not found"**: Account names are case-sensitive. Use list-accounts to see exact names.
 - **"Failed to send"**: Check network connection and Mail.app configuration.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Root skills/ is canonical; codex/skills/ and .antigravity-plugin/skills/
+      # are generated copies. Fails when they drift (fix: pnpm run sync:skills).
+      - name: Verify skill copies match skills/
+        run: node scripts/sync-skills.mjs --check
+
       - name: Run linter
         run: pnpm run lint
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ When adding a new MCP tool:
 2. **Implement the method** in `src/services/appleMailManager.ts`
 3. **Add type definitions** in `src/types.ts`
 4. **Write tests** in `src/services/appleMailManager.test.ts`
-5. **Update documentation** in README.md and CHANGELOG.md
+5. **Update documentation** in README.md and CHANGELOG.md. If the skill guidance changed, edit `skills/apple-mail/SKILL.md` (the canonical copy) and run `pnpm run sync:skills` — the `codex/` and `.antigravity-plugin/` copies are generated from it and CI fails if they drift
 
 ## AppleScript Guidelines
 

--- a/codex/skills/apple-mail/SKILL.md
+++ b/codex/skills/apple-mail/SKILL.md
@@ -27,19 +27,36 @@ Use this skill when the user:
 
 | Tool | Purpose |
 |------|---------|
-| `list-messages` | List messages in a mailbox (default: INBOX) |
+| `list-messages` | List messages in a mailbox (all mailboxes if omitted) |
 | `search-messages` | Find messages by sender, subject, or content |
 | `get-message` | Read the full content of a message |
+| `get-thread` | Get the full conversation thread for a message |
 | `send-email` | Send a new email immediately |
+| `send-serial-email` | Send personalized copies to many recipients (mail merge with `{{Key}}` placeholders) |
 | `create-draft` | Save an email to Drafts for review |
 | `reply-to-message` | Reply to a message (supports reply-all) |
 | `forward-message` | Forward a message to new recipients |
 | `mark-as-read` | Mark a message as read |
 | `mark-as-unread` | Mark a message as unread |
-| `flag-message` | Flag a message for follow-up |
+| `flag-message` | Flag a message for follow-up (optional color) |
 | `unflag-message` | Remove flag from a message |
 | `delete-message` | Move a message to Trash |
 | `move-message` | Move a message to a different mailbox |
+| `resolve-message-id` | Convert `imap:` ids to numeric Mail.app ids (needed for flag colors) |
+| `list-attachments` | List a message's attachments (name, MIME type, size) |
+| `save-attachment` | Save an attachment to disk |
+| `fetch-attachment` | Fetch an attachment's bytes inline as base64 |
+
+### Batch Operations (1-100 ids per call)
+
+| Tool | Purpose |
+|------|---------|
+| `batch-delete-messages` | Move multiple messages to Trash |
+| `batch-move-messages` | Move multiple messages to a mailbox |
+| `batch-mark-as-read` | Mark multiple messages as read |
+| `batch-mark-as-unread` | Mark multiple messages as unread |
+| `batch-flag-messages` | Flag multiple messages (optional color) |
+| `batch-unflag-messages` | Remove flags from multiple messages |
 
 ### Mailbox Operations
 
@@ -47,6 +64,9 @@ Use this skill when the user:
 |------|---------|
 | `list-mailboxes` | List all mailboxes/folders in an account |
 | `get-unread-count` | Get count of unread messages |
+| `create-mailbox` | Create a new mailbox/folder |
+| `delete-mailbox` | Delete a mailbox |
+| `rename-mailbox` | Rename a mailbox |
 
 ### Account Operations
 
@@ -54,12 +74,40 @@ Use this skill when the user:
 |------|---------|
 | `list-accounts` | List configured email accounts |
 
+### Rules
+
+| Tool | Purpose |
+|------|---------|
+| `list-rules` | List Mail rules and their enabled state |
+| `create-rule` | Create a Mail rule (conditions + actions) |
+| `enable-rule` | Enable a rule by name |
+| `disable-rule` | Disable a rule by name |
+| `delete-rule` | Delete a rule by name |
+
+### Contacts
+
+| Tool | Purpose |
+|------|---------|
+| `search-contacts` | Look up people in macOS Contacts to find their email addresses |
+
+### Templates
+
+| Tool | Purpose |
+|------|---------|
+| `save-template` | Create or update a reusable email template |
+| `list-templates` | List saved templates |
+| `get-template` | Read a template's full contents |
+| `use-template` | Compose a draft from a template (with overrides) |
+| `delete-template` | Delete a template |
+
 ### Diagnostics
 
 | Tool | Purpose |
 |------|---------|
 | `health-check` | Verify Mail.app connectivity |
+| `doctor` | Diagnose setup problems (permissions, accounts, IMAP/SMTP) with remediation steps |
 | `get-mail-stats` | Get message and unread statistics |
+| `get-sync-status` | Check whether Mail.app is running and syncing |
 
 ## Usage Patterns
 
@@ -142,7 +190,7 @@ Action: Use delete-message with the message ID
 
 1. **Message IDs**: All message operations require an ID. Get IDs from `list-messages` or `search-messages` first.
 2. **Recipient Arrays**: The `to`, `cc`, and `bcc` parameters must be arrays, even for single recipients: `["email@example.com"]`
-3. **Default Account**: Operations default to the first configured account. Use `account` parameter for others.
+3. **Account Selection**: Read tools (`list-messages`, `search-messages`) cover all accounts when `account` is omitted; other operations default to Mail's default account (first enabled account as fallback). Use the `account` parameter to target a specific one.
 4. **Draft vs Send**: Use `create-draft` when the user wants to review before sending. Recommend this for important emails.
 5. **Backslash Escaping**: When email content contains backslashes, escape them as `\\` in the JSON.
 6. **macOS Only**: This skill only works on macOS systems.
@@ -150,7 +198,7 @@ Action: Use delete-message with the message ID
 ## Error Handling
 
 - **"Message not found"**: The message ID may be invalid or the message was deleted. Use search-messages to find it again.
-- **"Permission denied"**: User needs to grant automation permission in System Settings > Privacy & Security > Automation.
+- **"Permission denied"**: User needs to grant automation permission in System Settings > Privacy & Security > Automation. Run the `doctor` tool for a full diagnosis.
 - **"Account not found"**: Account names are case-sensitive. Use list-accounts to see exact names.
 - **"Failed to send"**: Check network connection and Mail.app configuration.
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "format": "prettier --write src",
     "format:check": "prettier --check src",
     "typecheck": "tsc --noEmit",
+    "sync:skills": "node scripts/sync-skills.mjs",
     "version": "node scripts/sync-plugin-version.mjs && git add .claude-plugin .agents/plugins codex .hermes-plugin .antigravity-plugin",
     "prepublishOnly": "pnpm run lint && pnpm test && pnpm run build",
     "prepare": "husky; pnpm run build"

--- a/scripts/sync-skills.mjs
+++ b/scripts/sync-skills.mjs
@@ -1,0 +1,69 @@
+// Root skills/ is the canonical copy; the per-surface duplicates
+// (codex/skills/, .antigravity-plugin/skills/) are generated from it and must
+// never be edited directly. (.agents/plugins/marketplace.json sources ./codex,
+// and .hermes-plugin carries no skill copy — syncing codex covers every other
+// surface.)
+//
+//   node scripts/sync-skills.mjs          overwrite the copies from skills/
+//   node scripts/sync-skills.mjs --check  exit 1 on any drift (CI gate)
+//
+// Edit skills/**, run `pnpm run sync:skills`, and commit all three trees.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const CANONICAL = "skills";
+const TARGETS = ["codex/skills", ".antigravity-plugin/skills"];
+
+const check = process.argv.includes("--check");
+const canonicalFiles = listFiles(path.join(root, CANONICAL));
+const drifted = [];
+
+for (const target of TARGETS) {
+  const targetRoot = path.join(root, target);
+  // Files present in a target but absent from skills/ are orphans from a
+  // removed or renamed skill — stale content, so they count as drift too.
+  for (const rel of listFiles(targetRoot)) {
+    if (!canonicalFiles.includes(rel)) {
+      drifted.push(`${path.join(target, rel)} (orphan; not in ${CANONICAL}/)`);
+      if (!check) fs.rmSync(path.join(targetRoot, rel));
+    }
+  }
+  for (const rel of canonicalFiles) {
+    const source = path.join(root, CANONICAL, rel);
+    const dest = path.join(targetRoot, rel);
+    if (
+      fs.existsSync(dest) &&
+      fs.readFileSync(source).equals(fs.readFileSync(dest))
+    ) {
+      continue;
+    }
+    drifted.push(path.join(target, rel));
+    if (!check) {
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.copyFileSync(source, dest);
+    }
+  }
+}
+
+if (drifted.length === 0) {
+  console.log(`skill copies in sync with ${CANONICAL}/: ${TARGETS.join(", ")}`);
+} else if (check) {
+  console.error(`skill copies have drifted from ${CANONICAL}/:`);
+  for (const file of drifted) console.error(`  ${file}`);
+  console.error("Run 'pnpm run sync:skills' and commit the result.");
+  process.exit(1);
+} else {
+  console.log(`synced from ${CANONICAL}/:`);
+  for (const file of drifted) console.log(`  ${file}`);
+}
+
+function listFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.relative(dir, path.join(entry.parentPath, entry.name)))
+    .sort();
+}

--- a/skills/apple-mail/SKILL.md
+++ b/skills/apple-mail/SKILL.md
@@ -27,19 +27,36 @@ Use this skill when the user:
 
 | Tool | Purpose |
 |------|---------|
-| `list-messages` | List messages in a mailbox (default: INBOX) |
+| `list-messages` | List messages in a mailbox (all mailboxes if omitted) |
 | `search-messages` | Find messages by sender, subject, or content |
 | `get-message` | Read the full content of a message |
+| `get-thread` | Get the full conversation thread for a message |
 | `send-email` | Send a new email immediately |
+| `send-serial-email` | Send personalized copies to many recipients (mail merge with `{{Key}}` placeholders) |
 | `create-draft` | Save an email to Drafts for review |
 | `reply-to-message` | Reply to a message (supports reply-all) |
 | `forward-message` | Forward a message to new recipients |
 | `mark-as-read` | Mark a message as read |
 | `mark-as-unread` | Mark a message as unread |
-| `flag-message` | Flag a message for follow-up |
+| `flag-message` | Flag a message for follow-up (optional color) |
 | `unflag-message` | Remove flag from a message |
 | `delete-message` | Move a message to Trash |
 | `move-message` | Move a message to a different mailbox |
+| `resolve-message-id` | Convert `imap:` ids to numeric Mail.app ids (needed for flag colors) |
+| `list-attachments` | List a message's attachments (name, MIME type, size) |
+| `save-attachment` | Save an attachment to disk |
+| `fetch-attachment` | Fetch an attachment's bytes inline as base64 |
+
+### Batch Operations (1-100 ids per call)
+
+| Tool | Purpose |
+|------|---------|
+| `batch-delete-messages` | Move multiple messages to Trash |
+| `batch-move-messages` | Move multiple messages to a mailbox |
+| `batch-mark-as-read` | Mark multiple messages as read |
+| `batch-mark-as-unread` | Mark multiple messages as unread |
+| `batch-flag-messages` | Flag multiple messages (optional color) |
+| `batch-unflag-messages` | Remove flags from multiple messages |
 
 ### Mailbox Operations
 
@@ -47,6 +64,9 @@ Use this skill when the user:
 |------|---------|
 | `list-mailboxes` | List all mailboxes/folders in an account |
 | `get-unread-count` | Get count of unread messages |
+| `create-mailbox` | Create a new mailbox/folder |
+| `delete-mailbox` | Delete a mailbox |
+| `rename-mailbox` | Rename a mailbox |
 
 ### Account Operations
 
@@ -54,12 +74,40 @@ Use this skill when the user:
 |------|---------|
 | `list-accounts` | List configured email accounts |
 
+### Rules
+
+| Tool | Purpose |
+|------|---------|
+| `list-rules` | List Mail rules and their enabled state |
+| `create-rule` | Create a Mail rule (conditions + actions) |
+| `enable-rule` | Enable a rule by name |
+| `disable-rule` | Disable a rule by name |
+| `delete-rule` | Delete a rule by name |
+
+### Contacts
+
+| Tool | Purpose |
+|------|---------|
+| `search-contacts` | Look up people in macOS Contacts to find their email addresses |
+
+### Templates
+
+| Tool | Purpose |
+|------|---------|
+| `save-template` | Create or update a reusable email template |
+| `list-templates` | List saved templates |
+| `get-template` | Read a template's full contents |
+| `use-template` | Compose a draft from a template (with overrides) |
+| `delete-template` | Delete a template |
+
 ### Diagnostics
 
 | Tool | Purpose |
 |------|---------|
 | `health-check` | Verify Mail.app connectivity |
+| `doctor` | Diagnose setup problems (permissions, accounts, IMAP/SMTP) with remediation steps |
 | `get-mail-stats` | Get message and unread statistics |
+| `get-sync-status` | Check whether Mail.app is running and syncing |
 
 ## Usage Patterns
 
@@ -142,7 +190,7 @@ Action: Use delete-message with the message ID
 
 1. **Message IDs**: All message operations require an ID. Get IDs from `list-messages` or `search-messages` first.
 2. **Recipient Arrays**: The `to`, `cc`, and `bcc` parameters must be arrays, even for single recipients: `["email@example.com"]`
-3. **Default Account**: Operations default to the first configured account. Use `account` parameter for others.
+3. **Account Selection**: Read tools (`list-messages`, `search-messages`) cover all accounts when `account` is omitted; other operations default to Mail's default account (first enabled account as fallback). Use the `account` parameter to target a specific one.
 4. **Draft vs Send**: Use `create-draft` when the user wants to review before sending. Recommend this for important emails.
 5. **Backslash Escaping**: When email content contains backslashes, escape them as `\\` in the JSON.
 6. **macOS Only**: This skill only works on macOS systems.
@@ -150,7 +198,7 @@ Action: Use delete-message with the message ID
 ## Error Handling
 
 - **"Message not found"**: The message ID may be invalid or the message was deleted. Use search-messages to find it again.
-- **"Permission denied"**: User needs to grant automation permission in System Settings > Privacy & Security > Automation.
+- **"Permission denied"**: User needs to grant automation permission in System Settings > Privacy & Security > Automation. Run the `doctor` tool for a full diagnosis.
 - **"Account not found"**: Account names are case-sensitive. Use list-accounts to see exact names.
 - **"Failed to send"**: Check network connection and Mail.app configuration.
 


### PR DESCRIPTION
Ports the SKILL.md copy-sync drift guard from sweetrb/apple-notes-mcp#88 to this repo, and makes the root `skills/` tree the canonical skill source.

## What

- **Case-rename** `skills/apple-mail/skill.md` → `skills/apple-mail/SKILL.md`. The root copy was git-tracked lowercase (masked by the case-insensitive macOS fs), breaking the sibling repos' `skills/<name>/SKILL.md` convention and any exact-path sync. Content was confirmed identical to the codex de-facto master before the rename.
- **Staleness audit** of the root SKILL.md against the 46 shipped tools:
  - The tool tables listed only 18 tools — added the 28 missing: `get-thread`, `send-serial-email`, `resolve-message-id`, the 3 attachment tools, the 6 `batch-*` tools, `create/delete/rename-mailbox`, the 5 rules tools, `search-contacts`, the 5 template tools, `doctor`, `get-sync-status`.
  - Corrected `list-messages` "(default: INBOX)" — omitting `mailbox` now lists from all mailboxes.
  - Corrected the "operations default to the first configured account" guideline — reads (`list-messages`/`search-messages`) cover all accounts when `account` is omitted; other operations default to Mail's default account (first enabled as fallback).
  - Permission-denied error guidance now also points at the `doctor` tool.
- **Drift guard** (pattern from sweetrb/apple-notes-mcp#88):
  - `scripts/sync-skills.mjs` (byte-identical to the notes version — it is skill-name-agnostic, and its header comment holds here too: `.agents/plugins/marketplace.json` sources `./codex`, `.hermes-plugin` has no skill copy).
  - `pnpm run sync:skills` script in package.json.
  - ci.yml `test` job step "Verify skill copies match skills/" (`node scripts/sync-skills.mjs --check`) — fails PRs when `codex/skills/` or `.antigravity-plugin/skills/` drift from `skills/`.
  - CONTRIBUTING.md checklist note: edit only the canonical copy, then `pnpm run sync:skills`.
- `pnpm run sync:skills` regenerated both copies: the `.antigravity-plugin` copy was stale (older frontmatter description line); both now carry the audit fixes.

## Why no version bump

Docs/tooling only — no shipped code, no version bump (version-guard exempt: the package.json change is scripts-map only, `dependencies` untouched).

## Verification

- `node scripts/sync-skills.mjs --check` exits 0
- `pnpm run lint` / `typecheck` / `format:check` / `pnpm test` (397/397) all pass