### PR TITLE
fix: force-close pooled IMAP sockets to stop the CLOSE_WAIT leak

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.15",
+      "version": "2.8.16",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.15",
+      "version": "2.8.16",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.15",
+  "version": "2.8.16",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.8.15",
+  "version": "2.8.16",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.8.15",
+      "version": "2.8.16",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.15",
+  "version": "2.8.16",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.16] - 2026-07-23
+
+### Fixed
+- **IMAP connection leak.** The pool released a dropped connection with only a graceful `logout()`, which can't complete once the server (Gmail) has already half-closed the socket — the FD then lingered in `CLOSE_WAIT` and, over hours of idle-timeout/reconnect churn, accumulated against Gmail's ~15-connections-per-account cap (observed ~10 `ESTABLISHED` + 12 `CLOSE_WAIT` to Gmail per long-lived server instance, the real source of the intermittent "cannot connect" cap pressure). `dropPool` and the per-call connect path now force-close the socket via `ImapFlow.close()` after the logout attempt, so the connection is torn down unconditionally even when the graceful path throws.
+
 ## [2.8.15] - 2026-07-23
 
 ### Fixed

--- a/build/index.js
+++ b/build/index.js
@@ -79895,6 +79895,7 @@ async function dropPool(key) {
   if (e.idle) clearTimeout(e.idle);
   pools.delete(key);
   await e.client.logout().catch(() => void 0);
+  e.client.close?.();
 }
 async function dropAllPools() {
   await Promise.all([...pools.keys()].map((k) => dropPool(k)));
@@ -79968,6 +79969,7 @@ async function useClient(deps, fn, retryOnDrop = false) {
       return await fn(client, cfg);
     } finally {
       await client.logout().catch(() => void 0);
+      client.close?.();
     }
   }
   const key = poolKey(cfg);

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.15",
+  "version": "2.8.16",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.8.15",
+  "version": "2.8.16",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -938,6 +938,28 @@ describe("connection pooling (#50 / A3)", () => {
     expect(connects).toBe(3); // pool was cleared → next call reconnects
   });
 
+  it("force-closes the socket even when logout() rejects (CLOSE_WAIT leak fix)", async () => {
+    let logouts = 0;
+    let closes = 0;
+    __setPoolConnect(async () => {
+      const c = makeClient([1], {});
+      return {
+        ...c,
+        logout: async () => {
+          logouts++;
+          throw new Error("socket half-closed — LOGOUT cannot complete");
+        },
+        close: () => {
+          closes++;
+        },
+      };
+    });
+    await imapListMessages({ mailbox: "INBOX", limit: 5 }, { config: cfg });
+    await dropAllPools(); // dropPool: logout() rejects (caught) → close() must still fire
+    expect(logouts).toBe(1); // graceful logout was attempted
+    expect(closes).toBe(1); // socket force-closed anyway → no leaked CLOSE_WAIT FD
+  });
+
   it("closes the pooled connection after the idle window (at-rest → ZERO open sockets)", async () => {
     // Regression for the connection-footprint work: after the last read, the
     // pool's idle timer must fire and LOG OUT the connection, so an instance

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -136,6 +136,10 @@ export interface ImapClientLike {
   messageDelete(range: number[], opts: FlagOpts): Promise<boolean>;
   noop(): Promise<void>;
   logout(): Promise<void>;
+  /** Hard socket teardown (ImapFlow.close): destroys the connection even when a
+   *  graceful logout() can't complete on a half-closed socket. Optional so test
+   *  mocks needn't implement it. */
+  close?(): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -734,7 +738,14 @@ async function dropPool(key: string): Promise<void> {
   if (!e) return;
   if (e.idle) clearTimeout(e.idle);
   pools.delete(key);
+  // Graceful logout, THEN a hard close. When Gmail has already half-closed the
+  // socket (its idle timeout / a server BYE → the FD sits in CLOSE_WAIT),
+  // logout() cannot complete and throws; without the force-close that socket
+  // leaked and accumulated against Gmail's ~15-per-account cap (observed: 10
+  // ESTABLISHED + 12 CLOSE_WAIT to Gmail per instance). close() destroys it
+  // unconditionally so the FD/slot is always released.
   await e.client.logout().catch(() => undefined);
+  e.client.close?.();
 }
 
 /**
@@ -848,6 +859,7 @@ async function useClient<T>(
       return await fn(client, cfg);
     } finally {
       await client.logout().catch(() => undefined);
+      client.close?.();
     }
   }
   const key = poolKey(cfg);


### PR DESCRIPTION
## The leak (found live)

Each long-lived server instance was holding **~10 ESTABLISHED + 12 CLOSE_WAIT** IMAP connections to Gmail — for only 2 Gmail accounts, where the pool is meant to keep **one** per account. Confirmed persistent (steady across snapshots, not a transient close handshake). This is the real source of the intermittent "cannot connect" / Gmail ~15-per-account cap pressure — separate from the 2.8.15 `get-unread-count` sweep.

## Root cause

`dropPool` (and the per-call connect `finally`) released a connection with only a graceful `logout()`:

```js
await e.client.logout().catch(() => undefined);
```

When Gmail has already half-closed the socket (its idle timeout / a server `BYE` → the FD is in `CLOSE_WAIT`), `logout()` can't send its `LOGOUT` command and **throws** — the `.catch()` swallows it and **the socket is never destroyed**. Over hours of idle-timeout/reconnect churn, these leak and pile up. `ImapClientLike` only exposed `logout()`, so there was no hard teardown available.

## Fix

Force-close after the logout attempt, on every drop path:

```js
await e.client.logout().catch(() => undefined);
e.client.close?.();   // ImapFlow.close() — destroys the socket unconditionally
```

- Added optional `close?(): void` to `ImapClientLike` (the returned client is a real `ImapFlow`, which has `close()`; optional so test mocks are unaffected).
- Applied in `dropPool` (pool idle-close / liveness-fail / error / shutdown) and the injected-connect `finally`.

## Validation

- **New regression test** (deterministic): a mock whose `logout()` rejects — asserts `close()` still fires (the exact half-closed-socket case). Would be `closes === 0` without the fix.
- 398 unit tests pass; typecheck / lint / format clean.
- Real Gmail: fixed build serves correctly and pools/reuses (get-unread-count warm ~460ms) — no regression.
- Confirmed `ImapFlow.close()` exists and is callable at runtime.

Patch bump **2.8.16** + CHANGELOG.
