### PR TITLE
feat(flag): apply flag colors over IMAP via $MailFlagBitN keywords

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [2.10.0] - 2026-08-03
+
+### Added
+- **Flag COLORS now work over IMAP — `resolve-message-id` is no longer needed for them.** Apple Mail stores a flag's color as the custom IMAP keywords `$MailFlagBit0/1/2`, a plain 3-bit field holding the 0–6 palette index. It is not carried by `\Flagged` (which really is colorless), but the bits ride alongside it in an ordinary `UID STORE`, so color is fully readable **and writable** over IMAP. `flag-message` and `batch-flag-messages` now apply the requested color on the IMAP route instead of reporting `colorApplied: false`, and reads expose `flagColorIndex`. Encoding verified against live Mail.app state: green (3) = bit0+bit1, blue (4) = bit2, purple (5) = bit0+bit2.
+
+  This removes the last Mail.app dependency from color-keyed workflows. Previously a smart mailbox keyed on flag color could never match an IMAP-flagged message, so applying a color meant resolving to a numeric id and going through AppleScript — which needs Mail.app running, responsive, and holding a TCC Automation grant, and fails as an opaque 10s timeout when it is not.
+
+### Fixed
+- **Unflagging over IMAP now clears the color bits too.** Removing only `\Flagged` left `$MailFlagBitN` set, so a message read as unflagged over IMAP while Mail.app kept rendering it color-flagged until it resynced. Re-flagging in a different color also clears the bits it does not want, so the new color replaces the old index rather than OR-ing into a wrong one.
+
 ## [Unreleased]
 
 ### Added

--- a/build/index.js
+++ b/build/index.js
@@ -80234,6 +80234,7 @@ function structuredRow(m, account, path) {
     dateReceived: env.date ? new Date(env.date).toISOString() : "",
     isRead: m.flags?.has("\\Seen") ?? false,
     isFlagged: m.flags?.has("\\Flagged") ?? false,
+    flagColorIndex: mailFlagColorIndex(m.flags),
     mailbox: path,
     account,
     hasAttachments: false,
@@ -80594,6 +80595,28 @@ async function imapFetchMessageId(id, deps = {}) {
     return null;
   }
 }
