### PR TITLE
ci: bulletproof hardening (audit 2026-07-20)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.11",
+      "version": "2.8.12",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.11",
+      "version": "2.8.12",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.11",
+  "version": "2.8.12",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.8.11",
+  "version": "2.8.12",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.8.11",
+      "version": "2.8.12",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.11",
+  "version": "2.8.12",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,3 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# RENAME HAZARD: `name: CI` is publish.yml's workflow_run trigger key, and the
+# `test` job's matrix produces required branch-protection contexts
+# `test (22)` / `test (24)`. Renaming either silently severs publishing/merging.
 name: CI
 
 on:
@@ -30,13 +33,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -55,6 +58,9 @@ jobs:
       - name: Check formatting
         run: pnpm run format:check
 
+      - name: Verify plugin manifests match package.json version
+        run: node scripts/sync-plugin-version.mjs --check
+
       - name: Type check
         run: pnpm run typecheck
 
@@ -63,7 +69,7 @@ jobs:
 
       - name: Upload coverage reports
         if: matrix.node-version == 22
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
@@ -74,6 +80,11 @@ jobs:
 
       - name: Verify committed build/ matches source
         run: |
+          UNTRACKED=$(git status --porcelain --ignored -- build/ | grep -E '^(\?\?|!!)' || true)
+          if [ -n "$UNTRACKED" ]; then
+            echo "::error::Build emitted files into build/ that are not tracked:"; echo "$UNTRACKED"
+            exit 1
+          fi
           if ! git diff --quiet build/; then
             echo "::error::build/ is out of date. Run 'pnpm run build' locally and commit the changes."
             git --no-pager diff --stat build/
@@ -83,6 +94,35 @@ jobs:
       - name: outputSchema contract (boots the built server over stdio)
         if: matrix.node-version == 22
         run: pnpm exec vitest run --config vitest.integration.config.ts test/output-schema.test.ts
+
+  # The committed bundle must run with ONLY Node — no node_modules, and on the
+  # oldest supported runtime (engines.node >= 20). This is exactly how a
+  # marketplace/plugin clone executes it. (macOS runners have no `timeout`
+  # binary, so a perl alarm wrapper bounds the boot.)
+  bundle-boots:
+    name: bundle-boots (standalone, Node 20)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+      - name: Boot the committed bundle standalone (no node_modules, Node 20)
+        run: |
+          set -euo pipefail
+          DIR=$(mktemp -d)
+          cp package.json "$DIR/"
+          cp -R build "$DIR/build"
+          cd "$DIR"
+          RESP=$(printf '%s\n' \
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci-boot","version":"0"}}}' \
+            | perl -e 'alarm 30; exec @ARGV' node build/index.js | head -1)
+          echo "$RESP" | node -e '
+            let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+              const j=JSON.parse(s);
+              if(!j.result||!j.result.serverInfo||!j.result.serverInfo.version){console.error("no serverInfo in initialize response");process.exit(1)}
+              console.log("bundle boots standalone on Node 20: v"+j.result.serverInfo.version);
+            })'
 
   # IMAP backend integration tests run against a real IMAP server (GreenMail).
   # Unlike the Mail.app integration suite, the IMAP code path needs no macOS, so
@@ -102,13 +142,13 @@ jobs:
             -Dgreenmail.verbose
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: "pnpm"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,11 +17,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: javascript-typescript
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - name: Enable auto-merge for dev-deps and github-actions
         if: ${{ steps.meta.outputs.package-ecosystem == 'github_actions' || steps.meta.outputs.dependency-type == 'direct:development' }}
         run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"

--- a/.github/workflows/dependabot-rebuild.yml
+++ b/.github/workflows/dependabot-rebuild.yml
@@ -161,8 +161,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref || github.ref_name }}
-          # Full history: the auto-bump step below compares the version field
-          # against the fork point (merge-base with origin/main).
+          # Full history so the auto-bump step can compute the fork point
+          # (merge-base with origin/main) the same way version-guard does.
           fetch-depth: 0
 
       - name: Abort if the branch moved since the rebuild
@@ -196,43 +196,49 @@ jobs:
           path: build/
 
       - name: Auto-bump patch version for shipped-byte change
-        # version-guard now treats build/** as SHIPPED BYTES: the rebuilt
-        # bundle changes what npm users receive, so without this bump every
-        # bundle-changing Dependabot PR would fail the require-version-bump
-        # check (and, worse, merge without ever publishing). Token-split
-        # invariant: this job must run NO dependency lifecycle code, so the
-        # bump is done with bare `node -e` edits + the repo-owned dep-free
-        # sync script — no pnpm, no install.
+        # version-guard now treats build/** as shipped bytes; without this
+        # auto-bump, every bundle-changing Dependabot PR would fail that
+        # required check (the rebuilt bundle changes what users receive, but
+        # the bot never bumps package.json). Token-split invariant: NO pnpm
+        # and NO install in this job — dependency lifecycle code must never
+        # run with the write token — so the edits below are plain `node -e`
+        # plus the repo-owned, dependency-free sync script.
         if: needs.rebuild.outputs.changed == 'true'
         run: |
