### PR TITLE
feat: smart mailbox tools (continued from #105, @maf4711)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.16",
+      "version": "2.9.0",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.8.16",
+      "version": "2.9.0",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.16",
+  "version": "2.9.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.8.16",
+  "version": "2.9.0",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.8.16",
+      "version": "2.9.0",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.16",
+  "version": "2.9.0",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-07-23
+
+### Added
+- **Smart mailbox tools** — `list-smart-mailboxes`, `create-smart-mailbox`, `delete-smart-mailbox`, and `create-newsletter-smart-mailboxes`. Smart mailboxes are Apple Mail's criteria-based virtual views; AppleScript's `smart mailbox` / `intelligentes Postfach` terms don't compile reliably on localized (e.g. German) macOS, so these read and edit `~/Library/Mail/V*/MailData/SyncedSmartMailboxes.plist` directly. `create-newsletter-smart-mailboxes` scans recent INBOX mail for likely newsletter senders (volume plus List-Unsubscribe / noreply / repetitive-subject signals) and, with `dryRun: false`, creates one "NL: …" smart view per sender (defaults to a dry run). Thanks to @maf4711 (#105) for the feature and the German-localization diagnosis.
+- **Safe, non-destructive plist writes for the smart-mailbox tools.** Each create/delete backs the plist up to `SyncedSmartMailboxes.plist.bak`, mutates a temp copy with a lossless single-entry edit (`plutil -insert -json` to append, `PlistBuddy Delete` to remove), validates it with `plutil -lint`, then atomically renames it into place — so existing smart mailboxes, including any with `<date>`/`<data>` criteria that `plutil -convert json` cannot represent, are preserved byte-for-byte and the live file is only ever replaced by a validated copy. The tools no longer run `killall Mail`; changes appear the next time Mail is launched.
+
 ## [2.8.16] - 2026-07-23
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,26 @@ IMAP connections are capped: **Gmail allows at most 15 simultaneous IMAP connect
 4. delete-mailbox name="Old Folder" → delete
 ```
 
+### Manage smart mailboxes (intelligente Postfächer)
+
+Smart mailboxes are **criteria-based virtual views**, not real folders — use these instead of `*-mailbox` when the user wants a saved filter/search (e.g. "a folder that shows all mail from X"). They work on localized macOS (e.g. German), where AppleScript's smart-mailbox terms fail, because they edit `SyncedSmartMailboxes.plist` directly (backed up + atomic; existing smart mailboxes are never rewritten).
+
+```text
+1. list-smart-mailboxes → see existing smart mailboxes
+2. create-smart-mailbox name="From Boss" fromContains="boss@company.com"
+   (provide at least one of fromContains / subjectContains / bodyContains)
+3. delete-smart-mailbox name="From Boss" → remove it
+```
+
+For decluttering an inbox full of newsletters, prefer the high-level tool — it defaults to a **dry run**:
+
+```text
+1. create-newsletter-smart-mailboxes → dry run: proposes "NL: <sender>" smart views by score
+2. create-newsletter-smart-mailboxes dryRun=false → actually create the proposed views
+```
+
+Changes appear the next time Mail is launched — these tools do **not** quit or restart Mail. For reliable results, have the user quit Mail before creating/deleting smart mailboxes.
+
 ### Work with mail rules
 
 ```text

--- a/README.md
+++ b/README.md
@@ -881,7 +881,9 @@ Rename a mailbox (creates new, moves messages, deletes old).
 
 ### Smart Mailbox Operations (intelligente Postfächer)
 
-Smart mailboxes are virtual (criteria-based views, not real folders). These tools let you create dedicated smart views for newsletters etc. directly from the Inbox without moving messages.
+Smart mailboxes are Apple Mail's **criteria-based virtual views** — not real folders, so no messages are moved. AppleScript's `smart mailbox` / `intelligentes Postfach` terms don't compile reliably on localized (e.g. German) macOS, so these tools read and edit `~/Library/Mail/V*/MailData/SyncedSmartMailboxes.plist` directly.
+
+**How writes stay safe:** creating or deleting a smart mailbox first backs the plist up to `SyncedSmartMailboxes.plist.bak`, edits a temp copy with `plutil`/`PlistBuddy`, validates it with `plutil -lint`, and only then atomically renames it into place. Your **existing** smart mailboxes — including any with date/data criteria — are never rewritten, only the single target entry is added or removed. These tools do **not** quit or restart Mail: **quit Mail first** for reliable results, since a running Mail may not show a new smart mailbox until it's relaunched and can overwrite plist edits it didn't make.
 
 #### `list-smart-mailboxes`
 
@@ -904,7 +906,9 @@ Create a smart mailbox with a simple contains rule.
 | `subjectContains` | string | No | Match if Subject contains this |
 | `bodyContains` | string | No | Match if Body contains this |
 
-Exactly one of the three contains fields should be provided.
+Provide at least one of the three `*Contains` fields.
+
+**⚠️ Safety:** edits `SyncedSmartMailboxes.plist` (backed up + atomic, existing smart mailboxes preserved). Quit Mail first for reliable results; the new smart mailbox appears the next time Mail launches.
 
 ---
 
@@ -915,6 +919,8 @@ Delete a smart mailbox by name.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Smart mailbox name |
+
+**⚠️ Safety:** destructive — removes the smart mailbox from `SyncedSmartMailboxes.plist` (backed up + atomic; every other smart mailbox is preserved). Not undoable in-app. Confirm the exact name with `list-smart-mailboxes` first, and quit Mail first for reliable results.
 
 ---
 
@@ -928,7 +934,9 @@ High-level tool: scan recent messages in your INBOXes, detect likely newsletters
 | `minCount` | number | No | Min messages from a sender (default 3) |
 | `days` | number | No | Lookback window in days (default 90) |
 
-Use with `dryRun: false` to actually create the smart folders for newsletters cluttering your Inbox.
+Defaults to a **safe dry run** that only proposes. Pass `dryRun: false` to actually create the smart mailboxes for newsletters cluttering your Inbox.
+
+**⚠️ Safety:** with `dryRun: false` this edits `SyncedSmartMailboxes.plist` (backed up + atomic, existing entries preserved) and can create many smart mailboxes at once — review a dry run first. Scans up to ~400 recent messages per inbox via AppleScript, which can be slow on large mailboxes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -879,6 +879,59 @@ Rename a mailbox (creates new, moves messages, deletes old).
 
 ---
 
+### Smart Mailbox Operations (intelligente Postfächer)
+
+Smart mailboxes are virtual (criteria-based views, not real folders). These tools let you create dedicated smart views for newsletters etc. directly from the Inbox without moving messages.
+
+#### `list-smart-mailboxes`
+
+List existing smart mailboxes.
+
+**Parameters:** None
+
+**Returns:** List of smart mailbox names + criteria summary.
+
+---
+
+#### `create-smart-mailbox`
+
+Create a smart mailbox with a simple contains rule.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name for the smart mailbox |
+| `fromContains` | string | No | Match if From contains this |
+| `subjectContains` | string | No | Match if Subject contains this |
+| `bodyContains` | string | No | Match if Body contains this |
+
+Exactly one of the three contains fields should be provided.
+
+---
+
+#### `delete-smart-mailbox`
+
+Delete a smart mailbox by name.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Smart mailbox name |
+
+---
+
+#### `create-newsletter-smart-mailboxes`
+
+High-level tool: scan recent messages in your INBOXes, detect likely newsletters (volume + signals like List-Unsubscribe, noreply, repetitive subjects), and create smart mailboxes for them (names prefixed "NL: ...").
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `dryRun` | boolean | No | Default true — only propose, do not create |
+| `minCount` | number | No | Min messages from a sender (default 3) |
+| `days` | number | No | Lookback window in days (default 90) |
+
+Use with `dryRun: false` to actually create the smart folders for newsletters cluttering your Inbox.
+
+---
+
 ### Account Operations
 
 #### `list-accounts`

--- a/build/index.js
+++ b/build/index.js
@@ -75697,13 +75697,15 @@ import {
   readFileSync as readFileSync2,
   readdirSync as readdirSync2,
   unlinkSync,
+  copyFileSync,
+  renameSync,
   mkdtempSync as mkdtempSync2,
   rmSync as rmSync2,
   realpathSync,
   lstatSync
 } from "fs";
 import { isAbsolute, resolve, sep, join as join4 } from "path";
-import { homedir as homedir3, tmpdir as tmpdir2 } from "os";
+import { homedir as homedir3 } from "os";
 import { randomUUID } from "crypto";
 
 // src/utils/applescript.ts
@@ -78700,34 +78702,94 @@ var AppleMailManager = class {
     }
     return null;
   }
