### PR TITLE
fix: get-unread-count counts INBOX (not every mailbox) when no mailbox given

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.14",
+      "version": "2.8.15",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.14",
+      "version": "2.8.15",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.14",
+  "version": "2.8.15",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.8.14",
+  "version": "2.8.15",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.8.14",
+      "version": "2.8.15",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.14",
+  "version": "2.8.15",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.15] - 2026-07-23
+
+### Fixed
+- `get-unread-count` with no `mailbox` now counts **INBOX** instead of summing UNSEEN across every mailbox. The old sweep was both slow — a STATUS per label on a cold IMAP connection, dozens of serial round-trips that could overrun the MCP client's tool-call timeout — and **wrong on Gmail**, where one unread message simultaneously lives in INBOX, `[Gmail]/All Mail`, and each of its labels and so was counted several times over. Both backends are fixed: IMAP (`imapUnreadCount`) and AppleScript (`getUnreadCount`, which also carried the audit-#8 30s-timeout risk). INBOX is the meaningful "unread messages" figure; pass an explicit `mailbox` for any other scope. Per-account totals (no `account` given) are unaffected in shape — each account still contributes exactly once, now via its INBOX.
+
 ## [2.8.14] - 2026-07-22
 
 ### Security

--- a/build/index.js
+++ b/build/index.js
@@ -78534,20 +78534,9 @@ var AppleMailManager = class {
    */
   getUnreadCount(mailbox, account) {
     const targetAccount = this.resolveAccount(account);
-    let command;
-    if (mailbox) {
-      const targetMailbox = this.resolveMailbox(mailbox, targetAccount);
-      const safeMailbox = escapeForAppleScript(targetMailbox);
-      command = `return unread count of mailbox "${safeMailbox}"`;
-    } else {
-      command = `
-        set total to 0
-        repeat with mb in mailboxes
-          set total to total + (unread count of mb)
-        end repeat
-        return total
-      `;
-    }
+    const targetMailbox = this.resolveMailbox(mailbox || "INBOX", targetAccount);
+    const safeMailbox = escapeForAppleScript(targetMailbox);
+    const command = `return unread count of mailbox "${safeMailbox}"`;
     const script = buildAccountScopedScript(targetAccount, command);
     const result = executeAppleScript(script, { timeoutMs: 6e4 });
     if (!result.success) {
@@ -79815,19 +79804,8 @@ function imapUnreadCount(mailbox, deps = {}) {
   return useClient(
     deps,
     async (client) => {
-      if (mailbox) {
-        const s = await client.status(resolveMailboxPath(mailbox, "list"), { unseen: true });
-        return s.unseen ?? 0;
-      }
-      let total = 0;
-      for (const b of await client.list()) {
-        try {
-          const s = await client.status(b.path, { unseen: true });
-          total += s.unseen ?? 0;
-        } catch {
-        }
-      }
-      return total;
+      const s = await client.status(resolveMailboxPath(mailbox, "list"), { unseen: true });
+      return s.unseen ?? 0;
     },
     true
   );
@@ -82268,9 +82246,9 @@ ${mailboxList}`, structured);
 server.registerTool(
   "get-unread-count",
   {
-    description: "Use when: you only need the number of unread messages (optionally scoped to one mailbox and/or account), without listing the messages themselves.\nReturns: the unread count for the requested scope.\nDo not use when: you need the actual unread messages and their ids (use list-messages with unreadOnly, or search-messages with isRead=false) or broader totals (use get-mail-stats).",
+    description: "Use when: you only need the number of unread messages \u2014 INBOX by default, or scoped to one mailbox and/or account \u2014 without listing the messages themselves.\nReturns: the unread count for the requested scope (INBOX when no mailbox is given).\nDo not use when: you need the actual unread messages and their ids (use list-messages with unreadOnly, or search-messages with isRead=false) or broader totals across every mailbox (use get-mail-stats).",
     inputSchema: {
-      mailbox: external_exports.string().optional().describe("Mailbox to check (default: all)"),
+      mailbox: external_exports.string().optional().describe("Mailbox to check (default: INBOX)"),
       account: external_exports.string().optional().describe("Account to check")
     },
     outputSchema: {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.14",
+  "version": "2.8.15",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.8.14",
+  "version": "2.8.15",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1937,9 +1937,9 @@ server.registerTool(
   "get-unread-count",
   {
     description:
-      "Use when: you only need the number of unread messages (optionally scoped to one mailbox and/or account), without listing the messages themselves.\nReturns: the unread count for the requested scope.\nDo not use when: you need the actual unread messages and their ids (use list-messages with unreadOnly, or search-messages with isRead=false) or broader totals (use get-mail-stats).",
+      "Use when: you only need the number of unread messages — INBOX by default, or scoped to one mailbox and/or account — without listing the messages themselves.\nReturns: the unread count for the requested scope (INBOX when no mailbox is given).\nDo not use when: you need the actual unread messages and their ids (use list-messages with unreadOnly, or search-messages with isRead=false) or broader totals across every mailbox (use get-mail-stats).",
     inputSchema: {
-      mailbox: z.string().optional().describe("Mailbox to check (default: all)"),
+      mailbox: z.string().optional().describe("Mailbox to check (default: INBOX)"),
       account: z.string().optional().describe("Account to check"),
     },
     outputSchema: {
@@ -1950,8 +1950,11 @@ server.registerTool(
   },
   withErrorHandling(async ({ mailbox, account }) => {
     // IMAP (I4): STATUS (UNSEEN) is authoritative and fast even on huge
-    // mailboxes. Prefer-IMAP (v2.6.0). Counts are ACCOUNT-CENTRIC so each account
-    // is counted exactly once even if the coverage heuristic mis-matches:
+    // mailboxes. Prefer-IMAP (v2.6.0). No mailbox → each account's INBOX (the
+    // meaningful "unread" figure; summing every mailbox was slow and, on Gmail,
+    // counted one unread message once per label + All Mail). Counts are
+    // ACCOUNT-CENTRIC so each account is counted exactly once even if the
+    // coverage heuristic mis-matches:
     //   - explicit IMAP account → IMAP UNSEEN for that account;
     //   - no account + IMAP configured → planCountSources assigns each account
     //     ONE source (its matching IMAP config, else AppleScript) and counts any

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -2949,25 +2949,16 @@ export class AppleMailManager {
   getUnreadCount(mailbox?: string, account?: string): number {
     const targetAccount = this.resolveAccount(account);
 
-    let command: string;
-    if (mailbox) {
-      const targetMailbox = this.resolveMailbox(mailbox, targetAccount);
-      const safeMailbox = escapeForAppleScript(targetMailbox);
-      command = `return unread count of mailbox "${safeMailbox}"`;
-    } else {
-      // Get total unread across all mailboxes
-      command = `
-        set total to 0
-        repeat with mb in mailboxes
-          set total to total + (unread count of mb)
-        end repeat
-        return total
-      `;
-    }
+    // No mailbox → INBOX. Summing unread across every mailbox was slow (audit
+    // #8: could exceed 30s and then degrade silently to 0 = "all read") and
+    // wrong on Gmail, where one unread message also lives in All Mail and each
+    // of its labels and got counted several times. INBOX is the meaningful
+    // "unread messages" figure; this mirrors an explicit mailbox:"INBOX".
+    const targetMailbox = this.resolveMailbox(mailbox || "INBOX", targetAccount);
+    const safeMailbox = escapeForAppleScript(targetMailbox);
+    const command = `return unread count of mailbox "${safeMailbox}"`;
 
     const script = buildAccountScopedScript(targetAccount, command);
-    // Summing unread across every mailbox can exceed the default 30s; a timeout
-    // previously degraded silently to 0 ("all read") — audit finding #8.
     const result = executeAppleScript(script, { timeoutMs: 60000 });
 
     if (!result.success) {

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -813,13 +813,14 @@ describe("STATUS-based counts (I3/I4/I6)", () => {
     expect(n).toBe(7);
   });
 
-  it("imapUnreadCount sums UNSEEN across all mailboxes when none given", async () => {
+  it("imapUnreadCount defaults to INBOX (no cross-mailbox double-count) when none given", async () => {
     const n = await imapUnreadCount(undefined, {
       config: cfg,
       connect: async () =>
         statusClient({ INBOX: { unseen: 7 }, "[Gmail]/Sent Mail": { unseen: 2 } }),
     });
-    expect(n).toBe(9);
+    // INBOX only — the old sum-all behaviour double-counted Gmail labels/All Mail.
+    expect(n).toBe(7);
   });
 
   it("imapListMailboxes returns per-mailbox message/unseen counts", async () => {

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -568,25 +568,22 @@ export function imapListMessages(
 // AppleScript on large mailboxes (where the per-message walk times out, #8/#24).
 // ===========================================================================
 
-/** Unread count via IMAP STATUS (UNSEEN). No mailbox → sum across all mailboxes. */
+/**
+ * Unread count via IMAP STATUS (UNSEEN). No mailbox → INBOX.
+ *
+ * This used to sum UNSEEN across every mailbox, which was both slow — a STATUS
+ * per label on a cold pooled connection, dozens of serial round-trips that
+ * overran the MCP client's tool-call timeout — and WRONG on Gmail, where one
+ * unread message simultaneously lives in INBOX, [Gmail]/All Mail, and each of
+ * its labels and so got counted several times over. INBOX is the meaningful
+ * "unread messages" figure; pass `mailbox` for any other scope.
+ */
 export function imapUnreadCount(mailbox: string | undefined, deps: ImapDeps = {}): Promise<number> {
   return useClient(
     deps,
     async (client) => {
-      if (mailbox) {
-        const s = await client.status(resolveMailboxPath(mailbox, "list"), { unseen: true });
-        return s.unseen ?? 0;
-      }
-      let total = 0;
-      for (const b of await client.list()) {
-        try {
-          const s = await client.status(b.path, { unseen: true });
-          total += s.unseen ?? 0;
-        } catch {
-          // skip mailboxes that can't be STATUS'd (e.g. \Noselect parents)
-        }
-      }
-      return total;
+      const s = await client.status(resolveMailboxPath(mailbox, "list"), { unseen: true });
+      return s.unseen ?? 0;
     },
     true
   );


### PR DESCRIPTION
## Problem

`get-unread-count` with no `mailbox` summed `UNSEEN` across **every** mailbox. That was:

- **Slow** — a `STATUS` per label on a cold IMAP connection, dozens of serial round-trips that could overrun the MCP client's 10s tool-call timeout (this is what surfaced the bug: the call kept timing out under normal use).
- **Wrong on Gmail** — one unread message simultaneously lives in `INBOX`, `[Gmail]/All Mail`, and each of its labels, so it was counted several times over. The AppleScript backend had the same shape (plus the audit-#8 30s-timeout-degrades-to-0 risk).

## Fix

Both backends now count **INBOX** when no mailbox is given — the meaningful "unread messages" figure, and exactly what an explicit `mailbox:"INBOX"` already returned:

- IMAP: `imapUnreadCount(undefined)` → `STATUS INBOX` (collapses to the existing single-mailbox path).
- AppleScript: `getUnreadCount(undefined)` → `unread count of mailbox "INBOX"` (retires the all-mailboxes sweep).

Pass an explicit `mailbox` for any other scope (e.g. `[Gmail]/All Mail` for a deduped everything-total). The no-`account` fan-out is unchanged in shape — each account still contributes exactly once, now via its INBOX.

## Validation (live Gmail)

| call | old | new |
|------|-----|-----|
| no-mailbox, `rob@superiortech.io` | **132** (sum across all mailboxes) | **0** (INBOX) |
| explicit `INBOX` | 0 | 0 |
| explicit `[Gmail]/All Mail` | 74 | 74 |

The old **132** was archived/labeled/Sent unread masquerading as inbox unread (All Mail alone held 74). New path returns the correct **0** in ~0.5s warm. AppleScript INBOX resolution verified against a real Gmail account in Mail.app.

- `typecheck` / `lint` / `format:check` clean
- 397 unit tests pass (the `imapUnreadCount` no-arg test now asserts INBOX, documenting the no-double-count behavior)
- committed bundle rebuilt and confirmed reproducible

Patch bump **2.8.15** + CHANGELOG included.