+          set -euo pipefail
+          # Same fork-point semantics as version-guard: compare package.json's
+          # version field between the merge-base with origin/main and HEAD.
+          git fetch --no-tags --quiet origin +refs/heads/main:refs/remotes/origin/main
           BASE="$(git merge-base origin/main HEAD)"
           OLDV="$(git show "${BASE}:package.json" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).version))')"
           NEWV="$(node -p "require('./package.json').version")"
           if [ "$OLDV" != "$NEWV" ]; then
-            echo "Version already bumped on this branch (${OLDV} -> ${NEWV}) — skipping auto-bump."
+            echo "Version already bumped vs fork point (${OLDV} -> ${NEWV}) — skipping auto-bump."
             exit 0
           fi
           node -e '
             const fs = require("fs");
             const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
-            const [maj, min, pat] = pkg.version.split(".").map(Number);
-            pkg.version = [maj, min, pat + 1].join(".");
+            const p = pkg.version.split(".");
+            p[2] = String(Number(p[2]) + 1);
+            pkg.version = p.join(".");
             fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
-            console.log("package.json: " + [maj, min, pat].join(".") + " -> " + pkg.version);
+            console.log("Auto-bumped version to " + pkg.version);
           '
           node scripts/sync-plugin-version.mjs
-          node -e '
+          NEWV="$(node -p "require('./package.json').version")" node -e '
             const fs = require("fs");
-            const v = require("./package.json").version;
+            const v = process.env.NEWV;
             const date = new Date().toISOString().slice(0, 10);
+            const entry = "## [" + v + "] - " + date + "\n### Changed\n- Dependency bump via Dependabot; committed bundle rebuilt. (automated)\n";
             const cl = fs.readFileSync("CHANGELOG.md", "utf8");
             const marker = "## [Unreleased]";
             const i = cl.indexOf(marker);
-            if (i === -1) { console.error("CHANGELOG.md: no [Unreleased] section"); process.exit(1); }
-            const entry = "## [" + v + "] - " + date + "\n\n### Changed\n\n- Dependency bump via Dependabot; committed bundle rebuilt. (automated)";
+            if (i === -1) { console.error("no [Unreleased] section in CHANGELOG.md"); process.exit(1); }
             const at = i + marker.length;
-            fs.writeFileSync("CHANGELOG.md", cl.slice(0, at) + "\n\n" + entry + cl.slice(at));
-            console.log("CHANGELOG.md: added entry for " + v);
+            const rest = cl.slice(at).replace(/^\n*/, "");
+            fs.writeFileSync("CHANGELOG.md", cl.slice(0, at) + "\n\n" + entry + "\n" + rest);
+            console.log("Prepended CHANGELOG entry for " + v);
           '
           git add package.json CHANGELOG.md build .claude-plugin .agents codex .hermes-plugin .antigravity-plugin 2>/dev/null || true
 

--- a/.github/workflows/dependabot-rebuild.yml
+++ b/.github/workflows/dependabot-rebuild.yml
@@ -76,7 +76,7 @@ jobs:
       built_from: ${{ steps.head.outputs.sha }}
     steps:
       - name: Checkout PR head branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           persist-credentials: false
@@ -105,7 +105,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.guard.outputs.skip != 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: "pnpm"
@@ -158,9 +158,12 @@ jobs:
     steps:
       - name: Checkout PR head branch
         if: needs.rebuild.outputs.changed == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          # Full history: the auto-bump step below compares the version field
+          # against the fork point (merge-base with origin/main).
+          fetch-depth: 0
 
       - name: Abort if the branch moved since the rebuild
         if: needs.rebuild.outputs.changed == 'true'
@@ -191,6 +194,47 @@ jobs:
         with:
           name: rebuilt-bundle
           path: build/
+
+      - name: Auto-bump patch version for shipped-byte change
+        # version-guard now treats build/** as SHIPPED BYTES: the rebuilt
+        # bundle changes what npm users receive, so without this bump every
+        # bundle-changing Dependabot PR would fail the require-version-bump
+        # check (and, worse, merge without ever publishing). Token-split
+        # invariant: this job must run NO dependency lifecycle code, so the
+        # bump is done with bare `node -e` edits + the repo-owned dep-free
+        # sync script — no pnpm, no install.
+        if: needs.rebuild.outputs.changed == 'true'
+        run: |
+          BASE="$(git merge-base origin/main HEAD)"
+          OLDV="$(git show "${BASE}:package.json" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).version))')"
+          NEWV="$(node -p "require('./package.json').version")"
+          if [ "$OLDV" != "$NEWV" ]; then
+            echo "Version already bumped on this branch (${OLDV} -> ${NEWV}) — skipping auto-bump."
+            exit 0
+          fi
+          node -e '
+            const fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const [maj, min, pat] = pkg.version.split(".").map(Number);
+            pkg.version = [maj, min, pat + 1].join(".");
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+            console.log("package.json: " + [maj, min, pat].join(".") + " -> " + pkg.version);
+          '
+          node scripts/sync-plugin-version.mjs
+          node -e '
+            const fs = require("fs");
+            const v = require("./package.json").version;
+            const date = new Date().toISOString().slice(0, 10);
+            const cl = fs.readFileSync("CHANGELOG.md", "utf8");
+            const marker = "## [Unreleased]";
+            const i = cl.indexOf(marker);
+            if (i === -1) { console.error("CHANGELOG.md: no [Unreleased] section"); process.exit(1); }
+            const entry = "## [" + v + "] - " + date + "\n\n### Changed\n\n- Dependency bump via Dependabot; committed bundle rebuilt. (automated)";
+            const at = i + marker.length;
+            fs.writeFileSync("CHANGELOG.md", cl.slice(0, at) + "\n\n" + entry + cl.slice(at));
+            console.log("CHANGELOG.md: added entry for " + v);
+          '
+          git add package.json CHANGELOG.md build .claude-plugin .agents codex .hermes-plugin .antigravity-plugin 2>/dev/null || true
 
       - name: Commit and push the rebuilt bundle
         if: needs.rebuild.outputs.changed == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,15 @@