-  loadSmartMailboxes(plistPath) {
-    if (!plistPath) return [];
-    try {
-      const tmpJson = join4(tmpdir2(), `smart-${Date.now()}.json`);
-      const r = spawnSync2("plutil", ["-convert", "json", "-o", tmpJson, plistPath], {
-        encoding: "utf8"
-      });
-      if (r.status !== 0) return [];
-      const data = JSON.parse(readFileSync2(tmpJson, "utf8"));
-      unlinkSync(tmpJson);
-      return Array.isArray(data) ? data : [];
-    } catch {
-      return [];
+  /**
+   * Read all smart-mailbox entries without ever mutating the plist.
+   *
+   * Fast path: `plutil -convert json`. That converter *rejects* any plist
+   * containing <data>/<date> values ("Invalid object in plist for JSON
+   * format") — and smart-mailbox date criteria can contain exactly those — so
+   * on such libraries we fall back to structural probing with PlistBuddy. (The
+   * previous implementation used the json path unconditionally and, on
+   * failure, treated the whole file as empty, which then overwrote every
+   * existing smart mailbox on the next save.)
+   */
+  readSmartMailboxEntries(plistPath) {
+    if (!plistPath || !existsSync3(plistPath)) return [];
+    const j = spawnSync2("plutil", ["-convert", "json", "-o", "-", plistPath], {
+      encoding: "utf8"
+    });
+    if (j.status === 0 && j.stdout) {
+      try {
+        const data = JSON.parse(j.stdout);
+        if (Array.isArray(data)) {
+          return data.map((m) => ({
+            name: m?.MailboxName ?? "",
+            id: m?.MailboxID,
+            criteriaSummary: this.summarizeCriteria(m?.MailboxCriteria)
+          }));
+        }
+      } catch {
+      }
     }
+    return this.probeSmartMailboxEntries(plistPath);
   }
-  saveSmartMailboxes(plistPath, mailboxes) {
-    if (!plistPath) return false;
-    try {
-      const tmpJson = join4(tmpdir2(), `smart-${Date.now()}.json`);
-      writeFileSync3(tmpJson, JSON.stringify(mailboxes, null, 2), "utf8");
-      const r = spawnSync2("plutil", ["-convert", "binary1", "-o", plistPath, tmpJson], {
+  /**
+   * Structural enumeration for plists the json converter rejects (date/data
+   * criteria). Probes array indices via PlistBuddy until one is out of range.
+   */
+  probeSmartMailboxEntries(plistPath) {
+    const buddy = "/usr/libexec/PlistBuddy";
+    const out = [];
+    for (let i = 0; i < 1e3; i++) {
+      const exists = spawnSync2(buddy, ["-c", `Print :${i}`, plistPath], { encoding: "utf8" });
+      if (exists.status !== 0) break;
+      const nameR = spawnSync2(buddy, ["-c", `Print :${i}:MailboxName`, plistPath], {
         encoding: "utf8"
       });
-      unlinkSync(tmpJson);
-      return r.status === 0;
-    } catch {
+      const idR = spawnSync2(buddy, ["-c", `Print :${i}:MailboxID`, plistPath], {
+        encoding: "utf8"
+      });
+      out.push({
+        name: nameR.status === 0 ? (nameR.stdout || "").trim() : "",
+        id: idR.status === 0 ? (idR.stdout || "").trim() || void 0 : void 0
+      });
+    }
+    return out;
+  }
+  summarizeCriteria(crits) {
+    if (!Array.isArray(crits)) return void 0;
+    const summary = crits.map((c) => {
+      const n = c?.Name || c?.Header || "";
+      return c?.Expression ? `${n}=${String(c.Expression).slice(0, 25)}` : n;
+    }).filter(Boolean).join("; ").slice(0, 100);
+    return summary || void 0;
+  }
+  /**
+   * Back up `plistPath` to `<plist>.bak` and return a sibling temp-file path
+   * (same directory → same filesystem, so the later rename is atomic) seeded
+   * with the current contents. Callers mutate the temp copy, then
+   * commitSmartPlist() lints and atomically renames it into place — so the live
+   * plist is only ever replaced wholesale by a validated file, never edited in
+   * place and never left half-written.
+   */
+  prepareSmartPlistWrite(plistPath) {
+    copyFileSync(plistPath, `${plistPath}.bak`);
+    const temp = `${plistPath}.tmp-${randomUUID()}`;
+    copyFileSync(plistPath, temp);
+    return temp;
+  }
+  /** Lint the mutated temp file and atomically move it into place. */
+  commitSmartPlist(temp, plistPath) {
+    const lint = spawnSync2("plutil", ["-lint", temp], { encoding: "utf8" });
+    if (lint.status !== 0) {
+      try {
+        unlinkSync(temp);
+      } catch {
+      }
       return false;
     }
+    renameSync(temp, plistPath);
+    return true;
   }
   buildSmartMailboxEntry(name, fromContains = "", subjectContains = "", bodyContains = "") {
     const newUuid = () => randomUUID().toUpperCase();
@@ -78772,59 +78834,107 @@ var AppleMailManager = class {
    */
   listSmartMailboxes() {
     const plist = this.findSyncedSmartPlist();
-    const raw = this.loadSmartMailboxes(plist);
-    return raw.map((m) => {
-      const crits = m.MailboxCriteria || [];
-      const summary = crits.map((c) => {
-        const n = c.Name || c.Header || "";
-        return c.Expression ? `${n}=${String(c.Expression).slice(0, 25)}` : n;
-      }).filter(Boolean).join("; ").slice(0, 100);
-      return {
-        name: m.MailboxName || "",
-        id: m.MailboxID,
-        criteriaSummary: summary || void 0
-      };
-    });
+    return this.readSmartMailboxEntries(plist).map((m) => ({
+      name: m.name || "",
+      id: m.id,
+      criteriaSummary: m.criteriaSummary
+    }));
   }
   /**
-   * Create a new smart mailbox with simple contains criteria.
-   * Provide exactly one of fromContains / subjectContains / bodyContains.
+   * Create a new smart mailbox with a simple contains criterion.
+   * Provide at least one of fromContains / subjectContains / bodyContains.
+   *
+   * The new entry is appended to SyncedSmartMailboxes.plist with a lossless
+   * `plutil -insert -json` on a backed-up temp copy — existing smart mailboxes
+   * (including any with date/data criteria) are preserved byte-for-byte, and
+   * the live file is only ever replaced by a lint-validated copy. Does NOT quit
+   * or restart Mail; the new mailbox appears the next time Mail is launched.
    */
   createSmartMailbox(name, fromContains = "", subjectContains = "", bodyContains = "") {
     if (!name || !fromContains && !subjectContains && !bodyContains) {
-      return false;
+      return {
+        created: false,
+        alreadyExisted: false,
+        error: "Provide a name and at least one of fromContains / subjectContains / bodyContains"
+      };
     }
     const plist = this.findSyncedSmartPlist();
     if (!plist) {
-      console.error("No SyncedSmartMailboxes.plist found (launch Mail at least once)");
-      return false;
+      return {
+        created: false,
+        alreadyExisted: false,
+        error: "No SyncedSmartMailboxes.plist found (launch Mail at least once)"
+      };
     }
-    const mbs = this.loadSmartMailboxes(plist);
-    if (mbs.some((m) => m.MailboxName === name)) {
-      return true;
+    return this.createSmartMailboxAtPath(plist, name, fromContains, subjectContains, bodyContains);
+  }
+  /** Path-injectable core of createSmartMailbox (unit-testable against a fixture plist). */
+  createSmartMailboxAtPath(plistPath, name, fromContains = "", subjectContains = "", bodyContains = "") {
+    const entries = this.readSmartMailboxEntries(plistPath);
+    if (entries.some((e) => e.name === name)) {
+      return { created: false, alreadyExisted: true };
     }
     const entry = this.buildSmartMailboxEntry(name, fromContains, subjectContains, bodyContains);
-    mbs.push(entry);
-    const ok = this.saveSmartMailboxes(plist, mbs);
-    if (ok) {
+    const temp = this.prepareSmartPlistWrite(plistPath);
+    const ins = spawnSync2(
+      "plutil",
+      ["-insert", String(entries.length), "-json", JSON.stringify(entry), temp],
+      { encoding: "utf8" }
+    );
+    if (ins.status !== 0) {
       try {
-        spawnSync2("killall", ["Mail"], { stdio: "ignore" });
+        unlinkSync(temp);
       } catch {
       }
+      return {
+        created: false,
+        alreadyExisted: false,
+        error: (ins.stderr || "plutil insert failed").trim()
+      };
     }
-    return ok;
+    if (!this.commitSmartPlist(temp, plistPath)) {
+      return {
+        created: false,
+        alreadyExisted: false,
+        error: "Edited plist failed validation; original left untouched"
+      };
+    }
+    return { created: true, alreadyExisted: false };
   }
   /**
-   * Delete a smart mailbox by name (removes from the plist).
+   * Delete a smart mailbox by name. Removes exactly the matching entry via
+   * PlistBuddy on a backed-up temp copy; every other smart mailbox is
+   * preserved. Does NOT quit or restart Mail.
    */
   deleteSmartMailbox(name) {
     const plist = this.findSyncedSmartPlist();
-    if (!plist) return false;
-    const mbs = this.loadSmartMailboxes(plist);
-    const before = mbs.length;
-    const filtered = mbs.filter((m) => m.MailboxName !== name);
-    if (filtered.length === before) return false;
-    return this.saveSmartMailboxes(plist, filtered);
+    if (!plist) {
+      return { deleted: false, error: "No SyncedSmartMailboxes.plist found" };
+    }
+    return this.deleteSmartMailboxAtPath(plist, name);
+  }
+  /** Path-injectable core of deleteSmartMailbox (unit-testable against a fixture plist). */
+  deleteSmartMailboxAtPath(plistPath, name) {
+    const entries = this.readSmartMailboxEntries(plistPath);
+    const idx = entries.findIndex((e) => e.name === name);
+    if (idx < 0) {
+      return { deleted: false, error: `Smart mailbox "${name}" not found` };
+    }
+    const temp = this.prepareSmartPlistWrite(plistPath);
+    const del = spawnSync2("/usr/libexec/PlistBuddy", ["-c", `Delete :${idx}`, temp], {
+      encoding: "utf8"
+    });
+    if (del.status !== 0) {
+      try {
+        unlinkSync(temp);
+      } catch {
+      }
+      return { deleted: false, error: (del.stderr || "PlistBuddy delete failed").trim() };
+    }
+    if (!this.commitSmartPlist(temp, plistPath)) {
+      return { deleted: false, error: "Edited plist failed validation; original left untouched" };
+    }
+    return { deleted: true };
   }
   // --- Newsletter smart mailbox discovery (high level helper) ---
   extractEmail(sender) {
@@ -78832,10 +78942,12 @@ var AppleMailManager = class {
     return m ? m[1].toLowerCase().trim() : (sender || "").toLowerCase().trim();
   }
   /**
-   * Scan recent messages and return likely newsletter senders with scores.
-   * Uses existing search/list capabilities + source sampling for List-Unsubscribe etc.
+   * Scan recent INBOX messages and return raw [sender, subject, source] rows.
+   * This is the only AppleScript-touching part of newsletter discovery; the
+   * grouping/scoring is factored into groupAndScoreNewsletters() so it can be
+   * unit-tested without a running Mail.
    */
-  findNewsletterCandidates(days = 90, minCount = 3) {
+  scanInboxRows(days) {
     const script = `
 tell application "Mail"
   set outLines to ""
@@ -78862,10 +78974,22 @@ tell application "Mail"
 end tell`;
     const res = executeAppleScript(script, { timeoutMs: 12e4 });
     if (!res.success || !res.output) return [];
-    const groups = {};
+    const rows = [];
     for (const line of res.output.split("\n")) {
       if (!line.includes("|")) continue;
       const [snd = "", subj = "", src = ""] = line.split("|", 3);
+      rows.push({ sender: snd, subject: subj, source: src });
+    }
+    return rows;
+  }
+  /**
+   * Pure grouping + scoring over scanned rows. Groups by sender email, keeps
+   * senders at/above minCount, and scores by volume plus newsletter signals
+   * (List-Unsubscribe, noreply/newsletter keywords, repetitive subjects).
+   */
+  groupAndScoreNewsletters(rows, minCount) {
+    const groups = {};
+    for (const { sender: snd, subject: subj, source: src } of rows) {
       const email2 = this.extractEmail(snd);
       if (!email2 || !email2.includes("@")) continue;
       if (!groups[email2]) {
@@ -78874,7 +78998,7 @@ end tell`;
       const g = groups[email2];
       g.count++;
       if (g.subjects.length < 6) g.subjects.push(subj);
-      if (!g.sample) g.sample = src.slice(0, 3e3);
+      if (!g.sample) g.sample = (src || "").slice(0, 3e3);
     }
     const out = [];
     for (const g of Object.values(groups)) {
@@ -78909,6 +79033,12 @@ end tell`;
     return out.slice(0, 50);
   }
   /**
+   * Scan recent messages and return likely newsletter senders with scores.
+   */
+  findNewsletterCandidates(days = 90, minCount = 3) {
+    return this.groupAndScoreNewsletters(this.scanInboxRows(days), minCount);
+  }
+  /**
    * High-level: discover likely newsletters from INBOX and (optionally) create smart mailboxes for them.
    */
   createNewsletterSmartMailboxes(dryRun = true, minCount = 3, days = 90) {
@@ -78920,8 +79050,15 @@ end tell`;
         results.push({ name: nm, email: c.email, wouldCreate: true, score: c.score });
         continue;
       }
-      const ok = this.createSmartMailbox(nm, c.email);
-      results.push({ name: nm, email: c.email, success: ok, score: c.score });
+      const r = this.createSmartMailbox(nm, c.email);
+      results.push({
+        name: nm,
+        email: c.email,
+        success: r.created || r.alreadyExisted,
+        alreadyExisted: r.alreadyExisted,
+        error: r.error,
+        score: c.score
+      });
     }
     return { dryRun, createdOrProposed: results, count: results.length };
   }
@@ -82629,69 +82766,132 @@ server.registerTool(
     });
   }, "Error renaming mailbox")
 );
-server.tool(
+server.registerTool(
   "list-smart-mailboxes",
-  {},
+  {
+    description: "Use when: listing Apple Mail smart mailboxes (criteria-based virtual views), including on German-localized macOS where AppleScript's smart-mailbox terms do not compile.\nReturns: each smart mailbox's name and a short criteria summary.\nDo not use when: listing real folders/mailboxes (use list-mailboxes).",
+    inputSchema: {},
+    outputSchema: {
+      count: external_exports.number().optional(),
+      smartMailboxes: external_exports.array(
+        external_exports.object({
+          name: external_exports.string(),
+          id: external_exports.string().optional(),
+          criteriaSummary: external_exports.string().optional()
+        })
+      ).optional()
+    }
+  },
   withErrorHandling(() => {
     const list = mailManager.listSmartMailboxes();
     if (list.length === 0) {
-      return successResponse("No smart mailboxes found");
+      return successResponse("No smart mailboxes found", { count: 0, smartMailboxes: [] });
     }
     const lines = list.map((s) => `  - ${s.name}${s.criteriaSummary ? ` (${s.criteriaSummary})` : ""}`).join("\n");
     return successResponse(`Found ${list.length} smart mailbox(es):
-${lines}`);
+${lines}`, {
+      count: list.length,
+      smartMailboxes: list.map((s) => ({
+        name: s.name,
+        id: s.id,
+        criteriaSummary: s.criteriaSummary
+      }))
+    });
   }, "Error listing smart mailboxes")
 );
-server.tool(
+server.registerTool(
   "create-smart-mailbox",
   {
-    name: external_exports.string().min(1, "Smart mailbox name is required"),
-    fromContains: external_exports.string().optional().describe("Match sender (From contains)"),
-    subjectContains: external_exports.string().optional().describe("Match subject (contains)"),
-    bodyContains: external_exports.string().optional().describe("Match body (contains)")
+    description: "Use when: creating an Apple Mail smart mailbox (a criteria-based virtual view) that matches a sender, subject, or body substring \u2014 works on German-localized macOS where AppleScript's smart-mailbox terms fail.\nReturns: confirmation of creation, or a note that a smart mailbox with that name already existed.\nDo not use when: creating a real folder (use create-mailbox).\nSafety: edits Apple Mail's SyncedSmartMailboxes.plist directly. It backs the file up (.bak) and writes atomically, and never rewrites your existing smart mailboxes. It does not quit Mail \u2014 quit Mail first for reliable results, since a running Mail may not show the new smart mailbox until relaunched and can overwrite plist edits it did not make.",
+    inputSchema: {
+      name: external_exports.string().min(1, "Smart mailbox name is required"),
+      fromContains: external_exports.string().optional().describe("Match sender (From contains)"),
+      subjectContains: external_exports.string().optional().describe("Match subject (contains)"),
+      bodyContains: external_exports.string().optional().describe("Match body (contains)")
+    },
+    outputSchema: {
+      ok: external_exports.boolean().optional(),
+      name: external_exports.string().optional(),
+      alreadyExisted: external_exports.boolean().optional()
+    }
   },
   withErrorHandling(({ name, fromContains, subjectContains, bodyContains }) => {
-    const ok = mailManager.createSmartMailbox(
+    if (!fromContains && !subjectContains && !bodyContains) {
+      return errorResponse("Provide at least one of fromContains / subjectContains / bodyContains");
+    }
+    const r = mailManager.createSmartMailbox(
       name,
       fromContains || "",
       subjectContains || "",
       bodyContains || ""
     );
-    if (!ok) {
-      return errorResponse(`Failed to create smart mailbox "${name}"`);
+    if (r.alreadyExisted) {
+      return successResponse(`Smart mailbox "${name}" already exists`, {
+        ok: true,
+        name,
+        alreadyExisted: true
+      });
     }
-    return successResponse(`Smart mailbox "${name}" created (or already existed)`);
+    if (!r.created) {
+      return errorResponse(r.error || `Failed to create smart mailbox "${name}"`);
+    }
+    return successResponse(`Smart mailbox "${name}" created. Quit and reopen Mail to see it.`, {
+      ok: true,
+      name,
+      alreadyExisted: false
+    });
   }, "Error creating smart mailbox")
 );
-server.tool(
+server.registerTool(
   "delete-smart-mailbox",
   {
-    name: external_exports.string().min(1, "Smart mailbox name is required")
+    description: "Use when: deleting an Apple Mail smart mailbox (virtual view) by name.\nReturns: confirmation of deletion.\nDo not use when: deleting a real folder (use delete-mailbox) or messages (use delete-message / batch-delete-messages).\nSafety: destructive \u2014 removes the smart mailbox from Apple Mail's SyncedSmartMailboxes.plist. It backs the file up (.bak) and writes atomically, preserving every other smart mailbox, but the removal is not undoable in-app. Confirm the exact name with list-smart-mailboxes first, and quit Mail first for reliable results.",
+    inputSchema: {
+      name: external_exports.string().min(1, "Smart mailbox name is required")
+    },
+    outputSchema: {
+      ok: external_exports.boolean().optional(),
+      name: external_exports.string().optional()
+    }
   },
   withErrorHandling(({ name }) => {
-    const ok = mailManager.deleteSmartMailbox(name);
-    if (!ok) {
-      return errorResponse(`Failed to delete smart mailbox "${name}"`);
+    const r = mailManager.deleteSmartMailbox(name);
+    if (!r.deleted) {
+      return errorResponse(r.error || `Failed to delete smart mailbox "${name}"`);
     }
-    return successResponse(`Smart mailbox "${name}" deleted`);
+    return successResponse(`Smart mailbox "${name}" deleted. Quit and reopen Mail to refresh.`, {
+      ok: true,
+      name
+    });
   }, "Error deleting smart mailbox")
 );
-server.tool(
+server.registerTool(
   "create-newsletter-smart-mailboxes",
   {
-    dryRun: external_exports.boolean().default(true).describe("If true, only propose; if false, actually create"),
-    minCount: external_exports.number().int().min(1).default(3).describe("Minimum messages from sender in the period"),
-    days: external_exports.number().int().min(1).default(90).describe("Look back this many days in INBOXes")
+    description: `Use when: auto-discovering newsletter/bulk senders in your INBOX(es) and (optionally) creating a dedicated smart mailbox per sender (named "NL: <sender>"). Defaults to a safe dry run that only proposes.
+Returns: the proposed or created smart mailboxes with their match scores.
+Do not use when: you already know the exact sender (use create-smart-mailbox) or want real folders (use create-mailbox).
+Safety: with dryRun=false it edits Apple Mail's SyncedSmartMailboxes.plist (backed up, atomic, existing entries preserved) and can create many smart mailboxes at once \u2014 review a dryRun first. It scans up to ~400 recent messages per inbox via AppleScript, which can be slow on large mailboxes.`,
+    inputSchema: {
+      dryRun: external_exports.boolean().default(true).describe("If true (default), only propose; if false, actually create"),
+      minCount: external_exports.number().int().min(1).default(3).describe("Minimum messages from sender in the period"),
+      days: external_exports.number().int().min(1).default(90).describe("Look back this many days in INBOXes")
+    },
+    outputSchema: {
+      dryRun: external_exports.boolean().optional(),
+      count: external_exports.number().optional()
+    }
   },
   withErrorHandling(({ dryRun, minCount, days }) => {
     const result = mailManager.createNewsletterSmartMailboxes(!!dryRun, minCount, days);
     const lines = result.createdOrProposed.map(
-      (c) => `  - ${c.name || c.suggestedName || c.email} (score ${c.score || "?"}${c.wouldCreate ? ", dry-run" : ""})`
+      (c) => `  - ${c.name || c.suggestedName || c.email} (score ${c.score ?? "?"}${c.wouldCreate ? ", dry-run" : c.alreadyExisted ? ", already existed" : c.error ? `, error: ${c.error}` : ""})`
     ).join("\n");
     const prefix = result.dryRun ? "DRY RUN - would create" : "Created";
     return successResponse(
       `${prefix} ${result.count} newsletter smart mailbox(es):
-${lines || "  (none met the threshold)"}`
+${lines || "  (none met the threshold)"}`,
+      { dryRun: result.dryRun, count: result.count }
     );
   }, "Error creating newsletter smart mailboxes")
 );

--- a/build/index.js
+++ b/build/index.js
@@ -75695,13 +75695,16 @@ import {
   existsSync as existsSync3,
   writeFileSync as writeFileSync3,
   readFileSync as readFileSync2,
+  readdirSync as readdirSync2,
+  unlinkSync,
   mkdtempSync as mkdtempSync2,
   rmSync as rmSync2,
   realpathSync,
   lstatSync
 } from "fs";
 import { isAbsolute, resolve, sep, join as join4 } from "path";
-import { homedir as homedir3 } from "os";
+import { homedir as homedir3, tmpdir as tmpdir2 } from "os";
+import { randomUUID } from "crypto";
 
 // src/utils/applescript.ts
 import { execSync, spawnSync } from "child_process";
@@ -78676,6 +78679,251 @@ var AppleMailManager = class {
     }
     this.invalidateCache();
     return { success: true };
+  }
+  // ===========================================================================
+  // Smart Mailbox (intelligente Postfächer) Operations
+  // Uses plist manipulation because AppleScript terms for "smart mailbox"
+  // / "intelligentes Postfach" do not compile reliably on German-localized
+  // macOS (verified via osascript + JXA). Plist format is stable and
+  // gives full control over criteria without UI/GUI scripting.
+  // ===========================================================================
+  findSyncedSmartPlist() {
+    const base = join4(homedir3(), "Library", "Mail");
+    try {
+      const versions = readdirSync2(base).filter((d) => d.startsWith("V"));
+      versions.sort().reverse();
+      for (const v of versions) {
+        const p = join4(base, v, "MailData", "SyncedSmartMailboxes.plist");
+        if (existsSync3(p)) return p;
+      }
+    } catch {
+    }
+    return null;
+  }
+  loadSmartMailboxes(plistPath) {
+    if (!plistPath) return [];
+    try {
+      const tmpJson = join4(tmpdir2(), `smart-${Date.now()}.json`);
+      const r = spawnSync2("plutil", ["-convert", "json", "-o", tmpJson, plistPath], {
+        encoding: "utf8"
+      });
+      if (r.status !== 0) return [];
+      const data = JSON.parse(readFileSync2(tmpJson, "utf8"));
+      unlinkSync(tmpJson);
+      return Array.isArray(data) ? data : [];
+    } catch {
+      return [];
+    }
+  }
+  saveSmartMailboxes(plistPath, mailboxes) {
+    if (!plistPath) return false;
+    try {
+      const tmpJson = join4(tmpdir2(), `smart-${Date.now()}.json`);
+      writeFileSync3(tmpJson, JSON.stringify(mailboxes, null, 2), "utf8");
+      const r = spawnSync2("plutil", ["-convert", "binary1", "-o", plistPath, tmpJson], {
+        encoding: "utf8"
+      });
+      unlinkSync(tmpJson);
+      return r.status === 0;
+    } catch {
+      return false;
+    }
+  }
+  buildSmartMailboxEntry(name, fromContains = "", subjectContains = "", bodyContains = "") {
+    const newUuid = () => randomUUID().toUpperCase();
+    const userExpr = fromContains || subjectContains || bodyContains || "";
+    const userHeader = fromContains ? "From" : subjectContains ? "Subject" : "Body";
+    const userCriterion = {
+      AllCriteriaMustBeSatisfied: true,
+      Criteria: [
+        {
+          CriterionUniqueId: newUuid(),
+          Expression: userExpr,
+          Header: userHeader
+        }
+      ],
+      CriterionUniqueId: newUuid(),
+      Header: "Compound",
+      Name: "user criteria"
+    };
+    return {
+      IMAPMailboxAttributes: 17,
+      MailboxAllCriteriaMustBeSatisfied: true,
+      MailboxChildren: [],
+      MailboxCriteria: [
+        { CriterionUniqueId: newUuid(), Header: "NotInTrashMailbox", Name: "omit trash" },
+        {
+          CriterionUniqueId: newUuid(),
+          Header: "NotInASpecialMailbox",
+          Name: "omit sent",
+          SpecialMailboxType: 3
+        },
+        userCriterion,
+        { CriterionUniqueId: newUuid(), Header: "NotInJunkMailbox", Name: "omit junk" }
+      ],
+      MailboxID: newUuid(),
+      MailboxName: name,
+      MailboxType: 7
+    };
+  }
+  /**
+   * List all smart mailboxes (intelligente Postfächer).
+   * Reads from the synced plist (works on German + English systems).
+   */
+  listSmartMailboxes() {
+    const plist = this.findSyncedSmartPlist();
+    const raw = this.loadSmartMailboxes(plist);
+    return raw.map((m) => {
+      const crits = m.MailboxCriteria || [];
+      const summary = crits.map((c) => {
+        const n = c.Name || c.Header || "";
+        return c.Expression ? `${n}=${String(c.Expression).slice(0, 25)}` : n;
+      }).filter(Boolean).join("; ").slice(0, 100);
+      return {
+        name: m.MailboxName || "",
+        id: m.MailboxID,
+        criteriaSummary: summary || void 0
+      };
+    });
+  }
+  /**
+   * Create a new smart mailbox with simple contains criteria.
+   * Provide exactly one of fromContains / subjectContains / bodyContains.
+   */
+  createSmartMailbox(name, fromContains = "", subjectContains = "", bodyContains = "") {
+    if (!name || !fromContains && !subjectContains && !bodyContains) {
+      return false;
+    }
+    const plist = this.findSyncedSmartPlist();
+    if (!plist) {
+      console.error("No SyncedSmartMailboxes.plist found (launch Mail at least once)");
+      return false;
+    }
+    const mbs = this.loadSmartMailboxes(plist);
+    if (mbs.some((m) => m.MailboxName === name)) {
+      return true;
+    }
+    const entry = this.buildSmartMailboxEntry(name, fromContains, subjectContains, bodyContains);
+    mbs.push(entry);
+    const ok = this.saveSmartMailboxes(plist, mbs);
+    if (ok) {
+      try {
+        spawnSync2("killall", ["Mail"], { stdio: "ignore" });
+      } catch {
+      }
+    }
+    return ok;
+  }
+  /**
+   * Delete a smart mailbox by name (removes from the plist).
+   */
+  deleteSmartMailbox(name) {
+    const plist = this.findSyncedSmartPlist();
+    if (!plist) return false;
+    const mbs = this.loadSmartMailboxes(plist);
+    const before = mbs.length;
+    const filtered = mbs.filter((m) => m.MailboxName !== name);
+    if (filtered.length === before) return false;
+    return this.saveSmartMailboxes(plist, filtered);
+  }
+  // --- Newsletter smart mailbox discovery (high level helper) ---
+  extractEmail(sender) {
+    const m = /<([^>]+)>/.exec(sender || "");
+    return m ? m[1].toLowerCase().trim() : (sender || "").toLowerCase().trim();
+  }
+  /**
+   * Scan recent messages and return likely newsletter senders with scores.
+   * Uses existing search/list capabilities + source sampling for List-Unsubscribe etc.
+   */
+  findNewsletterCandidates(days = 90, minCount = 3) {
+    const script = `
+tell application "Mail"
+  set outLines to ""
+  set cutoff to (current date) - (${days} * days)
+  repeat with acc in accounts
+    repeat with mb in mailboxes of acc
+      if name of mb is "INBOX" or name of mb is "Inbox" then
+        set msgs to (messages of mb whose date received > cutoff)
+        set cnt to 0
+        repeat with m in msgs
+          if cnt > 400 then exit repeat
+          try
+            set snd to (sender of m as text)
+            set subj to (subject of m as text)
+            set src to (source of m as text)
+            set outLines to outLines & snd & "|" & subj & "|" & src & linefeed
+            set cnt to cnt + 1
+          end try
+        end repeat
+      end if
+    end repeat
+  end repeat
+  return outLines
+end tell`;
+    const res = executeAppleScript(script, { timeoutMs: 12e4 });
+    if (!res.success || !res.output) return [];
+    const groups = {};
+    for (const line of res.output.split("\n")) {
+      if (!line.includes("|")) continue;
+      const [snd = "", subj = "", src = ""] = line.split("|", 3);
+      const email2 = this.extractEmail(snd);
+      if (!email2 || !email2.includes("@")) continue;
+      if (!groups[email2]) {
+        groups[email2] = { email: email2, sender: snd, count: 0, subjects: [], sample: "" };
+      }
+      const g = groups[email2];
+      g.count++;
+      if (g.subjects.length < 6) g.subjects.push(subj);
+      if (!g.sample) g.sample = src.slice(0, 3e3);
+    }
+    const out = [];
+    for (const g of Object.values(groups)) {
+      if (g.count < minCount) continue;
+      let score = Math.min(g.count / 3, 8);
+      const blob = g.email + " " + (g.sample || "").toLowerCase();
+      const signals = [];
+      if (/newsletter|digest|noreply|no-reply|list-unsubscribe/.test(blob)) {
+        score += 4;
+        signals.push("keyword_or_list");
+      }
+      if (g.sample && /list-unsubscribe/i.test(g.sample)) {
+        score += 3;
+        signals.push("list_unsubscribe");
+      }
+      const prefixes = g.subjects.slice(0, 5).map((s) => s.slice(0, 30));
+      if (prefixes.length >= 2 && new Set(prefixes).size <= 2) {
+        score += 2;
+        signals.push("repetitive_subject");
+      }
+      const short = (g.sender.split("<")[0] || g.email).trim().slice(0, 30);
+      out.push({
+        email: g.email,
+        sender: g.sender.slice(0, 80),
+        count: g.count,
+        score: Math.max(0.1, Math.round(score * 10) / 10),
+        signals,
+        suggestedName: `NL: ${short}`
+      });
+    }
+    out.sort((a, b) => b.score - a.score);
+    return out.slice(0, 50);
+  }
+  /**
+   * High-level: discover likely newsletters from INBOX and (optionally) create smart mailboxes for them.
+   */
+  createNewsletterSmartMailboxes(dryRun = true, minCount = 3, days = 90) {
+    const cands = this.findNewsletterCandidates(days, minCount);
+    const results = [];
+    for (const c of cands) {
+      const nm = c.suggestedName;
+      if (dryRun) {
+        results.push({ name: nm, email: c.email, wouldCreate: true, score: c.score });
+        continue;
+      }
+      const ok = this.createSmartMailbox(nm, c.email);
+      results.push({ name: nm, email: c.email, success: ok, score: c.score });
+    }
+    return { dryRun, createdOrProposed: results, count: results.length };
   }
   // ===========================================================================
   // Account Operations
@@ -82380,6 +82628,72 @@ server.registerTool(
       newName
     });
   }, "Error renaming mailbox")
+);
+server.tool(
+  "list-smart-mailboxes",
+  {},
+  withErrorHandling(() => {
+    const list = mailManager.listSmartMailboxes();
+    if (list.length === 0) {
+      return successResponse("No smart mailboxes found");
+    }
+    const lines = list.map((s) => `  - ${s.name}${s.criteriaSummary ? ` (${s.criteriaSummary})` : ""}`).join("\n");
+    return successResponse(`Found ${list.length} smart mailbox(es):
+${lines}`);
+  }, "Error listing smart mailboxes")
+);
+server.tool(
+  "create-smart-mailbox",
+  {
+    name: external_exports.string().min(1, "Smart mailbox name is required"),
+    fromContains: external_exports.string().optional().describe("Match sender (From contains)"),
+    subjectContains: external_exports.string().optional().describe("Match subject (contains)"),
+    bodyContains: external_exports.string().optional().describe("Match body (contains)")
+  },
+  withErrorHandling(({ name, fromContains, subjectContains, bodyContains }) => {
+    const ok = mailManager.createSmartMailbox(
+      name,
+      fromContains || "",
+      subjectContains || "",
+      bodyContains || ""
+    );
+    if (!ok) {
+      return errorResponse(`Failed to create smart mailbox "${name}"`);
+    }
+    return successResponse(`Smart mailbox "${name}" created (or already existed)`);
+  }, "Error creating smart mailbox")
+);
+server.tool(
+  "delete-smart-mailbox",
+  {
+    name: external_exports.string().min(1, "Smart mailbox name is required")
+  },
+  withErrorHandling(({ name }) => {
+    const ok = mailManager.deleteSmartMailbox(name);
+    if (!ok) {
+      return errorResponse(`Failed to delete smart mailbox "${name}"`);
+    }
+    return successResponse(`Smart mailbox "${name}" deleted`);
+  }, "Error deleting smart mailbox")
+);
+server.tool(
+  "create-newsletter-smart-mailboxes",
+  {
+    dryRun: external_exports.boolean().default(true).describe("If true, only propose; if false, actually create"),
+    minCount: external_exports.number().int().min(1).default(3).describe("Minimum messages from sender in the period"),
+    days: external_exports.number().int().min(1).default(90).describe("Look back this many days in INBOXes")
+  },
+  withErrorHandling(({ dryRun, minCount, days }) => {
+    const result = mailManager.createNewsletterSmartMailboxes(!!dryRun, minCount, days);
+    const lines = result.createdOrProposed.map(
+      (c) => `  - ${c.name || c.suggestedName || c.email} (score ${c.score || "?"}${c.wouldCreate ? ", dry-run" : ""})`
+    ).join("\n");
+    const prefix = result.dryRun ? "DRY RUN - would create" : "Created";
+    return successResponse(
+      `${prefix} ${result.count} newsletter smart mailbox(es):
+${lines || "  (none met the threshold)"}`
+    );
+  }, "Error creating newsletter smart mailboxes")
 );
 server.registerTool(
   "list-accounts",

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.8.16",
+  "version": "2.9.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.8.16",
+  "version": "2.9.0",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2106,6 +2106,92 @@ server.registerTool(
   }, "Error renaming mailbox")
 );
 
+// --- list-smart-mailboxes (intelligente Postfächer) ---
+
+server.tool(
+  "list-smart-mailboxes",
+  {},
+  withErrorHandling(() => {
+    const list = mailManager.listSmartMailboxes();
+    if (list.length === 0) {
+      return successResponse("No smart mailboxes found");
+    }
+    const lines = list
+      .map((s: any) => `  - ${s.name}${s.criteriaSummary ? ` (${s.criteriaSummary})` : ""}`)
+      .join("\n");
+    return successResponse(`Found ${list.length} smart mailbox(es):\n${lines}`);
+  }, "Error listing smart mailboxes")
+);
+
+// --- create-smart-mailbox ---
+
+server.tool(
+  "create-smart-mailbox",
+  {
+    name: z.string().min(1, "Smart mailbox name is required"),
+    fromContains: z.string().optional().describe("Match sender (From contains)"),
+    subjectContains: z.string().optional().describe("Match subject (contains)"),
+    bodyContains: z.string().optional().describe("Match body (contains)"),
+  },
+  withErrorHandling(({ name, fromContains, subjectContains, bodyContains }) => {
+    const ok = mailManager.createSmartMailbox(
+      name,
+      fromContains || "",
+      subjectContains || "",
+      bodyContains || ""
+    );
+    if (!ok) {
+      return errorResponse(`Failed to create smart mailbox "${name}"`);
+    }
+    return successResponse(`Smart mailbox "${name}" created (or already existed)`);
+  }, "Error creating smart mailbox")
+);
+
+// --- delete-smart-mailbox ---
+
+server.tool(
+  "delete-smart-mailbox",
+  {
+    name: z.string().min(1, "Smart mailbox name is required"),
+  },
+  withErrorHandling(({ name }) => {
+    const ok = mailManager.deleteSmartMailbox(name);
+    if (!ok) {
+      return errorResponse(`Failed to delete smart mailbox "${name}"`);
+    }
+    return successResponse(`Smart mailbox "${name}" deleted`);
+  }, "Error deleting smart mailbox")
+);
+
+// --- create-newsletter-smart-mailboxes (the main use-case: from Inbox) ---
+
+server.tool(
+  "create-newsletter-smart-mailboxes",
+  {
+    dryRun: z.boolean().default(true).describe("If true, only propose; if false, actually create"),
+    minCount: z
+      .number()
+      .int()
+      .min(1)
+      .default(3)
+      .describe("Minimum messages from sender in the period"),
+    days: z.number().int().min(1).default(90).describe("Look back this many days in INBOXes"),
+  },
+  withErrorHandling(({ dryRun, minCount, days }) => {
+    const result = mailManager.createNewsletterSmartMailboxes(!!dryRun, minCount, days);
+    const lines = result.createdOrProposed
+      .map(
+        (c: any) =>
+          `  - ${c.name || c.suggestedName || c.email} (score ${c.score || "?"}${c.wouldCreate ? ", dry-run" : ""})`
+      )
+      .join("\n");
+    const prefix = result.dryRun ? "DRY RUN - would create" : "Created";
+    return successResponse(
+      `${prefix} ${result.count} newsletter smart mailbox(es):\n${lines || "  (none met the threshold)"}`
+    );
+  }, "Error creating newsletter smart mailboxes")
+);
+
 // =============================================================================
 // Account Tools
 // =============================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -2108,86 +2108,155 @@ server.registerTool(
 
 // --- list-smart-mailboxes (intelligente Postfächer) ---
 
-server.tool(
+server.registerTool(
   "list-smart-mailboxes",
-  {},
+  {
+    description:
+      "Use when: listing Apple Mail smart mailboxes (criteria-based virtual views), including on German-localized macOS where AppleScript's smart-mailbox terms do not compile.\nReturns: each smart mailbox's name and a short criteria summary.\nDo not use when: listing real folders/mailboxes (use list-mailboxes).",
+    inputSchema: {},
+    outputSchema: {
+      count: z.number().optional(),
+      smartMailboxes: z
+        .array(
+          z.object({
+            name: z.string(),
+            id: z.string().optional(),
+            criteriaSummary: z.string().optional(),
+          })
+        )
+        .optional(),
+    },
+  },
   withErrorHandling(() => {
     const list = mailManager.listSmartMailboxes();
     if (list.length === 0) {
-      return successResponse("No smart mailboxes found");
+      return successResponse("No smart mailboxes found", { count: 0, smartMailboxes: [] });
     }
     const lines = list
-      .map((s: any) => `  - ${s.name}${s.criteriaSummary ? ` (${s.criteriaSummary})` : ""}`)
+      .map((s) => `  - ${s.name}${s.criteriaSummary ? ` (${s.criteriaSummary})` : ""}`)
       .join("\n");
-    return successResponse(`Found ${list.length} smart mailbox(es):\n${lines}`);
+    return successResponse(`Found ${list.length} smart mailbox(es):\n${lines}`, {
+      count: list.length,
+      smartMailboxes: list.map((s) => ({
+        name: s.name,
+        id: s.id,
+        criteriaSummary: s.criteriaSummary,
+      })),
+    });
   }, "Error listing smart mailboxes")
 );
 
 // --- create-smart-mailbox ---
 
-server.tool(
+server.registerTool(
   "create-smart-mailbox",
   {
-    name: z.string().min(1, "Smart mailbox name is required"),
-    fromContains: z.string().optional().describe("Match sender (From contains)"),
-    subjectContains: z.string().optional().describe("Match subject (contains)"),
-    bodyContains: z.string().optional().describe("Match body (contains)"),
+    description:
+      "Use when: creating an Apple Mail smart mailbox (a criteria-based virtual view) that matches a sender, subject, or body substring — works on German-localized macOS where AppleScript's smart-mailbox terms fail.\nReturns: confirmation of creation, or a note that a smart mailbox with that name already existed.\nDo not use when: creating a real folder (use create-mailbox).\nSafety: edits Apple Mail's SyncedSmartMailboxes.plist directly. It backs the file up (.bak) and writes atomically, and never rewrites your existing smart mailboxes. It does not quit Mail — quit Mail first for reliable results, since a running Mail may not show the new smart mailbox until relaunched and can overwrite plist edits it did not make.",
+    inputSchema: {
+      name: z.string().min(1, "Smart mailbox name is required"),
+      fromContains: z.string().optional().describe("Match sender (From contains)"),
+      subjectContains: z.string().optional().describe("Match subject (contains)"),
+      bodyContains: z.string().optional().describe("Match body (contains)"),
+    },
+    outputSchema: {
+      ok: z.boolean().optional(),
+      name: z.string().optional(),
+      alreadyExisted: z.boolean().optional(),
+    },
   },
   withErrorHandling(({ name, fromContains, subjectContains, bodyContains }) => {
-    const ok = mailManager.createSmartMailbox(
+    if (!fromContains && !subjectContains && !bodyContains) {
+      return errorResponse("Provide at least one of fromContains / subjectContains / bodyContains");
+    }
+    const r = mailManager.createSmartMailbox(
       name,
       fromContains || "",
       subjectContains || "",
       bodyContains || ""
     );
-    if (!ok) {
-      return errorResponse(`Failed to create smart mailbox "${name}"`);
+    if (r.alreadyExisted) {
+      return successResponse(`Smart mailbox "${name}" already exists`, {
+        ok: true,
+        name,
+        alreadyExisted: true,
+      });
     }
-    return successResponse(`Smart mailbox "${name}" created (or already existed)`);
+    if (!r.created) {
+      return errorResponse(r.error || `Failed to create smart mailbox "${name}"`);
+    }
+    return successResponse(`Smart mailbox "${name}" created. Quit and reopen Mail to see it.`, {
+      ok: true,
+      name,
+      alreadyExisted: false,
+    });
   }, "Error creating smart mailbox")
 );
 
 // --- delete-smart-mailbox ---
 
-server.tool(
+server.registerTool(
   "delete-smart-mailbox",
   {
-    name: z.string().min(1, "Smart mailbox name is required"),
+    description:
+      "Use when: deleting an Apple Mail smart mailbox (virtual view) by name.\nReturns: confirmation of deletion.\nDo not use when: deleting a real folder (use delete-mailbox) or messages (use delete-message / batch-delete-messages).\nSafety: destructive — removes the smart mailbox from Apple Mail's SyncedSmartMailboxes.plist. It backs the file up (.bak) and writes atomically, preserving every other smart mailbox, but the removal is not undoable in-app. Confirm the exact name with list-smart-mailboxes first, and quit Mail first for reliable results.",
+    inputSchema: {
+      name: z.string().min(1, "Smart mailbox name is required"),
+    },
+    outputSchema: {
+      ok: z.boolean().optional(),
+      name: z.string().optional(),
+    },
   },
   withErrorHandling(({ name }) => {
-    const ok = mailManager.deleteSmartMailbox(name);
-    if (!ok) {
-      return errorResponse(`Failed to delete smart mailbox "${name}"`);
+    const r = mailManager.deleteSmartMailbox(name);
+    if (!r.deleted) {
+      return errorResponse(r.error || `Failed to delete smart mailbox "${name}"`);
     }
-    return successResponse(`Smart mailbox "${name}" deleted`);
+    return successResponse(`Smart mailbox "${name}" deleted. Quit and reopen Mail to refresh.`, {
+      ok: true,
+      name,
+    });
   }, "Error deleting smart mailbox")
 );
 
 // --- create-newsletter-smart-mailboxes (the main use-case: from Inbox) ---
 
-server.tool(
+server.registerTool(
   "create-newsletter-smart-mailboxes",
   {
-    dryRun: z.boolean().default(true).describe("If true, only propose; if false, actually create"),
-    minCount: z
-      .number()
-      .int()
-      .min(1)
-      .default(3)
-      .describe("Minimum messages from sender in the period"),
-    days: z.number().int().min(1).default(90).describe("Look back this many days in INBOXes"),
+    description:
+      'Use when: auto-discovering newsletter/bulk senders in your INBOX(es) and (optionally) creating a dedicated smart mailbox per sender (named "NL: <sender>"). Defaults to a safe dry run that only proposes.\nReturns: the proposed or created smart mailboxes with their match scores.\nDo not use when: you already know the exact sender (use create-smart-mailbox) or want real folders (use create-mailbox).\nSafety: with dryRun=false it edits Apple Mail\'s SyncedSmartMailboxes.plist (backed up, atomic, existing entries preserved) and can create many smart mailboxes at once — review a dryRun first. It scans up to ~400 recent messages per inbox via AppleScript, which can be slow on large mailboxes.',
+    inputSchema: {
+      dryRun: z
+        .boolean()
+        .default(true)
+        .describe("If true (default), only propose; if false, actually create"),
+      minCount: z
+        .number()
+        .int()
+        .min(1)
+        .default(3)
+        .describe("Minimum messages from sender in the period"),
+      days: z.number().int().min(1).default(90).describe("Look back this many days in INBOXes"),
+    },
+    outputSchema: {
+      dryRun: z.boolean().optional(),
+      count: z.number().optional(),
+    },
   },
   withErrorHandling(({ dryRun, minCount, days }) => {
     const result = mailManager.createNewsletterSmartMailboxes(!!dryRun, minCount, days);
     const lines = result.createdOrProposed
       .map(
         (c: any) =>
-          `  - ${c.name || c.suggestedName || c.email} (score ${c.score || "?"}${c.wouldCreate ? ", dry-run" : ""})`
+          `  - ${c.name || c.suggestedName || c.email} (score ${c.score ?? "?"}${c.wouldCreate ? ", dry-run" : c.alreadyExisted ? ", already existed" : c.error ? `, error: ${c.error}` : ""})`
       )
       .join("\n");
     const prefix = result.dryRun ? "DRY RUN - would create" : "Created";
     return successResponse(
-      `${prefix} ${result.count} newsletter smart mailbox(es):\n${lines || "  (none met the threshold)"}`
+      `${prefix} ${result.count} newsletter smart mailbox(es):\n${lines || "  (none met the threshold)"}`,
+      { dryRun: result.dryRun, count: result.count }
     );
   }, "Error creating newsletter smart mailboxes")
 );

--- a/src/services/appleMailManager.smartMailbox.test.ts
+++ b/src/services/appleMailManager.smartMailbox.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for the smart-mailbox (intelligente Postfächer) tools.
+ *
+ * Two layers:
+ *  1. Pure logic — extractEmail, buildSmartMailboxEntry, and the newsletter
+ *     grouping/scoring — with executeAppleScript mocked, so no Mail is needed.
+ *  2. Real plist round-trips via the path-injectable *AtPath cores against a
+ *     fixture SyncedSmartMailboxes.plist that deliberately contains <date> and
+ *     <data> criteria. That fixture is the exact case that broke the original
+ *     implementation (plutil's json converter rejects date/data, so it read the
+ *     file as empty and would overwrite every existing smart mailbox). These
+ *     tests assert the pre-existing entry — including its date/data — survives
+ *     a create and a delete untouched, and that a .bak backup is written.
+ *     They use only plutil / PlistBuddy (present on every macOS CI runner).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { spawnSync } from "child_process";
+import { existsSync, writeFileSync, mkdtempSync, rmSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const h = vi.hoisted(() => ({ output: "" }));
+
+vi.mock("@/utils/applescript.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/applescript.js")>();
+  return {
+    ...actual,
+    executeAppleScript: () => ({
+      success: true,
+      output: h.output,
+      error: undefined as string | undefined,
+    }),
+  };
+});
+
+import { AppleMailManager } from "@/services/appleMailManager.js";
+
+// A fixture plist whose first entry carries a <date> and a <data> value —
+// the types plutil's json converter cannot represent.
+const FIXTURE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+  <dict>
+    <key>MailboxName</key><string>Existing Date Rule</string>
+    <key>MailboxID</key><string>EXISTING-ID</string>
+    <key>MailboxType</key><integer>7</integer>
+    <key>MailboxCriteria</key>
+    <array>
+      <dict>
+        <key>Header</key><string>DateReceived</string>
+        <key>CriterionUniqueId</key><string>C-1</string>
+        <key>SomeDate</key><date>2024-01-15T00:00:00Z</date>
+        <key>SomeBlob</key><data>SGVsbG8gV29ybGQ=</data>
+      </dict>
+    </array>
+  </dict>
+</array>
+</plist>`;
+
+function makeFixture(dir: string): string {
+  const xml = join(dir, "src.xml");
+  const plist = join(dir, "SyncedSmartMailboxes.plist");
+  writeFileSync(xml, FIXTURE_XML, "utf8");
+  const r = spawnSync("plutil", ["-convert", "binary1", "-o", plist, xml], { encoding: "utf8" });
+  if (r.status !== 0) throw new Error(`fixture build failed: ${r.stderr}`);
+  return plist;
+}
+
+function xml1(plist: string): string {
+  return spawnSync("plutil", ["-convert", "xml1", "-o", "-", plist], { encoding: "utf8" }).stdout;
+}
+
+describe("smart mailbox — pure logic", () => {
+  let mgr: AppleMailManager;
+  beforeEach(() => {
+    mgr = new AppleMailManager();
+  });
+
+  it("extractEmail pulls the address out of a display-name header and lowercases it", () => {
+    const ex = (m: string) => (mgr as any).extractEmail(m);
+    expect(ex("Foo Bar <Foo@Bar.COM>")).toBe("foo@bar.com");
+    expect(ex("plain@addr.com")).toBe("plain@addr.com");
+    expect(ex("  Spaced <x@y.com>  ")).toBe("x@y.com");
+  });
+
+  it("buildSmartMailboxEntry selects the From/Subject/Body header from the given criterion", () => {
+    const build = (f: string, s: string, b: string) =>
+      (mgr as any).buildSmartMailboxEntry("Name", f, s, b);
+    const userCrit = (e: any) => e.MailboxCriteria.find((c: any) => c.Header === "Compound");
+
+    const fromE = build("news@x.com", "", "");
+    expect(fromE.MailboxName).toBe("Name");
+    expect(fromE.MailboxType).toBe(7);
+    expect(userCrit(fromE).Criteria[0].Header).toBe("From");
+    expect(userCrit(fromE).Criteria[0].Expression).toBe("news@x.com");
+
+    expect(userCrit(build("", "Invoice", "")).Criteria[0].Header).toBe("Subject");
+    expect(userCrit(build("", "", "urgent")).Criteria[0].Header).toBe("Body");
+  });
+
+  it("groupAndScoreNewsletters groups by sender, drops senders below minCount, and flags signals", () => {
+    const rows = [
+      {
+        sender: "Acme News <news@acme.com>",
+        subject: "Weekly Digest #1",
+        source: "List-Unsubscribe: <https://acme.com/u>",
+      },
+      { sender: "Acme News <news@acme.com>", subject: "Weekly Digest #2", source: "body" },
+      { sender: "Acme News <news@acme.com>", subject: "Weekly Digest #3", source: "body" },
+      { sender: "Real Person <bob@personal.com>", subject: "lunch?", source: "hey" },
+    ];
+    const res = (mgr as any).groupAndScoreNewsletters(rows, 3);
+    expect(res).toHaveLength(1);
+    expect(res[0].email).toBe("news@acme.com");
+    expect(res[0].count).toBe(3);
+    expect(res[0].suggestedName).toBe("NL: Acme News");
+    expect(res[0].signals).toContain("list_unsubscribe");
+    expect(res[0].signals).toContain("keyword_or_list");
+    expect(res[0].score).toBeGreaterThan(0);
+  });
+
+  it("groupAndScoreNewsletters detects repetitive subjects", () => {
+    const rows = Array.from({ length: 4 }, () => ({
+      sender: "Bot <bot@svc.com>",
+      subject: "Your daily report is ready to view now",
+      source: "plain",
+    }));
+    const res = (mgr as any).groupAndScoreNewsletters(rows, 3);
+    expect(res[0].signals).toContain("repetitive_subject");
+  });
+
+  it("findNewsletterCandidates runs the (mocked) scan through grouping/scoring", () => {
+    h.output = [
+      "Acme <news@acme.com>|Digest 1|List-Unsubscribe: <x>",
+      "Acme <news@acme.com>|Digest 2|body",
+      "Acme <news@acme.com>|Digest 3|body",
+      "",
+    ].join("\n");
+    const res = mgr.findNewsletterCandidates(90, 3);
+    expect(res).toHaveLength(1);
+    expect(res[0].email).toBe("news@acme.com");
+  });
+});
+
+describe("smart mailbox — real plist round-trips (preserve date/data, backup, atomic)", () => {
+  let dir: string;
+  let plist: string;
+  let mgr: AppleMailManager;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "smartmbox-"));
+    plist = makeFixture(dir);
+    mgr = new AppleMailManager();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads a date/data plist via the PlistBuddy fallback (json converter can't)", () => {
+    // The json fast-path fails on this fixture...
+    const j = spawnSync("plutil", ["-convert", "json", "-o", "-", plist], { encoding: "utf8" });
+    expect(j.status).not.toBe(0);
+    // ...but the manager still enumerates the entry structurally.
+    const entries = (mgr as any).readSmartMailboxEntries(plist);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe("Existing Date Rule");
+  });
+
+  it("createSmartMailboxAtPath appends without touching the existing date/data entry", () => {
+    const r = (mgr as any).createSmartMailboxAtPath(plist, "NL: Acme", "news@acme.com", "", "");
+    expect(r).toEqual({ created: true, alreadyExisted: false });
+
+    // Existing entry's <date> and <data> survived verbatim.
+    const out = xml1(plist);
+    expect(out).toContain("<date>2024-01-15T00:00:00Z</date>");
+    expect(out).toContain("SGVsbG8gV29ybGQ=");
+    expect(out).toContain("Existing Date Rule");
+
+    // Both entries present, still a valid plist, and a backup was written.
+    const names = (mgr as any).readSmartMailboxEntries(plist).map((e: any) => e.name);
+    expect(names).toEqual(["Existing Date Rule", "NL: Acme"]);
+    expect(spawnSync("plutil", ["-lint", plist], { encoding: "utf8" }).status).toBe(0);
+    expect(existsSync(`${plist}.bak`)).toBe(true);
+    // Backup holds the pre-write state (single original entry).
+    expect(readFileSync(`${plist}.bak`)).not.toBeNull();
+    expect((mgr as any).readSmartMailboxEntries(`${plist}.bak`)).toHaveLength(1);
+  });
+
+  it("createSmartMailboxAtPath is idempotent on an existing name", () => {
+    (mgr as any).createSmartMailboxAtPath(plist, "NL: Acme", "news@acme.com", "", "");
+    const again = (mgr as any).createSmartMailboxAtPath(plist, "NL: Acme", "news@acme.com", "", "");
+    expect(again).toEqual({ created: false, alreadyExisted: true });
+    expect((mgr as any).readSmartMailboxEntries(plist)).toHaveLength(2);
+  });
+
+  it("deleteSmartMailboxAtPath removes only the named entry and preserves the rest", () => {
+    (mgr as any).createSmartMailboxAtPath(plist, "NL: Acme", "news@acme.com", "", "");
+    const del = (mgr as any).deleteSmartMailboxAtPath(plist, "NL: Acme");
+    expect(del).toEqual({ deleted: true });
+
+    const names = (mgr as any).readSmartMailboxEntries(plist).map((e: any) => e.name);
+    expect(names).toEqual(["Existing Date Rule"]);
+    // The surviving entry still has its date/data intact.
+    const out = xml1(plist);
+    expect(out).toContain("<date>2024-01-15T00:00:00Z</date>");
+    expect(out).toContain("SGVsbG8gV29ybGQ=");
+  });
+
+  it("deleteSmartMailboxAtPath reports not-found without mutating the file", () => {
+    const before = xml1(plist);
+    const del = (mgr as any).deleteSmartMailboxAtPath(plist, "Does Not Exist");
+    expect(del.deleted).toBe(false);
+    expect(xml1(plist)).toBe(before);
+  });
+});

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -18,13 +18,16 @@ import {
   existsSync,
   writeFileSync,
   readFileSync,
+  readdirSync,
+  unlinkSync,
   mkdtempSync,
   rmSync,
   realpathSync,
   lstatSync,
 } from "fs";
 import { isAbsolute, resolve, sep, join } from "path";
-import { homedir } from "os";
+import { homedir, tmpdir } from "os";
+import { randomUUID } from "crypto";
 import { executeAppleScript } from "@/utils/applescript.js";
 import { parseMimeAttachments, extractMimeAttachment, extractHtmlBody } from "@/utils/mimeParse.js";
 import { TemplateStore } from "@/services/templateStore.js";
@@ -54,6 +57,7 @@ import type {
   SearchDiagnostics,
   SearchResult,
   AppleScriptResult,
+  SmartMailbox,
 } from "@/types.js";
 
 // =============================================================================
@@ -3169,6 +3173,309 @@ export class AppleMailManager {
 
     this.invalidateCache();
     return { success: true };
+  }
+
+  // ===========================================================================
+  // Smart Mailbox (intelligente Postfächer) Operations
+  // Uses plist manipulation because AppleScript terms for "smart mailbox"
+  // / "intelligentes Postfach" do not compile reliably on German-localized
+  // macOS (verified via osascript + JXA). Plist format is stable and
+  // gives full control over criteria without UI/GUI scripting.
+  // ===========================================================================
+
+  private findSyncedSmartPlist(): string | null {
+    const base = join(homedir(), "Library", "Mail");
+    try {
+      const versions = readdirSync(base).filter((d: string) => d.startsWith("V"));
+      versions.sort().reverse();
+      for (const v of versions) {
+        const p = join(base, v, "MailData", "SyncedSmartMailboxes.plist");
+        if (existsSync(p)) return p;
+      }
+    } catch {
+      // no Mail data dir yet (Mail.app never launched) — treat as "no smart mailboxes"
+    }
+    return null;
+  }
+
+  private loadSmartMailboxes(plistPath: string | null): any[] {
+    if (!plistPath) return [];
+    try {
+      // Convert binary plist -> JSON via plutil (no extra deps)
+      const tmpJson = join(tmpdir(), `smart-${Date.now()}.json`);
+      const r = spawnSync("plutil", ["-convert", "json", "-o", tmpJson, plistPath], {
+        encoding: "utf8",
+      });
+      if (r.status !== 0) return [];
+      const data = JSON.parse(readFileSync(tmpJson, "utf8"));
+      unlinkSync(tmpJson);
+      return Array.isArray(data) ? data : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private saveSmartMailboxes(plistPath: string, mailboxes: any[]): boolean {
+    if (!plistPath) return false;
+    try {
+      const tmpJson = join(tmpdir(), `smart-${Date.now()}.json`);
+      writeFileSync(tmpJson, JSON.stringify(mailboxes, null, 2), "utf8");
+      const r = spawnSync("plutil", ["-convert", "binary1", "-o", plistPath, tmpJson], {
+        encoding: "utf8",
+      });
+      unlinkSync(tmpJson);
+      return r.status === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  private buildSmartMailboxEntry(
+    name: string,
+    fromContains = "",
+    subjectContains = "",
+    bodyContains = ""
+  ): any {
+    const newUuid = () => randomUUID().toUpperCase();
+
+    const userExpr = fromContains || subjectContains || bodyContains || "";
+    const userHeader = fromContains ? "From" : subjectContains ? "Subject" : "Body";
+
+    const userCriterion = {
+      AllCriteriaMustBeSatisfied: true,
+      Criteria: [
+        {
+          CriterionUniqueId: newUuid(),
+          Expression: userExpr,
+          Header: userHeader,
+        },
+      ],
+      CriterionUniqueId: newUuid(),
+      Header: "Compound",
+      Name: "user criteria",
+    };
+
+    return {
+      IMAPMailboxAttributes: 17,
+      MailboxAllCriteriaMustBeSatisfied: true,
+      MailboxChildren: [],
+      MailboxCriteria: [
+        { CriterionUniqueId: newUuid(), Header: "NotInTrashMailbox", Name: "omit trash" },
+        {
+          CriterionUniqueId: newUuid(),
+          Header: "NotInASpecialMailbox",
+          Name: "omit sent",
+          SpecialMailboxType: 3,
+        },
+        userCriterion,
+        { CriterionUniqueId: newUuid(), Header: "NotInJunkMailbox", Name: "omit junk" },
+      ],
+      MailboxID: newUuid(),
+      MailboxName: name,
+      MailboxType: 7,
+    };
+  }
+
+  /**
+   * List all smart mailboxes (intelligente Postfächer).
+   * Reads from the synced plist (works on German + English systems).
+   */
+  listSmartMailboxes(): SmartMailbox[] {
+    const plist = this.findSyncedSmartPlist();
+    const raw = this.loadSmartMailboxes(plist);
+    return raw.map((m: any) => {
+      const crits = m.MailboxCriteria || [];
+      const summary = crits
+        .map((c: any) => {
+          const n = c.Name || c.Header || "";
+          return c.Expression ? `${n}=${String(c.Expression).slice(0, 25)}` : n;
+        })
+        .filter(Boolean)
+        .join("; ")
+        .slice(0, 100);
+      return {
+        name: m.MailboxName || "",
+        id: m.MailboxID,
+        criteriaSummary: summary || undefined,
+      };
+    });
+  }
+
+  /**
+   * Create a new smart mailbox with simple contains criteria.
+   * Provide exactly one of fromContains / subjectContains / bodyContains.
+   */
+  createSmartMailbox(
+    name: string,
+    fromContains = "",
+    subjectContains = "",
+    bodyContains = ""
+  ): boolean {
+    if (!name || (!fromContains && !subjectContains && !bodyContains)) {
+      return false;
+    }
+    const plist = this.findSyncedSmartPlist();
+    if (!plist) {
+      console.error("No SyncedSmartMailboxes.plist found (launch Mail at least once)");
+      return false;
+    }
+    const mbs = this.loadSmartMailboxes(plist);
+    if (mbs.some((m: any) => m.MailboxName === name)) {
+      return true; // already exists, treat as success
+    }
+    const entry = this.buildSmartMailboxEntry(name, fromContains, subjectContains, bodyContains);
+    mbs.push(entry);
+    const ok = this.saveSmartMailboxes(plist, mbs);
+    if (ok) {
+      // Best effort: make Mail reload the list
+      try {
+        spawnSync("killall", ["Mail"], { stdio: "ignore" });
+      } catch {
+        // best effort — Mail.app will pick up the change on its own next launch
+      }
+    }
+    return ok;
+  }
+
+  /**
+   * Delete a smart mailbox by name (removes from the plist).
+   */
+  deleteSmartMailbox(name: string): boolean {
+    const plist = this.findSyncedSmartPlist();
+    if (!plist) return false;
+    const mbs = this.loadSmartMailboxes(plist);
+    const before = mbs.length;
+    const filtered = mbs.filter((m: any) => m.MailboxName !== name);
+    if (filtered.length === before) return false;
+    return this.saveSmartMailboxes(plist, filtered);
+  }
+
+  // --- Newsletter smart mailbox discovery (high level helper) ---
+
+  private extractEmail(sender: string): string {
+    const m = /<([^>]+)>/.exec(sender || "");
+    return m ? m[1].toLowerCase().trim() : (sender || "").toLowerCase().trim();
+  }
+
+  /**
+   * Scan recent messages and return likely newsletter senders with scores.
+   * Uses existing search/list capabilities + source sampling for List-Unsubscribe etc.
+   */
+  findNewsletterCandidates(
+    days = 90,
+    minCount = 3
+  ): Array<{
+    email: string;
+    sender: string;
+    count: number;
+    score: number;
+    signals: string[];
+    suggestedName: string;
+  }> {
+    // Use a broad recent search across inboxes via the manager's search (or listMessages with date filter).
+    // For simplicity and to avoid huge data, we fetch recent messages and group in TS.
+    // We can use searchMessages with no specific query but limit high, then filter client side.
+    // To keep it self-contained, use a direct AS scan for senders + limited source (same pattern as macos-mcp).
+    // Since we have executeAppleScript available, do a lightweight scan here.
+    const script = `
+tell application "Mail"
+  set outLines to ""
+  set cutoff to (current date) - (${days} * days)
+  repeat with acc in accounts
+    repeat with mb in mailboxes of acc
+      if name of mb is "INBOX" or name of mb is "Inbox" then
+        set msgs to (messages of mb whose date received > cutoff)
+        set cnt to 0
+        repeat with m in msgs
+          if cnt > 400 then exit repeat
+          try
+            set snd to (sender of m as text)
+            set subj to (subject of m as text)
+            set src to (source of m as text)
+            set outLines to outLines & snd & "|" & subj & "|" & src & linefeed
+            set cnt to cnt + 1
+          end try
+        end repeat
+      end if
+    end repeat
+  end repeat
+  return outLines
+end tell`;
+    const res = executeAppleScript(script, { timeoutMs: 120000 });
+    if (!res.success || !res.output) return [];
+
+    const groups: Record<string, any> = {};
+    for (const line of res.output.split("\n")) {
+      if (!line.includes("|")) continue;
+      const [snd = "", subj = "", src = ""] = line.split("|", 3);
+      const email = this.extractEmail(snd);
+      if (!email || !email.includes("@")) continue;
+      if (!groups[email]) {
+        groups[email] = { email, sender: snd, count: 0, subjects: [] as string[], sample: "" };
+      }
+      const g = groups[email];
+      g.count++;
+      if (g.subjects.length < 6) g.subjects.push(subj);
+      if (!g.sample) g.sample = src.slice(0, 3000);
+    }
+
+    const out: any[] = [];
+    for (const g of Object.values(groups) as any[]) {
+      if (g.count < minCount) continue;
+      let score = Math.min(g.count / 3, 8);
+      const blob = g.email + " " + (g.sample || "").toLowerCase();
+      const signals: string[] = [];
+      if (/newsletter|digest|noreply|no-reply|list-unsubscribe/.test(blob)) {
+        score += 4;
+        signals.push("keyword_or_list");
+      }
+      if (g.sample && /list-unsubscribe/i.test(g.sample)) {
+        score += 3;
+        signals.push("list_unsubscribe");
+      }
+      const prefixes = g.subjects.slice(0, 5).map((s: string) => s.slice(0, 30));
+      if (prefixes.length >= 2 && new Set(prefixes).size <= 2) {
+        score += 2;
+        signals.push("repetitive_subject");
+      }
+      const short = (g.sender.split("<")[0] || g.email).trim().slice(0, 30);
+      out.push({
+        email: g.email,
+        sender: g.sender.slice(0, 80),
+        count: g.count,
+        score: Math.max(0.1, Math.round(score * 10) / 10),
+        signals,
+        suggestedName: `NL: ${short}`,
+      });
+    }
+    out.sort((a, b) => b.score - a.score);
+    return out.slice(0, 50);
+  }
+
+  /**
+   * High-level: discover likely newsletters from INBOX and (optionally) create smart mailboxes for them.
+   */
+  createNewsletterSmartMailboxes(
+    dryRun = true,
+    minCount = 3,
+    days = 90
+  ): {
+    dryRun: boolean;
+    createdOrProposed: any[];
+    count: number;
+  } {
+    const cands = this.findNewsletterCandidates(days, minCount);
+    const results: any[] = [];
+    for (const c of cands) {
+      const nm = c.suggestedName;
+      if (dryRun) {
+        results.push({ name: nm, email: c.email, wouldCreate: true, score: c.score });
+        continue;
+      }
+      const ok = this.createSmartMailbox(nm, c.email);
+      results.push({ name: nm, email: c.email, success: ok, score: c.score });
+    }
+    return { dryRun, createdOrProposed: results, count: results.length };
   }
 
   // ===========================================================================

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -20,13 +20,15 @@ import {
   readFileSync,
   readdirSync,
   unlinkSync,
+  copyFileSync,
+  renameSync,
   mkdtempSync,
   rmSync,
   realpathSync,
   lstatSync,
 } from "fs";
 import { isAbsolute, resolve, sep, join } from "path";
-import { homedir, tmpdir } from "os";
+import { homedir } from "os";
 import { randomUUID } from "crypto";
 import { executeAppleScript } from "@/utils/applescript.js";
 import { parseMimeAttachments, extractMimeAttachment, extractHtmlBody } from "@/utils/mimeParse.js";
@@ -3198,36 +3200,106 @@ export class AppleMailManager {
     return null;
   }
 
-  private loadSmartMailboxes(plistPath: string | null): any[] {
-    if (!plistPath) return [];
-    try {
-      // Convert binary plist -> JSON via plutil (no extra deps)
-      const tmpJson = join(tmpdir(), `smart-${Date.now()}.json`);
-      const r = spawnSync("plutil", ["-convert", "json", "-o", tmpJson, plistPath], {
-        encoding: "utf8",
-      });
-      if (r.status !== 0) return [];
-      const data = JSON.parse(readFileSync(tmpJson, "utf8"));
-      unlinkSync(tmpJson);
-      return Array.isArray(data) ? data : [];
-    } catch {
-      return [];
+  /**
+   * Read all smart-mailbox entries without ever mutating the plist.
+   *
+   * Fast path: `plutil -convert json`. That converter *rejects* any plist
+   * containing <data>/<date> values ("Invalid object in plist for JSON
+   * format") — and smart-mailbox date criteria can contain exactly those — so
+   * on such libraries we fall back to structural probing with PlistBuddy. (The
+   * previous implementation used the json path unconditionally and, on
+   * failure, treated the whole file as empty, which then overwrote every
+   * existing smart mailbox on the next save.)
+   */
+  private readSmartMailboxEntries(
+    plistPath: string | null
+  ): Array<{ name: string; id?: string; criteriaSummary?: string }> {
+    if (!plistPath || !existsSync(plistPath)) return [];
+    const j = spawnSync("plutil", ["-convert", "json", "-o", "-", plistPath], {
+      encoding: "utf8",
+    });
+    if (j.status === 0 && j.stdout) {
+      try {
+        const data = JSON.parse(j.stdout);
+        if (Array.isArray(data)) {
+          return data.map((m: any) => ({
+            name: m?.MailboxName ?? "",
+            id: m?.MailboxID,
+            criteriaSummary: this.summarizeCriteria(m?.MailboxCriteria),
+          }));
+        }
+      } catch {
+        // malformed json output — fall through to structural probing
+      }
     }
+    return this.probeSmartMailboxEntries(plistPath);
   }
 
-  private saveSmartMailboxes(plistPath: string, mailboxes: any[]): boolean {
-    if (!plistPath) return false;
-    try {
-      const tmpJson = join(tmpdir(), `smart-${Date.now()}.json`);
-      writeFileSync(tmpJson, JSON.stringify(mailboxes, null, 2), "utf8");
-      const r = spawnSync("plutil", ["-convert", "binary1", "-o", plistPath, tmpJson], {
+  /**
+   * Structural enumeration for plists the json converter rejects (date/data
+   * criteria). Probes array indices via PlistBuddy until one is out of range.
+   */
+  private probeSmartMailboxEntries(plistPath: string): Array<{ name: string; id?: string }> {
+    const buddy = "/usr/libexec/PlistBuddy";
+    const out: Array<{ name: string; id?: string }> = [];
+    for (let i = 0; i < 1000; i++) {
+      const exists = spawnSync(buddy, ["-c", `Print :${i}`, plistPath], { encoding: "utf8" });
+      if (exists.status !== 0) break;
+      const nameR = spawnSync(buddy, ["-c", `Print :${i}:MailboxName`, plistPath], {
         encoding: "utf8",
       });
-      unlinkSync(tmpJson);
-      return r.status === 0;
-    } catch {
+      const idR = spawnSync(buddy, ["-c", `Print :${i}:MailboxID`, plistPath], {
+        encoding: "utf8",
+      });
+      out.push({
+        name: nameR.status === 0 ? (nameR.stdout || "").trim() : "",
+        id: idR.status === 0 ? (idR.stdout || "").trim() || undefined : undefined,
+      });
+    }
+    return out;
+  }
+
+  private summarizeCriteria(crits: any): string | undefined {
+    if (!Array.isArray(crits)) return undefined;
+    const summary = crits
+      .map((c: any) => {
+        const n = c?.Name || c?.Header || "";
+        return c?.Expression ? `${n}=${String(c.Expression).slice(0, 25)}` : n;
+      })
+      .filter(Boolean)
+      .join("; ")
+      .slice(0, 100);
+    return summary || undefined;
+  }
+
+  /**
+   * Back up `plistPath` to `<plist>.bak` and return a sibling temp-file path
+   * (same directory → same filesystem, so the later rename is atomic) seeded
+   * with the current contents. Callers mutate the temp copy, then
+   * commitSmartPlist() lints and atomically renames it into place — so the live
+   * plist is only ever replaced wholesale by a validated file, never edited in
+   * place and never left half-written.
+   */
+  private prepareSmartPlistWrite(plistPath: string): string {
+    copyFileSync(plistPath, `${plistPath}.bak`);
+    const temp = `${plistPath}.tmp-${randomUUID()}`;
+    copyFileSync(plistPath, temp);
+    return temp;
+  }
+
+  /** Lint the mutated temp file and atomically move it into place. */
+  private commitSmartPlist(temp: string, plistPath: string): boolean {
+    const lint = spawnSync("plutil", ["-lint", temp], { encoding: "utf8" });
+    if (lint.status !== 0) {
+      try {
+        unlinkSync(temp);
+      } catch {
+        // best effort
+      }
       return false;
     }
+    renameSync(temp, plistPath);
+    return true;
   }
 
   private buildSmartMailboxEntry(
@@ -3282,72 +3354,127 @@ export class AppleMailManager {
    */
   listSmartMailboxes(): SmartMailbox[] {
     const plist = this.findSyncedSmartPlist();
-    const raw = this.loadSmartMailboxes(plist);
-    return raw.map((m: any) => {
-      const crits = m.MailboxCriteria || [];
-      const summary = crits
-        .map((c: any) => {
-          const n = c.Name || c.Header || "";
-          return c.Expression ? `${n}=${String(c.Expression).slice(0, 25)}` : n;
-        })
-        .filter(Boolean)
-        .join("; ")
-        .slice(0, 100);
-      return {
-        name: m.MailboxName || "",
-        id: m.MailboxID,
-        criteriaSummary: summary || undefined,
-      };
-    });
+    return this.readSmartMailboxEntries(plist).map((m) => ({
+      name: m.name || "",
+      id: m.id,
+      criteriaSummary: m.criteriaSummary,
+    }));
   }
 
   /**
-   * Create a new smart mailbox with simple contains criteria.
-   * Provide exactly one of fromContains / subjectContains / bodyContains.
+   * Create a new smart mailbox with a simple contains criterion.
+   * Provide at least one of fromContains / subjectContains / bodyContains.
+   *
+   * The new entry is appended to SyncedSmartMailboxes.plist with a lossless
+   * `plutil -insert -json` on a backed-up temp copy — existing smart mailboxes
+   * (including any with date/data criteria) are preserved byte-for-byte, and
+   * the live file is only ever replaced by a lint-validated copy. Does NOT quit
+   * or restart Mail; the new mailbox appears the next time Mail is launched.
    */
   createSmartMailbox(
     name: string,
     fromContains = "",
     subjectContains = "",
     bodyContains = ""
-  ): boolean {
+  ): { created: boolean; alreadyExisted: boolean; error?: string } {
     if (!name || (!fromContains && !subjectContains && !bodyContains)) {
-      return false;
+      return {
+        created: false,
+        alreadyExisted: false,
+        error: "Provide a name and at least one of fromContains / subjectContains / bodyContains",
+      };
     }
     const plist = this.findSyncedSmartPlist();
     if (!plist) {
-      console.error("No SyncedSmartMailboxes.plist found (launch Mail at least once)");
-      return false;
+      return {
+        created: false,
+        alreadyExisted: false,
+        error: "No SyncedSmartMailboxes.plist found (launch Mail at least once)",
+      };
     }
-    const mbs = this.loadSmartMailboxes(plist);
-    if (mbs.some((m: any) => m.MailboxName === name)) {
-      return true; // already exists, treat as success
+    return this.createSmartMailboxAtPath(plist, name, fromContains, subjectContains, bodyContains);
+  }
+
+  /** Path-injectable core of createSmartMailbox (unit-testable against a fixture plist). */
+  private createSmartMailboxAtPath(
+    plistPath: string,
+    name: string,
+    fromContains = "",
+    subjectContains = "",
+    bodyContains = ""
+  ): { created: boolean; alreadyExisted: boolean; error?: string } {
+    const entries = this.readSmartMailboxEntries(plistPath);
+    if (entries.some((e) => e.name === name)) {
+      return { created: false, alreadyExisted: true };
     }
     const entry = this.buildSmartMailboxEntry(name, fromContains, subjectContains, bodyContains);
-    mbs.push(entry);
-    const ok = this.saveSmartMailboxes(plist, mbs);
-    if (ok) {
-      // Best effort: make Mail reload the list
+    const temp = this.prepareSmartPlistWrite(plistPath);
+    const ins = spawnSync(
+      "plutil",
+      ["-insert", String(entries.length), "-json", JSON.stringify(entry), temp],
+      { encoding: "utf8" }
+    );
+    if (ins.status !== 0) {
       try {
-        spawnSync("killall", ["Mail"], { stdio: "ignore" });
+        unlinkSync(temp);
       } catch {
-        // best effort — Mail.app will pick up the change on its own next launch
+        // best effort
       }
+      return {
+        created: false,
+        alreadyExisted: false,
+        error: (ins.stderr || "plutil insert failed").trim(),
+      };
     }
-    return ok;
+    if (!this.commitSmartPlist(temp, plistPath)) {
+      return {
+        created: false,
+        alreadyExisted: false,
+        error: "Edited plist failed validation; original left untouched",
+      };
+    }
+    return { created: true, alreadyExisted: false };
   }
 
   /**
-   * Delete a smart mailbox by name (removes from the plist).
+   * Delete a smart mailbox by name. Removes exactly the matching entry via
+   * PlistBuddy on a backed-up temp copy; every other smart mailbox is
+   * preserved. Does NOT quit or restart Mail.
    */
-  deleteSmartMailbox(name: string): boolean {
+  deleteSmartMailbox(name: string): { deleted: boolean; error?: string } {
     const plist = this.findSyncedSmartPlist();
-    if (!plist) return false;
-    const mbs = this.loadSmartMailboxes(plist);
-    const before = mbs.length;
-    const filtered = mbs.filter((m: any) => m.MailboxName !== name);
-    if (filtered.length === before) return false;
-    return this.saveSmartMailboxes(plist, filtered);
+    if (!plist) {
+      return { deleted: false, error: "No SyncedSmartMailboxes.plist found" };
+    }
+    return this.deleteSmartMailboxAtPath(plist, name);
+  }
+
+  /** Path-injectable core of deleteSmartMailbox (unit-testable against a fixture plist). */
+  private deleteSmartMailboxAtPath(
+    plistPath: string,
+    name: string
+  ): { deleted: boolean; error?: string } {
+    const entries = this.readSmartMailboxEntries(plistPath);
+    const idx = entries.findIndex((e) => e.name === name);
+    if (idx < 0) {
+      return { deleted: false, error: `Smart mailbox "${name}" not found` };
+    }
+    const temp = this.prepareSmartPlistWrite(plistPath);
+    const del = spawnSync("/usr/libexec/PlistBuddy", ["-c", `Delete :${idx}`, temp], {
+      encoding: "utf8",
+    });
+    if (del.status !== 0) {
+      try {
+        unlinkSync(temp);
+      } catch {
+        // best effort
+      }
+      return { deleted: false, error: (del.stderr || "PlistBuddy delete failed").trim() };
+    }
+    if (!this.commitSmartPlist(temp, plistPath)) {
+      return { deleted: false, error: "Edited plist failed validation; original left untouched" };
+    }
+    return { deleted: true };
   }
 
   // --- Newsletter smart mailbox discovery (high level helper) ---
@@ -3358,25 +3485,12 @@ export class AppleMailManager {
   }
 
   /**
-   * Scan recent messages and return likely newsletter senders with scores.
-   * Uses existing search/list capabilities + source sampling for List-Unsubscribe etc.
+   * Scan recent INBOX messages and return raw [sender, subject, source] rows.
+   * This is the only AppleScript-touching part of newsletter discovery; the
+   * grouping/scoring is factored into groupAndScoreNewsletters() so it can be
+   * unit-tested without a running Mail.
    */
-  findNewsletterCandidates(
-    days = 90,
-    minCount = 3
-  ): Array<{
-    email: string;
-    sender: string;
-    count: number;
-    score: number;
-    signals: string[];
-    suggestedName: string;
-  }> {
-    // Use a broad recent search across inboxes via the manager's search (or listMessages with date filter).
-    // For simplicity and to avoid huge data, we fetch recent messages and group in TS.
-    // We can use searchMessages with no specific query but limit high, then filter client side.
-    // To keep it self-contained, use a direct AS scan for senders + limited source (same pattern as macos-mcp).
-    // Since we have executeAppleScript available, do a lightweight scan here.
+  private scanInboxRows(days: number): Array<{ sender: string; subject: string; source: string }> {
     const script = `
 tell application "Mail"
   set outLines to ""
@@ -3403,11 +3517,33 @@ tell application "Mail"
 end tell`;
     const res = executeAppleScript(script, { timeoutMs: 120000 });
     if (!res.success || !res.output) return [];
-
-    const groups: Record<string, any> = {};
+    const rows: Array<{ sender: string; subject: string; source: string }> = [];
     for (const line of res.output.split("\n")) {
       if (!line.includes("|")) continue;
       const [snd = "", subj = "", src = ""] = line.split("|", 3);
+      rows.push({ sender: snd, subject: subj, source: src });
+    }
+    return rows;
+  }
+
+  /**
+   * Pure grouping + scoring over scanned rows. Groups by sender email, keeps
+   * senders at/above minCount, and scores by volume plus newsletter signals
+   * (List-Unsubscribe, noreply/newsletter keywords, repetitive subjects).
+   */
+  private groupAndScoreNewsletters(
+    rows: Array<{ sender: string; subject: string; source: string }>,
+    minCount: number
+  ): Array<{
+    email: string;
+    sender: string;
+    count: number;
+    score: number;
+    signals: string[];
+    suggestedName: string;
+  }> {
+    const groups: Record<string, any> = {};
+    for (const { sender: snd, subject: subj, source: src } of rows) {
       const email = this.extractEmail(snd);
       if (!email || !email.includes("@")) continue;
       if (!groups[email]) {
@@ -3416,7 +3552,7 @@ end tell`;
       const g = groups[email];
       g.count++;
       if (g.subjects.length < 6) g.subjects.push(subj);
-      if (!g.sample) g.sample = src.slice(0, 3000);
+      if (!g.sample) g.sample = (src || "").slice(0, 3000);
     }
 
     const out: any[] = [];
@@ -3453,6 +3589,23 @@ end tell`;
   }
 
   /**
+   * Scan recent messages and return likely newsletter senders with scores.
+   */
+  findNewsletterCandidates(
+    days = 90,
+    minCount = 3
+  ): Array<{
+    email: string;
+    sender: string;
+    count: number;
+    score: number;
+    signals: string[];
+    suggestedName: string;
+  }> {
+    return this.groupAndScoreNewsletters(this.scanInboxRows(days), minCount);
+  }
+
+  /**
    * High-level: discover likely newsletters from INBOX and (optionally) create smart mailboxes for them.
    */
   createNewsletterSmartMailboxes(
@@ -3472,8 +3625,15 @@ end tell`;
         results.push({ name: nm, email: c.email, wouldCreate: true, score: c.score });
         continue;
       }
-      const ok = this.createSmartMailbox(nm, c.email);
-      results.push({ name: nm, email: c.email, success: ok, score: c.score });
+      const r = this.createSmartMailbox(nm, c.email);
+      results.push({
+        name: nm,
+        email: c.email,
+        success: r.created || r.alreadyExisted,
+        alreadyExisted: r.alreadyExisted,
+        error: r.error,
+        score: c.score,
+      });
     }
     return { dryRun, createdOrProposed: results, count: results.length };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,21 @@ export interface Mailbox {
 }
 
 /**
+ * Represents a smart mailbox (intelligentes Postfach) in Apple Mail.
+ * These are virtual, criteria-based views (not real folders).
+ */
+export interface SmartMailbox {
+  /** Display name of the smart mailbox */
+  name: string;
+
+  /** Internal ID from the plist */
+  id?: string;
+
+  /** Human readable summary of the matching criteria */
+  criteriaSummary?: string;
+}
+
+/**
  * Represents an email account in Apple Mail.
  */
 export interface Account {


### PR DESCRIPTION
Carries forward @maf4711's smart-mailbox tools from #105, plus the hardening, tests, and release bits that PR needed. The PR head on #105 is the fork's `main` branch, so its required checks never trigger — this in-repo branch gets full CI. Original PR: #105 (authorship preserved via `Co-authored-by`; squash-merge should keep that trailer).

## What was blocking #105, and how it's addressed

**1. Data-loss risk in the plist writes (the big one).** The original whole-plist `plutil -convert json` round-trip doesn't just *lossily* rewrite other entries — it **fails outright** on any plist containing `<date>`/`<data>` criteria (`plutil: Invalid object in plist for JSON format`). `loadSmartMailboxes` then returned `[]`, and `saveSmartMailboxes` wrote a single-entry plist — **wiping every existing smart mailbox** on a library that has even one date-based smart mailbox.

Now:
- **Reads** try `plutil -convert json` and fall back to structural `PlistBuddy` probing when json rejects the file.
- **Writes** never touch other entries: create appends one entry with `plutil -insert <count> -json`; delete removes one with `PlistBuddy Delete :<index>`. Both run on a **backup** (`SyncedSmartMailboxes.plist.bak`) + **temp copy**, are validated with `plutil -lint`, then **atomically renamed** into place. Existing entries (incl. `<date>`/`<data>`) are preserved byte-for-byte.

**2. `killall Mail` removed** — it was a silent destructive side effect and a lost-update race (SIGTERM makes Mail flush its in-memory state back over the plist edit). Changes now appear on Mail's next launch; documented in each tool's `Safety:` line.

**3. Tests added** (`appleMailManager.smartMailbox.test.ts`, 10 tests) — the AppleScript scan is factored out of newsletter discovery so the pure logic (`extractEmail`, `buildSmartMailboxEntry`, grouping/scoring) is covered, **plus real-plist round-trips against a fixture containing `<date>`/`<data>` that prove create/delete preserve existing entries** and write a `.bak`.

**4. Tool registration** converted from `server.tool(...)` to `server.registerTool(...)` with structured `Use when: / Returns: / Do not use when:` descriptions and `Safety:` callouts on the three write tools.

**5. Release gates** — `pnpm version minor` → **2.9.0**, CHANGELOG entry, README + CLAUDE.md docs, plugin manifests synced, bundle rebuilt from a clean frozen install (deterministic; CI verify passes).

## Local verification
- `typecheck` ✓, `lint` ✓ (0 errors), `format:check` ✓, `pnpm test` ✓ (408 tests)
- Build is deterministic; committed `build/index.js` matches source.

## ⚠️ Not yet done — needs a real-data check before merge
This writes the real `SyncedSmartMailboxes.plist`. Per the #105 review, a **create/delete round-trip against a live library that has a pre-existing date-criteria smart mailbox** should be verified before merging — the unit fixture simulates that case, but a real library is the final gate. Leaving unmerged for that.
