### PR TITLE
fix(deps): move dead js-yaml/postcss overrides into pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,9 +95,5 @@
       "eslint --fix",
       "prettier --write"
     ]
-  },
-  "overrides": {
-    "js-yaml": "^4.2.0",
-    "postcss": "^8.5.15"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   '@hono/node-server': 2.0.10
   fast-uri: 3.1.4
+  js-yaml: ^4.2.0
+  postcss: ^8.5.15
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,12 @@ minimumReleaseAge: 1440
 overrides:
   "@hono/node-server": 2.0.10
   fast-uri: 3.1.4
+  # Security floors for dev-only transitives (js-yaml via @eslint/eslintrc,
+  # postcss via vite), originally added in 29b0221 to clear npm audit advisories
+  # while this repo still used npm. pnpm has never read npm's bare top-level
+  # package.json "overrides" field, so the floors went inert at the pnpm
+  # migration; they live here now, which is the only place pnpm 11 reads them.
+  # Both currently resolve above these ranges on their own — the overrides exist
+  # so a future eslint/vite bump cannot drag them back down.
+  js-yaml: ^4.2.0
+  postcss: ^8.5.15


### PR DESCRIPTION
## Problem

`package.json` carries a top-level `overrides` block (`js-yaml: ^4.2.0`, `postcss: ^8.5.15`), added in 29b0221 to clear npm audit advisories **while this repo still used npm**. pnpm has never read npm's bare top-level `overrides` field in any version, so those floors went inert at the 2026-06-26 pnpm migration and have constrained nothing since.

It fails **silently**. pnpm emits an explicit warning for the legacy `pnpm.overrides` field but says nothing at all about a top-level `overrides`, and the entries never appear in `pnpm-lock.yaml`'s `overrides:` section. The block reads as an active security control while doing nothing — inert *and* undiagnosable.

## Evidence

Differential experiment, same block, four resolvers, against transitive deps deliberately pulling versions **below** the declared floors:

| variant | js-yaml | postcss |
|---|---|---|
| declared floor | `^4.2.0` | `^8.5.15` |
| pnpm, no overrides (baseline) | 3.15.0 | 7.0.39 |
| pnpm, top-level `package.json` overrides | 3.15.0 | 7.0.39 |
| pnpm, `pnpm-workspace.yaml` overrides | **4.3.0** | **8.5.24** |
| npm, top-level `package.json` overrides | **4.3.0** | **8.5.24** |

The top-level block produced resolution byte-identical to having no overrides at all, while the same block in `pnpm-workspace.yaml` forced both floors (positive control). Reproduced on pnpm 11.9.0 (the pinned version) and 11.17.0. pnpm 11.9.0's `getOptionsFromRootManifest.ts` builds overrides solely from `pnpm-workspace.yaml`.

Corroborating: the three sibling repos carry no such block yet resolve `js-yaml` to the identical 4.3.0, with postcss spread across 8.5.16/8.5.19/8.5.20 — the signature of unconstrained transitive resolution. `mail` was the only one of the four with this field, a conformance outlier.

## Fix

Move both entries into `pnpm-workspace.yaml`'s existing `overrides:` map (the only place pnpm 11 reads them) and delete the dead `package.json` block.

**Acceptance test:** `pnpm-lock.yaml`'s `overrides:` section now lists all four entries.

## Risk

**No live exposure today** — `js-yaml@4.3.0` and `postcss@8.5.20` already satisfy the ranges on their own. The defect is purely that nothing would hold if resolution drifted (e.g. an eslint bump pulling `js-yaml <= 4.1.1`, the DoS advisory 29b0221 was clearing). Both are dev-only transitives (`@eslint/eslintrc` → js-yaml, `vite` → postcss), absent from the shipped bundle.

## No version bump owed

Byte-neutral devDependency class. version-guard's `code` detector matches only `^(src/.*|requirements\.txt|build/.*)$` (none touched), and `deps_changed` compares the `dependencies` map only (`overrides` is not in it). Resolved versions are unchanged and `build/` is byte-identical, so expect `::notice::No shipped-byte changes`.

CHANGELOG deliberately skipped: with no version heading to file under it would land as `## [Unreleased]`, which `publish.yml`'s `awk -v v="## [$VERSION]"` scrape turns into a boilerplate release note.

## Verification

- `pnpm run build && git diff --quiet build/` — bundle **byte-identical**
- `pnpm run lint` — 0 errors (10 pre-existing `no-explicit-any` warnings)
- `pnpm run typecheck` — clean
- `pnpm test` — 408 passed (29 files)
- `pnpm run format:check` — clean
- Built in an external worktree with a real `pnpm install --frozen-lockfile` (no symlinked `node_modules`)