+# ┌─────────────────────────── RENAME HAZARD ───────────────────────────┐
+# │ Three names in this pipeline are LOAD-BEARING COUPLINGS:            │
+# │  1. This FILE's name (publish.yml) is the npm Trusted Publisher     │
+# │     key — rename it and OIDC publishing breaks (photos hit this:    │
+# │     auto-release.yml had to be renamed to match).                   │
+# │  2. `workflows: [CI]` below matches ci.yml's `name:` — retitle CI   │
+# │     and this workflow never fires again (the daily schedule below   │
+# │     is the safety net that turns that silent break into a loud one).│
+# │  3. ci.yml's `test` job + matrix [22, 24] produce the required      │
+# │     branch-protection contexts `test (22)` / `test (24)` — rename   │
+# │     the job or matrix and merges block on phantom checks.           │
+# └─────────────────────────────────────────────────────────────────────┘
 name: Publish to npm
 
 on:
@@ -7,14 +19,24 @@ on:
     workflows: [CI]
     types: [completed]
     branches: [main]
+  # Manual retry for a stranded publish (e.g. CI flake recovered by
+  # re-dispatching CI, whose green run a workflow_run trigger would
+  # otherwise accept only for `push` events).
+  workflow_dispatch:
+  # Daily watchdog: retries any pending publish (version on main absent from
+  # npm) and self-heals a missed GitHub Release. Converts every silent
+  # never-publish variant — severed trigger coupling, race, transient npm or
+  # gh failure — into automatic recovery within 24h, or a RED run (email)
+  # when recovery fails. Runs read-only when nothing is pending.
+  schedule:
+    - cron: "17 9 * * *"
 
-# Each release lands two pushes on main (the PR merge commit, then the
-# `chore(release)` version-bump commit), so two CI runs complete and each
-# triggers a publish. Without serialization they race: both read the
-# pre-publish version, both attempt `npm publish`, and the loser fails with a
-# 403 "cannot publish over existing version" (noisy failure emails). A
-# concurrency group serializes them; the second then sees the version already
-# published and skips cleanly.
+# Each release can land multiple pushes on main in quick succession, so
+# multiple CI runs complete and each triggers a publish. Without
+# serialization they race: both read the pre-publish version, both attempt
+# publish, and the loser fails with a 403 "cannot publish over existing
+# version" (noisy failure emails). A concurrency group serializes them; the
+# later run then sees the version already published and skips cleanly.
 concurrency:
   group: publish-to-npm
   cancel-in-progress: false
@@ -24,36 +46,53 @@ jobs:
     runs-on: macos-latest
     if: >
       (github.event_name == 'release') ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'schedule') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
+        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch'))
     permissions:
       id-token: write
       contents: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Checkout repository (the CI-validated commit, not a moving ref)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # For workflow_run, check out exactly the commit CI validated —
+          # otherwise a push landing between CI completion and this checkout
+          # publishes bytes (and provenance, and a Release tag) that no CI
+          # run ever saw. Other events check out their natural ref
+          # (main for schedule/dispatch, the tag for release).
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
-      - name: Check if version is already published
+      - name: Check if this exact version is already published
         id: check
+        # Exact-version existence (`npm view pkg@version`), NOT latest-equality:
+        # immune to the registry's `latest` CDN lag, and a manual Release
+        # created for an old version is a clean no-op instead of a re-publish
+        # attempt.
         run: |
+          PKG=$(node -p "require('./package.json').name")
           LOCAL_VERSION=$(node -p "require('./package.json').version")
-          PUBLISHED_VERSION=$(npm view apple-mail-mcp version 2>/dev/null || echo "0.0.0")
+          EXISTS=$(npm view "${PKG}@${LOCAL_VERSION}" version 2>/dev/null || echo "")
+          echo "pkg=$PKG" >> "$GITHUB_OUTPUT"
           echo "local=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