+var MAIL_FLAG_BITS = ["$MailFlagBit0", "$MailFlagBit1", "$MailFlagBit2"];
+function mailFlagBitsFor(colorIndex) {
+  const set = [];
+  const clear = [];
+  for (let b = 0; b < MAIL_FLAG_BITS.length; b++) {
+    (colorIndex >> b & 1 ? set : clear).push(MAIL_FLAG_BITS[b]);
+  }
+  return { set, clear };
+}
+function mailFlagColorIndex(flags) {
+  if (!flags) return void 0;
+  const have = new Set(flags);
+  let idx = 0;
+  let any = false;
+  for (let b = 0; b < MAIL_FLAG_BITS.length; b++) {
+    if (have.has(MAIL_FLAG_BITS[b])) {
+      idx |= 1 << b;
+      any = true;
+    }
+  }
+  return any ? idx : void 0;
+}
 function flagOp(id, flag, add, deps) {
   const ref = decodeImapId(id);
   if (!ref) return Promise.resolve({ success: false, error: `Not an IMAP message id: "${id}".` });
@@ -80613,8 +80636,38 @@ function flagOp(id, flag, add, deps) {
 }
 var imapMarkRead = (id, deps = {}) => flagOp(id, "\\Seen", true, deps);
 var imapMarkUnread = (id, deps = {}) => flagOp(id, "\\Seen", false, deps);
-var imapFlagMessage = (id, deps = {}) => flagOp(id, "\\Flagged", true, deps);
-var imapUnflagMessage = (id, deps = {}) => flagOp(id, "\\Flagged", false, deps);
+function imapFlagMessage(id, colorIndex, deps = {}) {
+  if (colorIndex === void 0) return flagOp(id, "\\Flagged", true, deps);
+  const ref = decodeImapId(id);
+  if (!ref) return Promise.resolve({ success: false, error: `Not an IMAP message id: "${id}".` });
+  const { set, clear } = mailFlagBitsFor(colorIndex);
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    try {
+      const ok = await client.messageFlagsAdd([ref.uid], ["\\Flagged", ...set], { uid: true });
+      if (!ok)
+        return { success: false, error: `IMAP flag update returned false for UID ${ref.uid}.` };
+      if (clear.length) await client.messageFlagsRemove([ref.uid], clear, { uid: true });
+      return { success: true };
+    } catch (e) {
+      return { success: false, error: `IMAP flag update failed for UID ${ref.uid}: ${errText(e)}` };
+    }
+  });
+}
+function imapUnflagMessage(id, deps = {}) {
+  const ref = decodeImapId(id);
+  if (!ref) return Promise.resolve({ success: false, error: `Not an IMAP message id: "${id}".` });
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    try {
+      const ok = await client.messageFlagsRemove([ref.uid], ["\\Flagged", ...MAIL_FLAG_BITS], {
+        uid: true
+      });
+      if (!ok) return { success: false, error: `IMAP unflag returned false for UID ${ref.uid}.` };
+      return { success: true };
+    } catch (e) {
+      return { success: false, error: `IMAP unflag failed for UID ${ref.uid}: ${errText(e)}` };
+    }
+  });
+}
 async function imapMoveMessageById(id, destMailbox, deps = {}) {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
@@ -80777,11 +80830,17 @@ var imapBatchMarkRead = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids)
 var imapBatchMarkUnread = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids) => {
   await c.messageFlagsRemove(uids, ["\\Seen"], { uid: true });
 });
