### PR TITLE
fix(ci): unbreak the Dependabot auto-bump after the .hermes-plugin removal

### DIFF
--- a/.github/workflows/dependabot-rebuild.yml
+++ b/.github/workflows/dependabot-rebuild.yml
@@ -240,7 +240,7 @@ jobs:
             fs.writeFileSync("CHANGELOG.md", cl.slice(0, at) + "\n\n" + entry + "\n" + rest);
             console.log("Prepended CHANGELOG entry for " + v);
           '
-          git add package.json CHANGELOG.md build .claude-plugin .agents codex .hermes-plugin .antigravity-plugin 2>/dev/null || true
+          git add package.json CHANGELOG.md build .claude-plugin .agents codex .antigravity-plugin
 
       - name: Commit and push the rebuilt bundle
         if: needs.rebuild.outputs.changed == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Dependabot auto-bump silently stopped staging its own changes.** `dependabot-rebuild.yml`'s bump step writes the patch version, syncs the plugin manifests and prepends a CHANGELOG entry, then staged them with `git add package.json CHANGELOG.md build .claude-plugin .agents codex .hermes-plugin .antigravity-plugin`. Once `.hermes-plugin/` was removed that pathspec matched nothing, and `git add` is all-or-nothing — it exited 128 and staged **none** of the others, with `2>/dev/null || true` hiding the failure. The following step re-adds only `build/`, so a Dependabot PR would have committed a rebuilt bundle with no version bump and no changelog entry, failing `require-version-bump` and blocking the automation that is meant to run without a human. Dropped the stale path, and dropped the error suppression so a future missing path fails loudly instead of silently skipping the bump.
+
 ### Removed
 - **`.hermes-plugin/` packaging docs** (`README.md`, `config.yaml`). Hermes Agent has no plugin/marketplace drop-in, so a directory of manifest-looking files was easy to misread as an installable package. The setup it documented is not lost — the `hermes mcp add` command, the `~/.hermes/config.yaml` `mcp_servers:` snippet, and the restart note now live inline in the README's "Other Hosts" section, which is where users actually look. Thanks to @maf4711 (#115). No effect on the published package: `.hermes-plugin/` was never in `package.json` `files[]`.
 


### PR DESCRIPTION
**The Dependabot auto-bump is currently broken in all four repos.** This is not the cosmetic cleanup it looked like.

`dependabot-rebuild.yml`'s bump step writes a patch version bump, runs `sync-plugin-version.mjs`, prepends a CHANGELOG entry, and then stages all of it with:

```
git add package.json CHANGELOG.md build .claude-plugin .agents codex \
        .hermes-plugin .antigravity-plugin 2>/dev/null || true
```

`.hermes-plugin/` no longer exists. **`git add` is all-or-nothing:** one pathspec matching nothing makes it exit 128 and stage *none* of the others. The `2>/dev/null || true` swallowed the exit code but not the consequence — nothing got staged.

The next step (`Commit and push the rebuilt bundle`) re-adds only `build/`. So a Dependabot npm PR whose rebuilt bundle changed would commit **the bundle with no version bump and no CHANGELOG entry**, then fail `require-version-bump` — blocking precisely the automation this workflow exists to provide ("so Dependabot automation flows without a human"). Silently, because the error was suppressed.

## Changes

1. **Drop the stale `.hermes-plugin` path.**
2. **Drop `2>/dev/null || true`.** That suppression is what let this go unnoticed; the step runs under `set -euo pipefail`, so a future missing path now fails the job loudly instead of quietly skipping the bump. Verified all seven remaining paths (`package.json`, `CHANGELOG.md`, `build`, `.claude-plugin`, `.agents`, `codex`, `.antigravity-plugin`) exist in **all four** repos and the unsuppressed `git add` exits 0 in each.

## Fleet consistency

The four repos keep `dependabot-rebuild.yml` byte-identical for `conformance-check.sh`, so this identical commit lands in all four. Verified matching `sha256` across all four after the edit, and `./conformance-check.sh` passes.

`.github/` does not ship, so no version bump is owed.