-          echo "published=$PUBLISHED_VERSION" >> "$GITHUB_OUTPUT"
-          if [ "$LOCAL_VERSION" = "$PUBLISHED_VERSION" ]; then
+          if [ -n "$EXISTS" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "${PKG}@${LOCAL_VERSION} is already on npm — nothing to publish."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "${PKG}@${LOCAL_VERSION} is not on npm — publishing."
           fi
 
       - name: Install dependencies
@@ -74,33 +113,34 @@ jobs:
 
       - name: Publish to npm (pnpm + OIDC trusted publishing)
         if: steps.check.outputs.skip == 'false'
-        # Phase 2 of the pnpm migration: release via `pnpm publish` (Phase 1 still
-        # used `npm publish`). `--no-git-checks` skips pnpm's clean-tree/branch
-        # guard, which CI does not satisfy. The read-only `npm view` version checks
-        # below stay on npm (provided by setup-node).
+        # `pnpm publish` does the OIDC exchange + provenance (no token).
+        # `--no-git-checks` skips pnpm's clean-tree/branch guard, which CI
+        # does not satisfy.
         #
-        # Tolerate the publish race: a release pushes two commits, so two CI runs
-        # complete and each triggers a publish. The concurrency group serializes
-        # them, but npm's registry read (`npm view`, CDN-cached) lags the write,
-        # so the second run's "already published?" check can still see the old
-        # version, attempt to publish, and get a 403 for the version the first
-        # run just pushed. Treat that specific case as success.
+        # Tolerate the publish race: the concurrency group serializes runs,
+        # but npm's registry read lags the write, so a later run's existence
+        # check can miss the version a concurrent run just pushed, attempt to
+        # publish, and get a 403. Re-check and treat that case as success.
         run: |
           if pnpm publish --provenance --no-git-checks; then
             echo "Published."
           else
-            LOCAL=$(node -p "require('./package.json').version")
-            PUBLISHED=$(npm view apple-mail-mcp version 2>/dev/null || echo "")
-            if [ "$PUBLISHED" = "$LOCAL" ]; then
-              echo "Version $LOCAL is already on npm (published by a concurrent run); treating as success."
+            PKG="${{ steps.check.outputs.pkg }}"
+            LOCAL="${{ steps.check.outputs.local }}"
+            NOW_EXISTS=$(npm view "${PKG}@${LOCAL}" version 2>/dev/null || echo "")
+            if [ -n "$NOW_EXISTS" ]; then
+              echo "${PKG}@${LOCAL} is already on npm (published by a concurrent run); treating as success."
             else
-              echo "::error::pnpm publish failed and $LOCAL is not on npm."
+              echo "::error::pnpm publish failed and ${PKG}@${LOCAL} is not on npm."
               exit 1
             fi
           fi
 
-      - name: Create GitHub Release (keep Releases in sync with npm)
-        if: steps.check.outputs.skip == 'false'
+      - name: Sync GitHub Release (self-healing — runs on every trigger)
+        # Deliberately NOT gated on the skip flag: idempotent via
+        # `gh release view`, so a Release missed by a transient failure in an
+        # earlier run is healed by ANY later run, including the daily
+        # schedule.
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -111,7 +151,7 @@ jobs:
             NOTES=$(awk -v v="## [$VERSION]" 'index($0,v)==1{p=1;next} p&&/^## \[/{exit} p' CHANGELOG.md)
             [ -z "$NOTES" ] && NOTES="Published to npm as v$VERSION."
             gh release create "v$VERSION" --target "$(git rev-parse HEAD)" --title "v$VERSION" --notes "$NOTES" \
-              || echo "::warning::Failed to create GitHub Release v$VERSION (npm publish still succeeded)"
+              || echo "::warning::Failed to create GitHub Release v$VERSION (will self-heal on the next run)"
           fi
 
       - name: Skip publish (version already published)

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write # publish results to the OpenSSF API (badge)
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -33,13 +33,13 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,15 +1,21 @@
 name: version-guard
 
-# Fail any PR to main that changes SHIPPED CODE without bumping package.json's
-# version. Shipped code = src/** (non-test), requirements.txt, and the RUNTIME
-# `dependencies` map in package.json — runtime deps are inlined into the
-# committed esbuild bundle, so bumping one changes shipped bytes too (rule
-# added 2026-07-15 alongside dependabot-rebuild.yml; previously a merged
-# runtime-dep bump silently never reached npm). Docs-only, test-only, dev-dep
-# and github-actions bumps stay exempt. Rationale: publish.yml only runs
-# `pnpm publish` when the version differs from npm, so an un-bumped code
-# change would silently never release. This makes the bump mandatory. The
-# guard file itself lives in .github/ (doesn't ship), so it needs no bump.
+# Fail any PR to main that changes SHIPPED BYTES without bumping package.json's
+# version. Shipped bytes = the committed esbuild bundle under build/** (it IS
+# what npm and marketplace users run), plus src/** (non-test) and
+# requirements.txt as first-cause detectors with better error messages, plus
+# the RUNTIME `dependencies` map in package.json. build/** was added
+# 2026-07-20: it subsumes every cause that changes what users receive — direct
+# deps, lockfile-only transitive bumps, and esbuild codegen changes — none of
+# which the src/deps detectors could see (a lockfile-only runtime-dep bump
+# merged un-bumped on 2026-07-15 and sat unshipped for two days).
+# Docs-only, test-only, and github-actions changes stay exempt; byte-neutral
+# devDependency bumps stay exempt because they leave build/ untouched.
+# Rationale: publish.yml only publishes when the version is absent from npm,
+# so an un-bumped shipped-byte change silently never releases. This guard
+# makes the bump mandatory; dependabot-rebuild.yml auto-bumps bot PRs whose
+# rebuilt bundle changed, so Dependabot automation keeps flowing.
+# The guard file itself lives in .github/ (doesn't ship), so it needs no bump.
 
 on:
   pull_request:
@@ -27,11 +33,11 @@ jobs:
   require-version-bump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - name: Require a version bump when shipped code changes
+      - name: Require a version bump when shipped bytes change
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -51,15 +57,17 @@ jobs:
           changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
           echo "Changed files:"; printf '%s\n' "$changed" | sed 's/^/  /'
 
-          # Shipped-code paths: TS/JS sources and python sidecars under src/ (minus
-          # tests/mocks), plus the python dependency manifest. build/ is generated.
+          # Shipped bytes: the committed bundle itself (build/**), plus source
+          # and the python dependency manifest (minus tests/mocks) as
+          # first-cause detectors.
           code="$(printf '%s\n' "$changed" \
-            | grep -E '^(src/.*|requirements\.txt)$' \
+            | grep -E '^(src/.*|requirements\.txt|build/.*)$' \
             | grep -vE '(\.test\.ts$|\.spec\.ts$|/__tests__/|/__mocks__/)' || true)"
 
           # Runtime deps are shipped code too: they are inlined into the
           # committed bundle. Compare only the `dependencies` map —
-          # devDependencies stay exempt so dev-dep automerge is unaffected.
+          # devDependencies stay exempt so dev-dep automerge is unaffected
+          # (a devDep bump that changes the bundle is caught by build/**).
           deps_changed=""
           if printf '%s\n' "$changed" | grep -qx 'package.json'; then
             old_deps="$(git show "${BASE_SHA}:package.json" | jq -cS '.dependencies // {}')"
@@ -72,34 +80,50 @@ jobs:
             fi
           fi
 
-          if [ -z "$code" ] && [ -z "$deps_changed" ]; then
-            echo "::notice::No shipped-code changes — version bump not required."
-            exit 0
-          fi
-          if [ -n "$code" ]; then
-            echo "Shipped-code changes detected:"; printf '%s\n' "$code" | sed 's/^/  /'
-          fi
-
           oldv="$(git show "${BASE_SHA}:package.json" \
             | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).version))')"
           newv="$(node -e 'console.log(require("./package.json").version)')"
           echo "package.json version: base=${oldv}  head=${newv}"
 
+          if [ "$oldv" != "$newv" ]; then
+            # Bump present: require it to be an increase (typo'd downgrades)…
+            OLDV="$oldv" NEWV="$newv" node -e '
+              const a = process.env.OLDV.split(".").map(Number);
+              const b = process.env.NEWV.split(".").map(Number);
+              const cmp = (b[0]-a[0]) || (b[1]-a[1]) || (b[2]-a[2]);
+              if (cmp > 0) { console.log("Version bumped " + process.env.OLDV + " -> " + process.env.NEWV + "."); process.exit(0); }
+              console.error("::error::package.json version went " + process.env.OLDV + " -> " + process.env.NEWV + " (not an increase). Bump it forward.");
+              process.exit(1);
+            '
+            # …and require it to be UNPUBLISHED. Two concurrently-open PRs can
+            # each bump to the same next patch; without this, the second merge
+            # is a version collision publish.yml silently skips. Registry
+            # errors fail open (a registry outage must not block merges).
+            PKG="$(node -p "require('./package.json').name")"
+            set +e
+            existing="$(npm view "${PKG}@${newv}" version 2>/dev/null)"
+            set -e
+            if [ -n "$existing" ]; then
+              echo "::error::${PKG}@${newv} is already published on npm — this bump collides with an existing release (another PR likely claimed it first). Rebase on main and bump again:  pnpm version patch --no-git-tag-version"
+              exit 1
+            fi
+            echo "${PKG}@${newv} is unclaimed on npm."
+          fi
+
+          if [ -z "$code" ] && [ -z "$deps_changed" ]; then
+            echo "::notice::No shipped-byte changes — version bump not required."
+            exit 0
+          fi
+          if [ -n "$code" ]; then
+            echo "Shipped-byte changes detected:"; printf '%s\n' "$code" | sed 's/^/  /'
+          fi
+
           if [ "$oldv" = "$newv" ]; then
             if [ -n "$deps_changed" ]; then
               echo "::error::Runtime dependencies changed (the shipped bundle changes) but package.json version is unchanged (${oldv}). Bump at least a patch + add a CHANGELOG entry so publish.yml actually ships the dependency update:  pnpm version patch --no-git-tag-version"
             else
-              echo "::error::Shipped code changed but package.json version is unchanged (${oldv}). Bump it at least a patch:  pnpm version patch --no-git-tag-version  (and add a CHANGELOG entry)."
+              echo "::error::Shipped bytes changed (src/, requirements.txt, or the committed build/ bundle) but package.json version is unchanged (${oldv}). Bump it at least a patch:  pnpm version patch --no-git-tag-version  (and add a CHANGELOG entry)."
             fi
             exit 1
           fi
-
-          # Guard against a typo'd downgrade — require the new version to be greater.
-          OLDV="$oldv" NEWV="$newv" node -e '
-            const a = process.env.OLDV.split(".").map(Number);
-            const b = process.env.NEWV.split(".").map(Number);
-            const cmp = (b[0]-a[0]) || (b[1]-a[1]) || (b[2]-a[2]);
-            if (cmp > 0) { console.log("Version bumped " + process.env.OLDV + " -> " + process.env.NEWV + "."); process.exit(0); }
-            console.error("::error::package.json version went " + process.env.OLDV + " -> " + process.env.NEWV + " (not an increase). Bump it forward.");
-            process.exit(1);
-          '
+          echo "Shipped bytes changed and version is bumped — OK."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,12 +1,8 @@
-set -e
-
 pnpm exec lint-staged
-
-# Marketplace path-source plugins are git-cloned without `pnpm install`, so the
-# `build/` artifacts must be committed for the plugin to work after install.
-# Keep them fresh: if any staged file is under src/, rebuild and stage build/.
-if git diff --cached --name-only --diff-filter=ACMR | grep -q '^src/'; then
-  echo "src/ changed — rebuilding build/ for plugin distribution"
-  pnpm --silent run build
+# Rebuild the committed bundle when shipped inputs are staged, so a stale
+# build/ can never be committed alongside source (CI's verify step would
+# fail the PR otherwise).
+if git diff --cached --name-only | grep -qE '^(src/|package\.json$|pnpm-lock\.yaml$)'; then
+  pnpm run build
   git add build
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.12] - 2026-07-20
+
+### Changed
+
+- CI/release hardening: `version-guard` now treats the committed `build/` bundle as shipped bytes (closing the lockfile-only and devDep silent-never-publish vectors) with an npm version-collision check; `publish.yml` gained a daily self-healing watchdog, manual dispatch, exact-version skip, CI-validated-commit checkout, and GitHub-Release self-heal; Dependabot bundle rebuilds now auto-bump a patch version; CI boots the committed bundle standalone on Node 20 every run; the bundle is now built with `--target=node20`, making the `engines.node >= 20` claim enforced at build time.
+
 ## [2.8.11] - 2026-07-18
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,10 @@ Thank you for your interest in contributing! This document provides guidelines f
 
 2. **Install dependencies**
    ```bash
-   pnpm install
+   corepack enable && pnpm install --frozen-lockfile
    ```
 
