### PR TITLE
docs(flag): correct the color-over-IMAP text left behind by 2.10.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,3 @@
-## [2.10.0] - 2026-08-03
-
-### Added
-- **Flag COLORS now work over IMAP — `resolve-message-id` is no longer needed for them.** Apple Mail stores a flag's color as the custom IMAP keywords `$MailFlagBit0/1/2`, a plain 3-bit field holding the 0–6 palette index. It is not carried by `\Flagged` (which really is colorless), but the bits ride alongside it in an ordinary `UID STORE`, so color is fully readable **and writable** over IMAP. `flag-message` and `batch-flag-messages` now apply the requested color on the IMAP route instead of reporting `colorApplied: false`, and reads expose `flagColorIndex`. Encoding verified against live Mail.app state: green (3) = bit0+bit1, blue (4) = bit2, purple (5) = bit0+bit2.
-
-  This removes the last Mail.app dependency from color-keyed workflows. Previously a smart mailbox keyed on flag color could never match an IMAP-flagged message, so applying a color meant resolving to a numeric id and going through AppleScript — which needs Mail.app running, responsive, and holding a TCC Automation grant, and fails as an opaque 10s timeout when it is not.
-
-### Fixed
-- **Unflagging over IMAP now clears the color bits too.** Removing only `\Flagged` left `$MailFlagBitN` set, so a message read as unflagged over IMAP while Mail.app kept rendering it color-flagged until it resynced. Re-flagging in a different color also clears the bits it does not want, so the new color replaces the old index rather than OR-ing into a wrong one.
-
 ## [Unreleased]
 
 ### Added
@@ -23,6 +13,21 @@
 
 ### Security
 - **Moved both dev-only `brace-expansion` paths onto their complete fixes for GHSA-mh99-v99m-4gvg / CVE-2026-14257 (high)** — `1.1.18` on the v1 line and `5.0.9` on the v5 line. The two majors are floored independently because they are not API-compatible: ESLint reaches `brace-expansion` through `minimatch@3.1.5`, which requires the v1 CommonJS API, so forcing the v5 line the advisory names as patched into that path fails with `expand is not a function`; the upstream v1 backport is the only fix that applies without crossing that boundary. `minimatch@10.2.6` reaches the v5 line independently. Both floors are written as two-sided ranges (`>=1.0.0 <1.1.18`, `>=5.0.0 <5.0.9`) — a bare `<5.0.9` also matches `1.1.18` under semver and would drag the CommonJS path onto v5. The advisory's own first-patched versions (`1.1.17` / `5.0.8`) are **not sufficient**: they bound the accumulator in `combine` but never thread `maxLength` into `expandSequence`, leaving the sequence path (`{1..N}`, `{a..z..k}`) capped only by item count, so a padded sequence still materialises ~100,000 intermediate strings before the outer bound truncates (measured 4,606 ms / 176 MB RSS on `1.1.17` vs 9 ms / 61 MB on `1.1.18`, identical final output). `1.1.18` and `5.0.9` add the missing bound. Both were adopted only after clearing this repo's 24-hour `minimumReleaseAge` supply-chain gate, with no `minimumReleaseAgeExclude` carve-out and no audit suppression — `pnpm audit` will keep reporting the advisory until GitHub's metadata (which still lists `5.0.8` as first-patched, and so marks the entire v1 line vulnerable under semver) catches up. Dev toolchain only: `brace-expansion` is not in the shipped bundle, so the published package is unaffected, the committed bundle is byte-identical, and no version bump is owed. Thanks to @jjoanna2-debug (#119, #121, #123).
