### PR TITLE
docs: modernize contributor docs for the pnpm toolchain

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,12 +12,14 @@ Brief description of the changes.
 
 ## Testing
 
-- [ ] Tests pass locally (`npm test`)
-- [ ] Linting passes (`npm run lint`)
-- [ ] Build succeeds (`npm run build`)
+- [ ] Tests pass locally (`pnpm test`)
+- [ ] Linting passes (`pnpm run lint`)
+- [ ] Typecheck and formatting pass (`pnpm run typecheck && pnpm run format:check`)
+- [ ] Build succeeds (`pnpm run build`)
 
 ## Checklist
 
 - [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
 - [ ] My code follows the project's style
 - [ ] I have updated documentation if needed
+- [ ] If this PR changes shipped code (`src/**` excluding tests, or the runtime `dependencies` in `package.json`): version bumped at least a patch (`pnpm version patch --no-git-tag-version`) + a CHANGELOG.md entry — the `require-version-bump` CI check enforces this (docs-only and test-only PRs are exempt)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,17 +12,19 @@ Thank you for your interest in contributing! This document provides guidelines f
 
 2. **Install dependencies**
    ```bash
-   npm install
+   pnpm install
    ```
+
+   This repo pins pnpm via `packageManager` in `package.json` — `corepack enable` provides it. Development needs Node >= 22.13 (CI tests on Node 22 and 24); the published server itself runs on Node >= 20.
 
 3. **Build the project**
    ```bash
-   npm run build
+   pnpm run build
    ```
 
 4. **Run tests**
    ```bash
-   npm test
+   pnpm test
    ```
 
 ## Code Style
@@ -31,16 +33,16 @@ This project uses ESLint and Prettier for code quality and formatting.
 
 ```bash
 # Check for linting issues
-npm run lint
+pnpm run lint
 
 # Auto-fix linting issues
-npm run lint:fix
+pnpm run lint:fix
 
 # Format code
-npm run format
+pnpm run format
 
 # Check formatting
-npm run format:check
+pnpm run format:check
 ```
 
 ## Testing
@@ -49,16 +51,16 @@ All new features should include tests. We use Vitest for testing.
 
 ```bash
 # Run unit tests
-npm test
+pnpm test
 
 # Run tests in watch mode
-npm run test:watch
+pnpm run test:watch
 
 # Run integration tests (requires macOS with Mail.app configured)
-npm run test:integration
+pnpm run test:integration
 
 # Run all tests (unit + integration)
-npm run test:all
+pnpm run test:all
 ```
 
 ### Test File Locations
@@ -75,7 +77,7 @@ covered by the local integration suite. Before bumping the version and pushing a
 `chore(release)` commit, run the full suite locally on a configured Mac:
 
 ```bash
-npm run test:all   # unit + integration against real Mail.app
+pnpm run test:all   # unit + integration against real Mail.app
 ```
 
 A green CI run alone does not exercise the live Mail.app behavior.
@@ -101,17 +103,22 @@ A green CI run alone does not exercise the live Mail.app behavior.
 
 3. **Run all checks**
    ```bash
-   npm run lint
-   npm run typecheck
-   npm test
-   npm run build
+   pnpm run lint
+   pnpm run typecheck
+   pnpm run format:check
+   pnpm test
+   pnpm run build
    ```
 
-4. **Commit your changes**
+4. **Version bump & committed bundle** (shipped-code changes only)
+   - Any change to shipped code (`src/**` excluding tests, or the runtime `dependencies` in `package.json`) must bump `package.json` at least a patch (`pnpm version patch --no-git-tag-version`) and add a CHANGELOG.md entry in the same PR — the `require-version-bump` CI check fails the PR otherwise. Docs-only and test-only PRs are exempt.
+   - The bundled `build/index.js` and `build/cli.js` are committed to git: after source changes, rebuild (`pnpm run build`) and commit the updated bundle alongside `src/` — CI verifies the committed bundle matches the source.
+
+5. **Commit your changes**
    - Use clear, descriptive commit messages
    - Reference any related issues
 
-5. **Push and create a PR**
+6. **Push and create a PR**
    - Describe what your PR does
    - Link any related issues
 
@@ -119,7 +126,7 @@ A green CI run alone does not exercise the live Mail.app behavior.
 
 When adding a new MCP tool:
 
-1. **Add the schema** in `src/index.ts`
+1. **Add the schema** in `src/index.ts` (with a structured `Use when: / Returns: / Do not use when:` description, plus `Safety:` for any write/destructive tool)
 2. **Implement the method** in `src/services/appleMailManager.ts`
 3. **Add type definitions** in `src/types.ts`
 4. **Write tests** in `src/services/appleMailManager.test.ts`


### PR DESCRIPTION
The repos migrated from npm to pnpm in June 2026, but the contributor-facing docs still taught the npm toolchain — anyone following CONTRIBUTING.md or the PR template was steered to the wrong package manager and an out-of-date checklist. This brings both up to date with the current pnpm workflow and CI gates.

**CONTRIBUTING.md**
- All dev commands converted npm -> pnpm (install, build, test, lint, lint:fix, format, format:check, test:watch, test:integration, test:all)
- Development Setup now notes the `packageManager` pin / `corepack enable`, and Node >= 22.13 for development (CI tests on Node 22 + 24; the published server still runs on Node >= 20)
- "Run all checks" now includes `pnpm run format:check` (CI gates formatting separately)
- New Pull Request Process step: version bump (`pnpm version patch --no-git-tag-version`) + CHANGELOG entry for shipped-code changes (enforced by `require-version-bump`), and rebuilding/committing the bundled `build/index.js` + `build/cli.js` (CI verifies the committed bundle)
- "Adding New Tools": schema step now calls for the structured `Use when: / Returns: / Do not use when:` (+ `Safety:`) tool description, and the docs step reminds contributors to keep every SKILL.md copy (`skills/`, `codex/skills/`, `.antigravity-plugin/skills/`) in sync

**.github/PULL_REQUEST_TEMPLATE.md**
- Testing checklist converted to pnpm and extended with a typecheck + format:check item
- Checklist gains the version-bump/CHANGELOG item for shipped-code changes

Docs-only — no version bump (version-guard exempts docs-only PRs).