-   This repo pins pnpm via `packageManager` in `package.json` — `corepack enable` provides it. Development needs Node >= 22.13 (CI tests on Node 22 and 24); the published server itself runs on Node >= 20.
+   This repo pins pnpm via `packageManager` in `package.json` — `corepack enable` provides it. Development needs Node >= 22.13 (CI tests on Node 22 and 24); the published server itself runs on Node >= 20. A `preinstall` guard rejects `npm install`/`yarn` in a git checkout: they resolve dependencies off-lockfile, so the committed bundle would mismatch CI.
 
 3. **Build the project**
    ```bash
@@ -24,7 +24,8 @@ Thank you for your interest in contributing! This document provides guidelines f
 
 4. **Run tests**
    ```bash
-   pnpm test
+   pnpm test                 # unit tests (fast, no Mail.app needed)
+   pnpm run test:integration # live Mail.app interaction (requires a configured macOS Mail.app)
    ```
 
 ## Code Style
@@ -32,22 +33,15 @@ Thank you for your interest in contributing! This document provides guidelines f
 This project uses ESLint and Prettier for code quality and formatting.
 
 ```bash
-# Check for linting issues
-pnpm run lint
-
-# Auto-fix linting issues
-pnpm run lint:fix
-
-# Format code
-pnpm run format
-
-# Check formatting
+pnpm run lint        # check
+pnpm run lint:fix    # auto-fix
+pnpm run format      # format
 pnpm run format:check
 ```
 
 ## Testing
 
-All new features should include tests. We use Vitest for testing.
+All new features should include tests. We use Vitest.
 
 ```bash
 # Run unit tests