+
+## [2.10.1] - 2026-08-03
+
+### Fixed
+- **Corrected the flag-color documentation and response that still said colors don't work over IMAP.** 2.10.0 made `flag-message` and `batch-flag-messages` write the color over IMAP as Mail.app's `$MailFlagBit0/1/2` keywords, but several places kept describing the old behavior, and one of them was not merely stale text: on the IMAP route `flag-message` returned `colorApplied: false` and the message `the "<color>" color was not applied — this is an IMAP-routed message and IMAP flags are colorless`, while in fact applying it. A caller checking `colorApplied` was told the opposite of what happened. Also corrected: the `color` parameter description, the `batch-flag-messages` tool description, the README's "Flag colors" note and its `batch-flag-messages` parameter row, and two source comments implying `resolve-message-id` is still required for color. This matters beyond tidiness — an agent reading those descriptions would resolve `imap:` ids to numeric ones purely to get a color, reintroducing the AppleScript/TCC dependency that 2.10.0 removed and that previously killed four consecutive scheduled jobs.
+
+## [2.10.0] - 2026-08-03
+
+### Added
+- **Flag COLORS now work over IMAP — `resolve-message-id` is no longer needed for them.** Apple Mail stores a flag's color as the custom IMAP keywords `$MailFlagBit0/1/2`, a plain 3-bit field holding the 0–6 palette index. It is not carried by `\Flagged` (which really is colorless), but the bits ride alongside it in an ordinary `UID STORE`, so color is fully readable **and writable** over IMAP. `flag-message` and `batch-flag-messages` now apply the requested color on the IMAP route instead of reporting `colorApplied: false`, and reads expose `flagColorIndex`. Encoding verified against live Mail.app state: green (3) = bit0+bit1, blue (4) = bit2, purple (5) = bit0+bit2.
+
+  This removes the last Mail.app dependency from color-keyed workflows. Previously a smart mailbox keyed on flag color could never match an IMAP-flagged message, so applying a color meant resolving to a numeric id and going through AppleScript — which needs Mail.app running, responsive, and holding a TCC Automation grant, and fails as an opaque 10s timeout when it is not.
+
+### Fixed
+- **Unflagging over IMAP now clears the color bits too.** Removing only `\Flagged` left `$MailFlagBitN` set, so a message read as unflagged over IMAP while Mail.app kept rendering it color-flagged until it resynced. Re-flagging in a different color also clears the bits it does not want, so the new color replaces the old index rather than OR-ing into a wrong one.
 
 ## [2.9.1] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ Flag or unflag a message. `flag-message` optionally takes a flag **color**; `unf
 | `id` | string | Yes | Message ID |
 | `color` | string | No | (`flag-message` only) Flag color: `red`, `orange`, `yellow`, `green`, `blue`, `purple`, `gray` (`grey` accepted). Omit for Mail's default flag. |
 
-**Flag colors** are an Apple Mail feature, applied via AppleScript as the message's `flag index` (0 red, 1 orange, 2 yellow, 3 green, 4 blue, 5 purple, 6 gray) — the same property a Mail smart mailbox can match on. For an **IMAP-routed** message id (`imap:…`) the flag is still set, but the color is **not** applied, because IMAP's `\Flagged` flag is colorless. To color a flag, use the message's AppleScript (numeric) id.
+**Flag colors** are an Apple Mail feature — the message's `flag index` (0 red, 1 orange, 2 yellow, 3 green, 4 blue, 5 purple, 6 gray), which is the property a Mail smart mailbox can match on. **The color is applied on both routes** (since 2.10.0): AppleScript sets the flag index directly, and for an **IMAP-routed** id (`imap:…`) the color is written as Mail.app's `$MailFlagBit0/1/2` keywords — a 3-bit field holding the same palette index. `\Flagged` on its own really is colorless, but those keywords ride alongside it in an ordinary `UID STORE`, so a smart mailbox keyed on flag color matches an IMAP-flagged message too. You do **not** need to resolve to a numeric id just to color a flag.
 
 ---
 
