### PR TITLE
docs(changelog): record the version-guard CHANGELOG-heading requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Added
+- **`version-guard` now requires every version bump to be documented under a real `## [X.Y.Z]` CHANGELOG heading.** The guard already refused a bump to a version that was already on npm, but it never checked that the new version was described anywhere. Notes parked under `## [Unreleased]` are orphaned the moment the release ships: nothing in the release path renames that section — the `version` lifecycle script only syncs the plugin manifests — so the published version goes out undocumented while its release notes sit under a heading still claiming they are unreleased. apple-notes-mcp shipped 2.6.10 and 2.6.11 exactly that way before this check existed. A bump whose version has no matching heading now hard-fails the PR, with an error naming the heading to add. Keep an empty `## [Unreleased]` at the top regardless — `dependabot-rebuild.yml` hard-exits without that marker, and since it already inserts a real heading, bot PRs pass unchanged. The guard file lives in `.github/`, which does not ship, so this owes no version bump. (#124)
+
 ### Removed
 - **`.hermes-plugin/` packaging docs** (`README.md`, `config.yaml`). Hermes Agent has no plugin/marketplace drop-in, so a directory of manifest-looking files was easy to misread as an installable package. The setup it documented is not lost — the `hermes mcp add` command, the `~/.hermes/config.yaml` `mcp_servers:` snippet, and the restart note now live inline in the README's "Other Hosts" section, which is where users actually look. Thanks to @maf4711 (#115). No effect on the published package: `.hermes-plugin/` was never in `package.json` `files[]`.
 


### PR DESCRIPTION
#124 added a hard gate to `version-guard`: a version bump whose version has no matching `## [X.Y.Z]` heading in CHANGELOG.md now fails the PR, so release notes can't be stranded under `## [Unreleased]` and silently orphaned once the release ships.

It shipped with **no CHANGELOG entry of its own** — the guard that exists to stop undocumented releases was itself undocumented. This files it under `[Unreleased]` > `Added`, matching how the previous `version-guard` change (the `src/**/*.ts` bundle-only exemption) was recorded in this file.

Docs-only. `.github/` does not ship and CHANGELOG.md is not shipped bytes, so no version bump is owed and `require-version-bump` should pass unchanged.

Found by the standing `/mcpscan` docs+changelog audit; applied to all four servers in one pass.