@@ -91,36 +85,19 @@ A green CI run alone does not exercise the live Mail.app behavior.
 
 ## Pull Request Process
 
-1. **Create a feature branch**
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
+1. Create a feature branch (`git checkout -b feature/your-feature-name`).
+2. Make your changes — follow the existing style, add JSDoc, add tests.
+3. Run all checks: `pnpm run lint && pnpm run typecheck && pnpm run format:check && pnpm test && pnpm run build`.
+4. Make sure your PR satisfies everything in "What CI requires of your PR" below.
+5. Commit with clear messages referencing any related issues.
+6. Push and open a PR describing what it does and linking related issues.
 
-2. **Make your changes**
-   - Follow the existing code style
-   - Add JSDoc comments for new functions
-   - Add tests for new functionality
+## What CI requires of your PR
 
-3. **Run all checks**
-   ```bash
-   pnpm run lint
-   pnpm run typecheck
-   pnpm run format:check
-   pnpm test
-   pnpm run build
-   ```
-
-4. **Version bump & committed bundle** (shipped-code changes only)
-   - Any change to shipped code (`src/**` excluding tests, or the runtime `dependencies` in `package.json`) must bump `package.json` at least a patch (`pnpm version patch --no-git-tag-version`) and add a CHANGELOG.md entry in the same PR — the `require-version-bump` CI check fails the PR otherwise. Docs-only and test-only PRs are exempt.
-   - The bundled `build/index.js` and `build/cli.js` are committed to git: after source changes, rebuild (`pnpm run build`) and commit the updated bundle alongside `src/` — CI verifies the committed bundle matches the source.
-
-5. **Commit your changes**
-   - Use clear, descriptive commit messages
-   - Reference any related issues
-
-6. **Push and create a PR**
-   - Describe what your PR does
-   - Link any related issues
+- **Patch bump + CHANGELOG for shipped code.** Any change to shipped bytes (`src/**` excluding tests, the runtime `dependencies` in `package.json`, or the committed `build/` bundle) must bump `package.json` at least a patch (`pnpm version patch --no-git-tag-version`) and add a CHANGELOG.md entry in the same PR — the `require-version-bump` check fails the PR otherwise. Docs-only and test-only PRs are exempt.
+- **Committed, rebuilt `build/`.** The bundled `build/index.js` and `build/cli.js` are committed to git: after source changes, rebuild (`pnpm run build`) and commit the updated bundle alongside `src/` — CI verifies the committed bundle matches the source and boots it standalone on Node 20.
+- **Prettier-clean.** `pnpm run format:check` must pass (CI gates formatting separately from lint).
+- **Tests green.** `pnpm test` must pass on Node 22 and 24; run the integration suite locally for AppleScript-path changes (see above).
 
 ## Adding New Tools
 