@@ -829,7 +829,7 @@ All batch operations accept an array of message IDs (max 100 per batch) and retu
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `ids` | string[] | Yes | Message IDs (max 100) |
-| `color` | string | No | (`batch-flag-messages` only) Flag color applied to AppleScript (numeric) ids — see [`flag-message`](#flag-message--unflag-message). Any `imap:` ids in the batch are flagged but not colored. |
+| `color` | string | No | (`batch-flag-messages` only) Flag color — see [`flag-message`](#flag-message--unflag-message). Applied on both routes, so a mixed batch of numeric and `imap:` ids all end up colored. |
 
 ---
 

--- a/build/index.js
+++ b/build/index.js
@@ -78120,9 +78120,13 @@ var AppleMailManager = class {
   /**
    * Resolve a message's numeric Mail.app id from its RFC822 Message-ID (the
    * backend-independent join key). This bridges an `imap:` id to the numeric id
-   * required to apply a flag *color* — IMAP flags are colorless, so a smart
-   * mailbox keyed on flag color can only ever match a message flagged via the
-   * AppleScript numeric-id path.
+   * required by the AppleScript-only tools — `reply-to-message` and
+   * `forward-message`.
+   *
+   * Note: flag *color* no longer needs this (since 2.10.0). Mail.app stores the
+   * color as the `$MailFlagBit0/1/2` keywords, which ride alongside `\Flagged`
+   * in an ordinary `UID STORE`, so flag-message/batch-flag-messages color an
+   * `imap:` id directly and a smart mailbox keyed on flag color matches it.
    *
    * The Message-ID is matched both bracketless and `<bracketed>` (Mail returns
    * it bracketless; IMAP envelopes carry the brackets). When `accountName` is
@@ -81490,7 +81494,7 @@ var FLAG_COLOR_INDEX = {
   grey: 6
 };
 var FLAG_COLOR_SCHEMA = external_exports.enum(["red", "orange", "yellow", "green", "blue", "purple", "gray", "grey"]).optional().describe(
-  "Optional flag color (Apple Mail palette: red, orange, yellow, green, blue, purple, gray \u2014 'grey' accepted). Omit for Mail's default flag. Colors are applied via Mail.app (AppleScript); for an IMAP-routed message id the flag is set but the color is not applied (IMAP flags are colorless)."
+  "Optional flag color (Apple Mail palette: red, orange, yellow, green, blue, purple, gray \u2014 'grey' accepted). Omit for Mail's default flag. The color is applied on both routes: AppleScript sets the flag index, and IMAP writes the equivalent $MailFlagBit0/1/2 keywords Mail.app reads \u2014 so a smart mailbox keyed on flag color matches either way."
 );
 var DATE_FILTER_SCHEMA = external_exports.string().regex(
   /^[a-zA-Z0-9 ,/\-:]+$/,
@@ -82315,10 +82319,11 @@ server.registerTool(
         id,
         ...color ? { color, colorApplied: true } : {}
       }) : errorResponse(`Failed to flag message "${id}"`),
-      // IMAP path: the flag is set, but flag colors are a Mail.app-only feature.
-      ok: color ? `Message flagged. Note: the "${color}" color was not applied \u2014 this is an IMAP-routed message and IMAP flags are colorless.` : "Message flagged",
+      // IMAP path: imapFlagMessage writes the color as $MailFlagBit0/1/2 keywords,
+      // so the outcome matches the AppleScript route above.
+      ok: color ? `Message flagged (${color})` : "Message flagged",
       fail: `Failed to flag message "${id}"`,
-      structured: color ? { ok: true, id, color, colorApplied: false } : { ok: true, id }
+      structured: color ? { ok: true, id, color, colorApplied: true } : { ok: true, id }
     });
   }, "Error flagging message")
 );
@@ -82514,7 +82519,7 @@ server.registerTool(
 server.registerTool(
   "batch-flag-messages",
   {
-    description: "Use when: flagging multiple messages (1\u2013100 ids) in one call, optionally with a color (red/orange/yellow/green/blue/purple/gray).\nReturns: counts of how many were flagged and how many failed.\nDo not use when: flagging just one (use flag-message) or removing flags (use batch-unflag-messages). Get the ids from search-messages or list-messages first.\nNote: flag colors are applied via Mail.app (AppleScript); any IMAP-routed ids in the batch are flagged but not colored (IMAP flags are colorless).",
+    description: "Use when: flagging multiple messages (1\u2013100 ids) in one call, optionally with a color (red/orange/yellow/green/blue/purple/gray).\nReturns: counts of how many were flagged and how many failed.\nDo not use when: flagging just one (use flag-message) or removing flags (use batch-unflag-messages). Get the ids from search-messages or list-messages first.\nNote: the color is applied on both routes \u2014 AppleScript sets the flag index, IMAP writes the equivalent $MailFlagBit0/1/2 keywords Mail.app reads \u2014 so a mixed batch of numeric and `imap:` ids all end up colored.",
     inputSchema: {
       ids: BATCH_IDS_SCHEMA,
       color: FLAG_COLOR_SCHEMA

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ const FLAG_COLOR_SCHEMA = z
   .enum(["red", "orange", "yellow", "green", "blue", "purple", "gray", "grey"])
   .optional()
   .describe(
-    "Optional flag color (Apple Mail palette: red, orange, yellow, green, blue, purple, gray — 'grey' accepted). Omit for Mail's default flag. Colors are applied via Mail.app (AppleScript); for an IMAP-routed message id the flag is set but the color is not applied (IMAP flags are colorless)."
+    "Optional flag color (Apple Mail palette: red, orange, yellow, green, blue, purple, gray — 'grey' accepted). Omit for Mail's default flag. The color is applied on both routes: AppleScript sets the flag index, and IMAP writes the equivalent $MailFlagBit0/1/2 keywords Mail.app reads — so a smart mailbox keyed on flag color matches either way."
   );
 
 /** Date filter strings must look like natural-language dates (e.g. "March 1, 2026").
@@ -1341,12 +1341,11 @@ server.registerTool(
               ...(color ? { color, colorApplied: true } : {}),
             })
           : errorResponse(`Failed to flag message "${id}"`),
-      // IMAP path: the flag is set, but flag colors are a Mail.app-only feature.
-      ok: color
-        ? `Message flagged. Note: the "${color}" color was not applied — this is an IMAP-routed message and IMAP flags are colorless.`
-        : "Message flagged",
+      // IMAP path: imapFlagMessage writes the color as $MailFlagBit0/1/2 keywords,
+      // so the outcome matches the AppleScript route above.
+      ok: color ? `Message flagged (${color})` : "Message flagged",
       fail: `Failed to flag message "${id}"`,
-      structured: color ? { ok: true, id, color, colorApplied: false } : { ok: true, id },
+      structured: color ? { ok: true, id, color, colorApplied: true } : { ok: true, id },
     });
   }, "Error flagging message")
 );
@@ -1588,7 +1587,7 @@ server.registerTool(
   "batch-flag-messages",
   {
     description:
-      "Use when: flagging multiple messages (1–100 ids) in one call, optionally with a color (red/orange/yellow/green/blue/purple/gray).\nReturns: counts of how many were flagged and how many failed.\nDo not use when: flagging just one (use flag-message) or removing flags (use batch-unflag-messages). Get the ids from search-messages or list-messages first.\nNote: flag colors are applied via Mail.app (AppleScript); any IMAP-routed ids in the batch are flagged but not colored (IMAP flags are colorless).",
+      "Use when: flagging multiple messages (1–100 ids) in one call, optionally with a color (red/orange/yellow/green/blue/purple/gray).\nReturns: counts of how many were flagged and how many failed.\nDo not use when: flagging just one (use flag-message) or removing flags (use batch-unflag-messages). Get the ids from search-messages or list-messages first.\nNote: the color is applied on both routes — AppleScript sets the flag index, IMAP writes the equivalent $MailFlagBit0/1/2 keywords Mail.app reads — so a mixed batch of numeric and `imap:` ids all end up colored.",
     inputSchema: {
       ids: BATCH_IDS_SCHEMA,
       color: FLAG_COLOR_SCHEMA,

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -2326,9 +2326,13 @@ export class AppleMailManager {
   /**
    * Resolve a message's numeric Mail.app id from its RFC822 Message-ID (the
    * backend-independent join key). This bridges an `imap:` id to the numeric id
-   * required to apply a flag *color* — IMAP flags are colorless, so a smart
-   * mailbox keyed on flag color can only ever match a message flagged via the
-   * AppleScript numeric-id path.
+   * required by the AppleScript-only tools — `reply-to-message` and
+   * `forward-message`.
+   *
+   * Note: flag *color* no longer needs this (since 2.10.0). Mail.app stores the
+   * color as the `$MailFlagBit0/1/2` keywords, which ride alongside `\Flagged`
+   * in an ordinary `UID STORE`, so flag-message/batch-flag-messages color an
+   * `imap:` id directly and a smart mailbox keyed on flag color matches it.
    *
    * The Message-ID is matched both bracketless and `<bracketed>` (Mail returns
    * it bracketless; IMAP envelopes carry the brackets). When `accountName` is

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -1028,8 +1028,9 @@ export function normalizeMessageId(mid: string): string {
 /**
  * Fetch the RFC822 Message-ID for an `imap:` id. This is the join key that lets
  * the AppleScript backend locate the *same* message and return its numeric
- * Mail.app id — needed because flag **colors** only apply on the AppleScript
- * numeric-id path (IMAP `\Flagged` is colorless). Returns the normalized
+ * Mail.app id — needed by the numeric-id-only tools, `reply-to-message` and
+ * `forward-message`. (Flag **colors** no longer need it: since 2.10.0 they are
+ * written over IMAP as the `$MailFlagBit0/1/2` keywords.) Returns the normalized
  * Message-ID (no angle brackets), or null if `id` isn't an imap: token, the
  * message/envelope can't be fetched, or it carries no Message-ID.
  */


### PR DESCRIPTION
## Description

2.10.0 made `flag-message` and `batch-flag-messages` write the flag color over IMAP as Mail.app's `$MailFlagBit0/1/2` keywords. Several places were left describing the old AppleScript-only behavior.

**One of them was not merely stale text.** On the IMAP route, `flag-message` returned:

```
colorApplied: false
"Message flagged. Note: the \"gray\" color was not applied — this is an IMAP-routed message and IMAP flags are colorless."
```

…while actually applying the color. A caller checking `colorApplied` was told the opposite of what happened.

## Why this matters beyond tidiness

The stale descriptions actively push an agent the wrong way: reading them, it would resolve `imap:` ids to numeric ones *purely to get a color*, reintroducing the AppleScript/TCC dependency 2.10.0 removed — the same dependency that silently killed four consecutive scheduled mail jobs on 2026-07-29/30.

Found while running the spam sweep, whose queue is keyed on a gray flag: the sweep's `batch-flag-messages` step reads as a no-op for color if you trust the tool description, which would leave the color-keyed smart mailbox permanently empty.

## Changes

| Location | Was |
|---|---|
| `src/index.ts` `flag-message` IMAP branch | `colorApplied: false` + "color was not applied" — **now `true` and a plain `Message flagged (<color>)`** |
| `src/index.ts` `color` param description | "the color is not applied (IMAP flags are colorless)" |
| `src/index.ts` `batch-flag-messages` description | "any IMAP-routed ids in the batch are flagged but not colored" |
| `README.md` "Flag colors" note | "To color a flag, use the message's AppleScript (numeric) id." |
| `README.md` `batch-flag-messages` param row | "Any `imap:` ids in the batch are flagged but not colored." |
| `src/services/appleMailManager.ts` comment | resolve-message-id "required to apply a flag *color*" |
| `src/services/imapClient.ts` comment | colors "only apply on the AppleScript numeric-id path" |

`flag-message`'s own tool description was already correct in 2.10.0 — only the batch one was missed, which is what made the inconsistency easy to miss.

Also moves `## [Unreleased]` back above the released sections: the 2.10.0 release inserted its heading *above* it, so `dependabot-rebuild.yml` (which inserts right after the `## [Unreleased]` marker) would have filed the next version entry out of order.

## Verification

- Confirmed against live Mail state that the implementation was already correct on both routes — `index.ts:1603` → `imapBatchFlag(im, colorIndex)` → `imapClient.ts:1427`; only the text disagreed.
- New text present in the committed bundle, old text gone (`grep` on `build/index.js`: 3 / 0).
- No test asserted the old `colorApplied: false` behavior.
- lint (0 errors; 10 pre-existing `no-explicit-any` warnings, count unchanged vs `origin/main`), typecheck, format:check, 417 tests, manifest sync, bundle-matches-source all pass.

## Type of Change

- [x] Bug fix (incorrect `colorApplied` / response text)
- [x] Documentation update

## Checklist

- [x] Version bumped 2.10.0 → **2.10.1** with a real `## [2.10.1]` CHANGELOG heading (shipped bytes changed — tool descriptions live in the bundle)