-var imapBatchFlag = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids) => {
-  await c.messageFlagsAdd(uids, ["\\Flagged"], { uid: true });
+var imapBatchFlag = (ids, colorIndex, deps = {}) => imapBatch(ids, deps, async (c, uids) => {
+  if (colorIndex === void 0) {
+    await c.messageFlagsAdd(uids, ["\\Flagged"], { uid: true });
+    return;
+  }
+  const { set, clear } = mailFlagBitsFor(colorIndex);
+  await c.messageFlagsAdd(uids, ["\\Flagged", ...set], { uid: true });
+  if (clear.length) await c.messageFlagsRemove(uids, clear, { uid: true });
 });
 var imapBatchUnflag = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids) => {
-  await c.messageFlagsRemove(uids, ["\\Flagged"], { uid: true });
+  await c.messageFlagsRemove(uids, ["\\Flagged", ...MAIL_FLAG_BITS], { uid: true });
 });
 var imapBatchDelete = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids, path) => {
   await trashUids(c, uids, path);
@@ -82235,7 +82294,7 @@ server.registerTool(
 server.registerTool(
   "flag-message",
   {
-    description: "Use when: flagging a single message (by id), optionally with a color (red/orange/yellow/green/blue/purple/gray).\nReturns: a confirmation that the message was flagged (and the color, when applied).\nDo not use when: flagging several at once (use batch-flag-messages) or removing a flag (use unflag-message). Get the id from search-messages or list-messages first.\nNote: flag colors are a Mail.app feature applied via AppleScript; for an IMAP-routed id the flag is set but the color is not applied (IMAP flags are colorless).",
+    description: "Use when: flagging a single message (by id), optionally with a color (red/orange/yellow/green/blue/purple/gray).\nReturns: a confirmation that the message was flagged (and the color, when applied).\nDo not use when: flagging several at once (use batch-flag-messages) or removing a flag (use unflag-message). Get the id from search-messages or list-messages first.\nNote: the color is applied on both routes \u2014 AppleScript sets the flag index, IMAP writes the equivalent $MailFlagBit0/1/2 keywords Mail.app reads.",
     inputSchema: {
       id: MESSAGE_ID_SCHEMA,
       color: FLAG_COLOR_SCHEMA
@@ -82250,7 +82309,7 @@ server.registerTool(
   withErrorHandling(({ id, color }) => {
     const colorIndex = color ? FLAG_COLOR_INDEX[color] : void 0;
     return routeMessage(id, {
-      imap: () => imapFlagMessage(id),
+      imap: () => imapFlagMessage(id, colorIndex),
       apple: () => mailManager.flagMessage(id, colorIndex) ? successResponse(color ? `Message flagged (${color})` : "Message flagged", {
         ok: true,
         id,
@@ -82467,7 +82526,7 @@ server.registerTool(
     const { success: successCount, fail: failCount } = await hybridBatchCounts(
       ids,
       (n) => mailManager.batchFlagMessages(n, colorIndex),
-      (im) => imapBatchFlag(im)
+      (im) => imapBatchFlag(im, colorIndex)
     );
     const structured = { ok: failCount === 0, success: successCount, failed: failCount };
     if (failCount === 0) {
@@ -82510,7 +82569,7 @@ server.registerTool(
 server.registerTool(
   "resolve-message-id",
   {
-    description: "Use when: you have `imap:` message id(s) and need the numeric Mail.app id(s) \u2014 most importantly to apply a flag COLOR, which only sticks on the AppleScript numeric-id path (IMAP `\\Flagged` is colorless, so a smart mailbox keyed on flag color never matches an IMAP-flagged message). Each imap: id is resolved via its RFC822 Message-ID.\nReturns: for each input id, its `numericId` (the AppleScript id) or null when it can't be resolved, plus the `messageId` used; and a `resolvedCount`.\nDo not use when: your ids are already numeric (they pass straight through), or you don't need a color \u2014 flag/move/mark tools operate on `imap:` ids directly.",
+    description: "Use when: you have `imap:` message id(s) and genuinely need the numeric Mail.app id(s) \u2014 e.g. for reply-to-message/forward-message, which are numeric-id only. NOTE: as of 2.10.0 you no longer need this to apply a flag COLOR \u2014 flag-message/batch-flag-messages write the color over IMAP directly via Mail.app's $MailFlagBit0/1/2 keywords, so a smart mailbox keyed on flag color matches an IMAP-flagged message. Each imap: id is resolved via its RFC822 Message-ID.\nReturns: for each input id, its `numericId` (the AppleScript id) or null when it can't be resolved, plus the `messageId` used; and a `resolvedCount`.\nDo not use when: your ids are already numeric (they pass straight through), or you don't need a color \u2014 flag/move/mark tools operate on `imap:` ids directly.",
     inputSchema: {
       ids: BATCH_IDS_SCHEMA
     },

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,9 +126,11 @@ const BATCH_IDS_SCHEMA = z
   .min(1, "At least one message ID is required")
   .max(100, "Cannot process more than 100 messages in a single batch");
 
-/** Apple Mail flag colors → AppleScript `flag index` palette. `grey` is an alias
- *  for `gray`. Colors are a Mail.app feature (the flag index a smart mailbox can
- *  match on); the IMAP `\Flagged` flag is colorless. */
+/** Apple Mail flag colors → the 0-6 palette index. `grey` is an alias for `gray`.
+ *  Works on BOTH routes: AppleScript sets `flag index`, and the IMAP path writes
+ *  the same index as the `$MailFlagBit0/1/2` keyword bitfield Mail.app uses on the
+ *  wire. `\Flagged` alone is colorless, but the bits ride alongside it, so a smart
+ *  mailbox keyed on flag color matches either way. */
 const FLAG_COLOR_INDEX: Record<string, number> = {
   red: 0,
   orange: 1,
@@ -1315,7 +1317,7 @@ server.registerTool(
   "flag-message",
   {
     description:
-      "Use when: flagging a single message (by id), optionally with a color (red/orange/yellow/green/blue/purple/gray).\nReturns: a confirmation that the message was flagged (and the color, when applied).\nDo not use when: flagging several at once (use batch-flag-messages) or removing a flag (use unflag-message). Get the id from search-messages or list-messages first.\nNote: flag colors are a Mail.app feature applied via AppleScript; for an IMAP-routed id the flag is set but the color is not applied (IMAP flags are colorless).",
+      "Use when: flagging a single message (by id), optionally with a color (red/orange/yellow/green/blue/purple/gray).\nReturns: a confirmation that the message was flagged (and the color, when applied).\nDo not use when: flagging several at once (use batch-flag-messages) or removing a flag (use unflag-message). Get the id from search-messages or list-messages first.\nNote: the color is applied on both routes — AppleScript sets the flag index, IMAP writes the equivalent $MailFlagBit0/1/2 keywords Mail.app reads.",
     inputSchema: {
       id: MESSAGE_ID_SCHEMA,
       color: FLAG_COLOR_SCHEMA,
@@ -1330,7 +1332,7 @@ server.registerTool(
   withErrorHandling(({ id, color }) => {
     const colorIndex = color ? FLAG_COLOR_INDEX[color] : undefined;
     return routeMessage(id, {
-      imap: () => imapFlagMessage(id),
+      imap: () => imapFlagMessage(id, colorIndex),
       apple: () =>
         mailManager.flagMessage(id, colorIndex)
           ? successResponse(color ? `Message flagged (${color})` : "Message flagged", {
@@ -1598,7 +1600,7 @@ server.registerTool(
     const { success: successCount, fail: failCount } = await hybridBatchCounts(
       ids,
       (n) => mailManager.batchFlagMessages(n, colorIndex),
-      (im) => imapBatchFlag(im)
+      (im) => imapBatchFlag(im, colorIndex)
     );
     const structured = { ok: failCount === 0, success: successCount, failed: failCount };
 
@@ -1651,7 +1653,7 @@ server.registerTool(
   "resolve-message-id",
   {
     description:
-      "Use when: you have `imap:` message id(s) and need the numeric Mail.app id(s) — most importantly to apply a flag COLOR, which only sticks on the AppleScript numeric-id path (IMAP `\\Flagged` is colorless, so a smart mailbox keyed on flag color never matches an IMAP-flagged message). Each imap: id is resolved via its RFC822 Message-ID.\nReturns: for each input id, its `numericId` (the AppleScript id) or null when it can't be resolved, plus the `messageId` used; and a `resolvedCount`.\nDo not use when: your ids are already numeric (they pass straight through), or you don't need a color — flag/move/mark tools operate on `imap:` ids directly.",
+      "Use when: you have `imap:` message id(s) and genuinely need the numeric Mail.app id(s) — e.g. for reply-to-message/forward-message, which are numeric-id only. NOTE: as of 2.10.0 you no longer need this to apply a flag COLOR — flag-message/batch-flag-messages write the color over IMAP directly via Mail.app's $MailFlagBit0/1/2 keywords, so a smart mailbox keyed on flag color matches an IMAP-flagged message. Each imap: id is resolved via its RFC822 Message-ID.\nReturns: for each input id, its `numericId` (the AppleScript id) or null when it can't be resolved, plus the `messageId` used; and a `resolvedCount`.\nDo not use when: your ids are already numeric (they pass straight through), or you don't need a color — flag/move/mark tools operate on `imap:` ids directly.",
     inputSchema: {
       ids: BATCH_IDS_SCHEMA,
     },

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -474,11 +474,30 @@ describe("IMAP message mutations (#43 Phase 3)", () => {
 
   it("flag / unflag toggle \\Flagged", async () => {
     const recF: MsgRec = {};
-    await imapFlagMessage(MID, { config: cfg, connect: async () => makeMsgClient(recF) });
+    // colorIndex omitted -> plain flag, no color keywords touched
+    await imapFlagMessage(MID, undefined, {
+      config: cfg,
+      connect: async () => makeMsgClient(recF),
+    });
     expect(recF.flagsAdded).toEqual(["\\Flagged"]);
     const recU: MsgRec = {};
     await imapUnflagMessage(MID, { config: cfg, connect: async () => makeMsgClient(recU) });
-    expect(recU.flagsRemoved).toEqual(["\\Flagged"]);
+    // Unflag clears the color bits too, or Mail.app keeps rendering the color.
+    expect(recU.flagsRemoved).toEqual([
+      "\\Flagged",
+      "$MailFlagBit0",
+      "$MailFlagBit1",
+      "$MailFlagBit2",
+    ]);
+  });
+
+  it("flagging with a color sets \\Flagged plus that color's bits", async () => {
+    const rec: MsgRec = {};
+    // 5 = purple = bit0 + bit2
+    await imapFlagMessage(MID, 5, { config: cfg, connect: async () => makeMsgClient(rec) });
+    expect(rec.flagsAdded).toEqual(["\\Flagged", "$MailFlagBit0", "$MailFlagBit2"]);
+    // bit1 must be cleared, so re-flagging in a new color replaces rather than OR-ing
+    expect(rec.flagsRemoved).toEqual(["$MailFlagBit1"]);
   });
 
   it("move routes the uid to the resolved destination", async () => {

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -469,6 +469,7 @@ function structuredRow(m: ImapMessage, account: string, path: string): Record<st
     dateReceived: env.date ? new Date(env.date).toISOString() : "",
     isRead: m.flags?.has("\\Seen") ?? false,
     isFlagged: m.flags?.has("\\Flagged") ?? false,
+    flagColorIndex: mailFlagColorIndex(m.flags),
     mailbox: path,
     account,
     hasAttachments: false,
@@ -1046,6 +1047,48 @@ export async function imapFetchMessageId(id: string, deps: ImapDeps = {}): Promi
   }
 }
 
+/**
+ * Apple Mail encodes a flag COLOR as custom IMAP keywords `$MailFlagBit0/1/2`,
+ * a plain 3-bit field holding the 0-6 palette index. It is NOT carried by
+ * `\Flagged`, which is colorless — but the bits ride alongside it in an
+ * ordinary UID STORE, so color is fully readable AND writable over IMAP.
+ *
+ * Verified against live Mail.app state 2026-08-03:
+ *   $MailFlagBit0 + $MailFlagBit1            -> 3 = green
+ *   $MailFlagBit2                            -> 4 = blue
+ *   $MailFlagBit0 + $MailFlagBit2            -> 5 = purple
+ *
+ * This is what lets a smart mailbox keyed on flag color match a message flagged
+ * over IMAP. Before this, color required resolving to a numeric id and going
+ * through AppleScript, which needed Mail.app running plus a TCC grant.
+ */
+const MAIL_FLAG_BITS = ["$MailFlagBit0", "$MailFlagBit1", "$MailFlagBit2"] as const;
+
+/** Keywords to SET for a palette index (0-6), and the ones to CLEAR. */
+export function mailFlagBitsFor(colorIndex: number): { set: string[]; clear: string[] } {
+  const set: string[] = [];
+  const clear: string[] = [];
+  for (let b = 0; b < MAIL_FLAG_BITS.length; b++) {
+    ((colorIndex >> b) & 1 ? set : clear).push(MAIL_FLAG_BITS[b]);
+  }
+  return { set, clear };
+}
+
+/** Palette index carried by a message's IMAP keywords, or undefined when none. */
+export function mailFlagColorIndex(flags: Iterable<string> | undefined): number | undefined {
+  if (!flags) return undefined;
+  const have = new Set(flags);
+  let idx = 0;
+  let any = false;
+  for (let b = 0; b < MAIL_FLAG_BITS.length; b++) {
+    if (have.has(MAIL_FLAG_BITS[b])) {
+      idx |= 1 << b;
+      any = true;
+    }
+  }
+  return any ? idx : undefined;
+}
+
 function flagOp(id: string, flag: string, add: boolean, deps: ImapDeps): Promise<ImapOpResult> {
   const ref = decodeImapId(id);
   if (!ref) return Promise.resolve({ success: false, error: `Not an IMAP message id: "${id}".` });
@@ -1070,10 +1113,51 @@ export const imapMarkRead = (id: string, deps = {}): Promise<ImapOpResult> =>
   flagOp(id, "\\Seen", true, deps);
 export const imapMarkUnread = (id: string, deps = {}): Promise<ImapOpResult> =>
   flagOp(id, "\\Seen", false, deps);
-export const imapFlagMessage = (id: string, deps = {}): Promise<ImapOpResult> =>
-  flagOp(id, "\\Flagged", true, deps);
-export const imapUnflagMessage = (id: string, deps = {}): Promise<ImapOpResult> =>
-  flagOp(id, "\\Flagged", false, deps);
+/**
+ * Flag over IMAP, optionally with a color. Bits for the requested color are
+ * ADDED and the other bits REMOVED, so re-flagging with a different color
+ * replaces it rather than OR-ing into a wrong index.
+ */
+export function imapFlagMessage(
+  id: string,
+  colorIndex?: number,
+  deps: ImapDeps = {}
+): Promise<ImapOpResult> {
+  if (colorIndex === undefined) return flagOp(id, "\\Flagged", true, deps);
+  const ref = decodeImapId(id);
+  if (!ref) return Promise.resolve({ success: false, error: `Not an IMAP message id: "${id}".` });
+  const { set, clear } = mailFlagBitsFor(colorIndex);
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    try {
+      const ok = await client.messageFlagsAdd([ref.uid], ["\\Flagged", ...set], { uid: true });
+      if (!ok)
+        return { success: false, error: `IMAP flag update returned false for UID ${ref.uid}.` };
+      // Non-fatal: the flag and its color are already set; a failure here can only
+      // leave a stale higher bit, which is cosmetic.
+      if (clear.length) await client.messageFlagsRemove([ref.uid], clear, { uid: true });
+      return { success: true };
+    } catch (e) {
+      return { success: false, error: `IMAP flag update failed for UID ${ref.uid}: ${errText(e)}` };
+    }
+  });
+}
+
+/** Unflag clears the color bits too — otherwise Mail.app keeps rendering the color. */
+export function imapUnflagMessage(id: string, deps: ImapDeps = {}): Promise<ImapOpResult> {
+  const ref = decodeImapId(id);
+  if (!ref) return Promise.resolve({ success: false, error: `Not an IMAP message id: "${id}".` });
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    try {
+      const ok = await client.messageFlagsRemove([ref.uid], ["\\Flagged", ...MAIL_FLAG_BITS], {
+        uid: true,
+      });
+      if (!ok) return { success: false, error: `IMAP unflag returned false for UID ${ref.uid}.` };
+      return { success: true };
+    } catch (e) {
+      return { success: false, error: `IMAP unflag failed for UID ${ref.uid}: ${errText(e)}` };
+    }
+  });
+}
 
 export async function imapMoveMessageById(
   id: string,
@@ -1338,13 +1422,25 @@ export const imapBatchMarkUnread = (ids: string[], deps: ImapDeps = {}): Promise
   imapBatch(ids, deps, async (c, uids) => {
     await c.messageFlagsRemove(uids, ["\\Seen"], { uid: true });
   });
-export const imapBatchFlag = (ids: string[], deps: ImapDeps = {}): Promise<ImapBatchResult> =>
+export const imapBatchFlag = (
+  ids: string[],
+  colorIndex?: number,
+  deps: ImapDeps = {}
+): Promise<ImapBatchResult> =>
   imapBatch(ids, deps, async (c, uids) => {
-    await c.messageFlagsAdd(uids, ["\\Flagged"], { uid: true });
+    if (colorIndex === undefined) {
+      await c.messageFlagsAdd(uids, ["\\Flagged"], { uid: true });
+      return;
+    }
+    const { set, clear } = mailFlagBitsFor(colorIndex);
+    await c.messageFlagsAdd(uids, ["\\Flagged", ...set], { uid: true });
+    // Clear the unwanted bits so re-flagging with a new color replaces it.
+    if (clear.length) await c.messageFlagsRemove(uids, clear, { uid: true });
   });
 export const imapBatchUnflag = (ids: string[], deps: ImapDeps = {}): Promise<ImapBatchResult> =>
   imapBatch(ids, deps, async (c, uids) => {
-    await c.messageFlagsRemove(uids, ["\\Flagged"], { uid: true });
+    // Clear the color bits too, or Mail.app keeps rendering the color.
+    await c.messageFlagsRemove(uids, ["\\Flagged", ...MAIL_FLAG_BITS], { uid: true });
   });
 export const imapBatchDelete = (ids: string[], deps: ImapDeps = {}): Promise<ImapBatchResult> =>
   imapBatch(ids, deps, async (c, uids, path) => {

--- a/src/services/imapFlagColor.test.ts
+++ b/src/services/imapFlagColor.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Flag COLOR over IMAP — Mail.app's `$MailFlagBit0/1/2` keyword bitfield.
+ *
+ * The palette index is a plain 3-bit little-endian field. Getting the bit order
+ * backwards still "works" for red (0) and gray (6) — the palindromes — so the
+ * asymmetric colors are what actually pin the encoding down. These expectations
+ * were taken from live Mail.app state, not from the spec:
+ *   green  (3) = bit0 + bit1
+ *   blue   (4) = bit2
+ *   purple (5) = bit0 + bit2
+ */
+import { describe, it, expect } from "vitest";
+import { mailFlagBitsFor, mailFlagColorIndex } from "@/services/imapClient.js";
+
+const B0 = "$MailFlagBit0";
+const B1 = "$MailFlagBit1";
+const B2 = "$MailFlagBit2";
+
+describe("mailFlagBitsFor", () => {
+  it("encodes the observed live values", () => {
+    expect(mailFlagBitsFor(3).set.sort()).toEqual([B0, B1]); // green
+    expect(mailFlagBitsFor(4).set).toEqual([B2]); // blue
+    expect(mailFlagBitsFor(5).set.sort()).toEqual([B0, B2]); // purple
+  });
+
+  it("red (0) sets no bits but still clears all three", () => {
+    expect(mailFlagBitsFor(0).set).toEqual([]);
+    expect(mailFlagBitsFor(0).clear.sort()).toEqual([B0, B1, B2]);
+  });
+
+  it("gray (6) is bit1 + bit2", () => {
+    expect(mailFlagBitsFor(6).set.sort()).toEqual([B1, B2]);
+    expect(mailFlagBitsFor(6).clear).toEqual([B0]);
+  });
+
+  it("set and clear are always complementary — no bit left ambiguous", () => {
+    for (let i = 0; i <= 6; i++) {
+      const { set, clear } = mailFlagBitsFor(i);
+      expect([...set, ...clear].sort()).toEqual([B0, B1, B2]);
+      expect(set.filter((b) => clear.includes(b))).toEqual([]);
+    }
+  });
+});
+
+describe("mailFlagColorIndex", () => {
+  it("decodes the observed live values", () => {
+    expect(mailFlagColorIndex([B0, B1])).toBe(3);
+    expect(mailFlagColorIndex([B2])).toBe(4);
+    expect(mailFlagColorIndex([B0, B2])).toBe(5);
+  });
+
+  it("round-trips every palette index", () => {
+    for (let i = 0; i <= 6; i++) {
+      const { set } = mailFlagBitsFor(i);
+      // index 0 sets no bits, so it is indistinguishable from "no color" on read
+      expect(mailFlagColorIndex(set)).toBe(i === 0 ? undefined : i);
+    }
+  });
+
+  it("returns undefined when no color bits are present", () => {
+    expect(mailFlagColorIndex([])).toBeUndefined();
+    expect(mailFlagColorIndex(["\\Seen", "\\Flagged"])).toBeUndefined();
+    expect(mailFlagColorIndex(undefined)).toBeUndefined();
+  });
+
+  it("ignores unrelated flags alongside the color bits", () => {
+    expect(mailFlagColorIndex(["\\Seen", B0, "\\Flagged", B1, "$NotJunk"])).toBe(3);
+  });
+});

--- a/test/imap.integration.test.ts
+++ b/test/imap.integration.test.ts
@@ -22,6 +22,7 @@ import {
   imapRenameMailbox,
   imapMarkRead,
   imapFlagMessage,
+  imapUnflagMessage,
   imapMoveMessageById,
   imapDeleteMessageById,
   imapUnreadCount,
@@ -106,7 +107,16 @@ run("IMAP backend (GreenMail) integration", () => {
     const list = (await imapListMessages({ mailbox: "INBOX", limit: 10 }, deps)).text;
     const id = firstImapId(list);
     expect((await imapMarkRead(id, deps)).success).toBe(true);
-    expect((await imapFlagMessage(id, deps)).success).toBe(true);
+    expect((await imapFlagMessage(id, undefined, deps)).success).toBe(true);
+  });
+
+  it("flag color round-trips through the $MailFlagBitN keywords", async () => {
+    const list = (await imapListMessages({ mailbox: "INBOX", limit: 10 }, deps)).text;
+    const id = firstImapId(list);
+    // 5 = purple = bit0 + bit2
+    expect((await imapFlagMessage(id, 5, deps)).success).toBe(true);
+    // unflag must clear \Flagged AND every color bit, or Mail.app keeps the color
+    expect((await imapUnflagMessage(id, deps)).success).toBe(true);
   });
 
   it("create / rename / delete mailbox round-trips", async () => {


### PR DESCRIPTION
## Summary

Apple Mail stores a flag's **color** as the custom IMAP keywords `$MailFlagBit0/1/2` — a plain 3-bit field holding the 0–6 palette index. It is **not** carried by `\Flagged` (which really is colorless), but the bits ride alongside it in an ordinary `UID STORE`, so color turns out to be fully readable **and writable** over IMAP.

Encoding verified against live Mail.app state *before* implementing:

| keywords | index | color |
|---|---|---|
| `$MailFlagBit0 $MailFlagBit1` | 3 | green |
| `$MailFlagBit2` | 4 | blue |
| `$MailFlagBit0 $MailFlagBit2` | 5 | purple |

## Why it matters

This removes the **last Mail.app dependency** from color-keyed workflows. A smart mailbox keyed on flag color could never match an IMAP-flagged message, so applying a color meant resolving to a numeric id and going through AppleScript — which needs Mail.app running, responsive, and holding a TCC Automation grant, and fails as an opaque 10s timeout when it is not. `resolve-message-id`'s description said so explicitly; it is now scoped to reply/forward, which are genuinely numeric-id only.

## Changes

- `flag-message` / `batch-flag-messages` apply the color on the IMAP route instead of reporting `colorApplied: false`
- Reads expose `flagColorIndex`
- **Unflag clears the color bits too** — removing only `\Flagged` left `$MailFlagBitN` set, so a message read as unflagged over IMAP while Mail.app kept rendering it color-flagged until it resynced
- **Re-flagging clears the bits it does not want**, so a new color replaces the old index rather than OR-ing into a wrong one

## Tests

417 pass. The new suite pins the encoding against the live values — note a *reversed* bit order still "works" for red (0) and gray (6) since they are palindromes, so the asymmetric colors are what actually catch it. `imapFlagMessage`/`imapBatchFlag` take `colorIndex` before `deps`; the one existing caller is updated.