--- a/build/index.js
+++ b/build/index.js
@@ -58296,7 +58296,7 @@ var require_imap_flow = __commonJS({
         );
         for (let key of Object.keys(this.clientInfo)) {
           if (typeof this.clientInfo[key] === "string") {
-            this.clientInfo[key] = this.clientInfo[key].normalize("NFD").replace(/\p{Diacritic}/gu, "");
+            this.clientInfo[key] = this.clientInfo[key].normalize("NFD").replace(new RegExp("\\p{Diacritic}", "gu"), "");
           }
         }
         this.serverInfo = null;

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.11",
+  "version": "2.8.12",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.8.11",
+  "version": "2.8.12",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",
@@ -16,7 +16,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc --noEmit && esbuild src/index.ts src/cli.ts --bundle --platform=node --format=esm --outdir=build --banner:js=\"import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);\"",
+    "preinstall": "node -e \"const fs=require('fs');const ua=process.env.npm_config_user_agent||'';if(fs.existsSync('.git')&&!ua.startsWith('pnpm')){console.error('\\nThis repo uses pnpm. npm/yarn resolve dependencies off-lockfile and the committed bundle will mismatch CI.\\n\\n  corepack enable && pnpm install --frozen-lockfile\\n');process.exit(1)}\"",
+    "build": "tsc --noEmit && esbuild src/index.ts src/cli.ts --bundle --platform=node --format=esm --target=node20 --outdir=build --banner:js=\"import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);\"",
     "start": "node build/index.js",
     "dev": "tsc --watch",
     "test": "vitest run",

--- a/scripts/sync-plugin-version.mjs
+++ b/scripts/sync-plugin-version.mjs
@@ -1,9 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
 
+// Syncs every plugin manifest's version to package.json's version.
+// With --check: writes nothing — exits 0 silently when every manifest already
+// matches, exits 1 listing the mismatched files (used by CI to catch drift).
 const root = process.cwd();
+const checkMode = process.argv.includes("--check");
 const packageJson = readJson("package.json");
 const version = packageJson.version;
+const mismatches = [];
 
 updateJson(".claude-plugin/plugin.json", (data) => {
   data.version = version;
@@ -42,13 +47,31 @@ updateJson(".antigravity-plugin/marketplace.json", (data) => {
   }
 });
 
+if (checkMode && mismatches.length > 0) {
+  console.error(
+    `Plugin manifest version(s) do not match package.json (${version}) — run: node scripts/sync-plugin-version.mjs`,
+  );
+  for (const m of mismatches) {
+    console.error(`  ${m}`);
+  }
+  process.exit(1);
+}
+
 function readJson(relativePath) {
   return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8"));
 }
 
 function updateJson(relativePath, update) {
   const fullPath = path.join(root, relativePath);
-  const data = readJson(relativePath);
+  const original = fs.readFileSync(fullPath, "utf8");
+  const data = JSON.parse(original);
   update(data);
-  fs.writeFileSync(fullPath, `${JSON.stringify(data, null, 2)}\n`);
+  const next = `${JSON.stringify(data, null, 2)}\n`;
+  if (checkMode) {
+    if (next !== original) {
+      mismatches.push(relativePath);
+    }
+    return;
+  }
+  fs.writeFileSync(fullPath, next);
 }


### PR DESCRIPTION
CI-hardening change set for apple-mail-mcp, applied from the canonical 2026-07-20 audit spec (one PR per repo; branch `ci/bulletproof-hardening`).

## What changed

- **version-guard.yml** (canonical, verbatim): `build/**` now counts as **shipped bytes** — subsumes lockfile-only transitive bumps, devDep bumps that change the bundle, and esbuild codegen changes, none of which the old src/deps detectors could see. Also: the bump must be an increase, and a bumped version must be **unpublished on npm** (collision check between concurrently-open PRs; registry errors fail open).
- **publish.yml** (canonical, verbatim): RENAME HAZARD header; **daily self-healing watchdog** (cron 17:09 UTC — retries any pending publish and heals a missed GitHub Release, converting every silent never-publish variant into recovery within 24h or a red run); `workflow_dispatch` manual retry; exact-version existence skip (immune to `latest` CDN lag); `workflow_run` checks out the **CI-validated head SHA** (not a moving ref); publish-race tolerance; idempotent GitHub-Release self-heal on every trigger.
- **ci.yml**: RENAME HAZARD comment above `name: CI`; new **`bundle-boots (standalone, Node 20)`** job — copies only `package.json` + `build/` into a mktemp dir and runs the MCP `initialize` handshake with no `node_modules` on the oldest supported runtime (perl-alarm bounded; macOS runners ship no `timeout` binary); verify step now also fails on **untracked emissions into `build/`**; new "Verify plugin manifests match package.json version" step (`sync-plugin-version.mjs --check`).
- **dependabot-rebuild.yml**: the write job now **auto-bumps a patch version** when the rebuilt bundle differs and the PR hasn't bumped already (fork-point comparison à la version-guard) — bare `node -e` edits + the repo-owned dep-free sync script, **no pnpm/install in the write job** (token-split invariant preserved); prepends an automated CHANGELOG entry under `[Unreleased]`; rides the existing `[dependabot skip]` commit; existing check re-dispatch unchanged. Required because version-guard would otherwise fail every bundle-changing Dependabot PR.
- **Action pin catchup** (verified SHAs, all workflow files): checkout v7.0.1, setup-node v7.0.0, upload-artifact v7.0.1, codecov v7.0.0, codeql v4.37.1, fetch-metadata v3.1.0. `pnpm/action-setup` deliberately left at v4.4.0.
- **dependabot.yml**: github-actions block no longer ignores semver-major (Dependabot will now propose action majors; npm ignores untouched).
- **scripts/sync-plugin-version.mjs**: `--check` mode — compares, writes nothing, exit 1 listing mismatches.
- **package.json**: esbuild `--target=node20` (covers both bundles — index + cli — via the single invocation; enforces the `engines.node >= 20` claim at build time); **preinstall guard** rejecting `npm`/`yarn` installs in a git checkout (off-lockfile resolution would mismatch the committed bundle; inert in registry tarballs — no `.git`); version **2.8.11 → 2.8.12**.
- **.husky/pre-commit**: canonical hook — rebuilds + stages `build/` whenever `src/`, `package.json`, or `pnpm-lock.yaml` are staged (previously `src/` only, so a dep-only or build-flag change could commit a stale bundle).
- **CONTRIBUTING.md**: aligned to the house (numbers-repo) structure — `corepack enable && pnpm install --frozen-lockfile` flow, Node >= 22.13 dev vs `engines >= 20` runtime distinction, "What CI requires of your PR" section; mail-specific sections (test locations, before-release integration-suite note, AppleScript guidelines) kept.
- **CHANGELOG.md** + plugin manifests: 2.8.12.

## Local verification (all green, in an isolated worktree with a real frozen install)

- `pnpm run lint` / `typecheck` / `format:check` / `pnpm test` (397/397)
- `pnpm run test:integration` against the live Mail.app (47 passed, 10 skipped)
- YAML parse of every workflow file
- Standalone boot smoke exactly like the new CI job (mktemp, no node_modules) — `v2.8.12` handshake OK (pinned Node 24.17.0 locally; Node 20 exercised in CI)
- npm-guard both directions: `npm install --ignore-scripts=false` in a git checkout fails loudly on the guard; inert without `.git`; `pnpm install --frozen-lockfile` passes
- `node scripts/sync-plugin-version.mjs --check` passes (and correctly exits 1 on a perturbed manifest)
- Dependabot auto-bump node snippets dry-run (bump 2.8.12→2.8.13 + CHANGELOG insertion verified on a copy)
- Bundle determinism: post-commit rebuild → `git diff --quiet -- build/`

## Deviations from the spec (recorded per instructions)

1. **dependabot-rebuild.yml push-job checkout gained `fetch-depth: 0`** — the spec's auto-bump guard computes `git merge-base origin/main HEAD`, which a default depth-1 checkout cannot resolve. Minimal enabling change.
2. **Old pre-commit hook's `set -e` line dropped** — husky v9's shim runs hooks via `sh -e`, so it was redundant; canonical content adopted as-is.
3. **CONTRIBUTING.md "What CI requires of your PR"** — numbers' actual on-main CONTRIBUTING has that content inside the PR-process list, not as a named section; the spec names the section explicitly, so mail got the named section (content per spec).
4. **`--target=node20` changed no emitted syntax in mail's bundle** — only the inlined version string differs (Node 20 already supports everything esbuild emits here). The spec predicted changed bundle bytes; the patch bump ships regardless and the flag is now enforced going forward.
5. **vitest 3→4: n/a** — mail is already on vitest 4 (`^4.1.9`, installed 4.1.10).
6. **Local boot smoke ran on the pinned Node 24.17.0** — no Node 20 on this Mac; the spec allows the pinned-node fallback, and CI's `bundle-boots` job covers Node 20.

Do not merge until the sibling repo PRs are reviewed together (orchestrator handles merge + cleanup).
