### PR TITLE
fix(deps): floor js-yaml on 4.3.1 — GHSA-5p4m-2wfm-xmqj (high)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Security
+
+- **Floored `js-yaml` to `^4.3.1`, clearing GHSA-5p4m-2wfm-xmqj (high).** Quadratic CPU consumption while resolving `!!omap` keys — a malicious YAML document can be made to burn CPU superlinearly in the number of map entries. The advisory notes the CVE-2026-59870 fix was never backported to the 3.x line, so 4.3.1 is the first complete release. `js-yaml` reaches the tree as `eslint` -> `js-yaml`, which is **development scope**, and it does not appear in the committed `build/index.js` — verified, 0 references — so no published artifact ever carried it and this owes no version bump. The override entry already existed here as `js-yaml: ^4.2.0`, a floor written for an earlier advisory: **an out-of-date floor is not something a caret range protects against**, because a caret only stops the tree moving backwards, never forwards onto a newer fix. The sibling repos carried no `js-yaml` entry at all and were floored for the first time.
+- **Raised the `postcss` floor from `^8.5.15` to `^8.5.23`,** the patched release for GHSA-fxqj-rqcc-2cmp (moderate). Same defect as above in a second entry: the floor sat below the fix it was meant to enforce. The tree resolved a safe 8.5.25 anyway, because `vite`'s own range pulls it forward — so nothing was exposed, but the override was not doing the job it documented. Now matches apple-notes-mcp and apple-photos-mcp.
+
 ## [2.10.8] - 2026-08-07
 
 ### Fixed

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ overrides:
   fast-uri: ^3.1.5
   ip-address: ^10.3.1
   hono: ^4.12.34
-  js-yaml: ^4.2.0
-  postcss: ^8.5.15
+  js-yaml: ^4.3.1
+  postcss: ^8.5.23
 
 importers:
 
@@ -1078,8 +1078,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1889,7 +1889,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2697,7 +2697,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,5 +45,18 @@ overrides:
   # minimumReleaseAgeExclude carve-out was ever added; the soak is the point.
   # It matured at 2026-08-04T02:36:40Z and is floored here now.
   hono: ^4.12.34
-  js-yaml: ^4.2.0
-  postcss: ^8.5.15
+  # GHSA-5p4m-2wfm-xmqj (high): quadratic CPU consumption resolving !!omap,
+  # fixed in 4.3.1 — the CVE-2026-59870 fix was never backported to the 3.x line.
+  # This entry already existed as `^4.2.0`, a floor for an earlier advisory, and
+  # 4.2.0 is BELOW this fix: an out-of-date floor is not a failure mode a caret
+  # protects against, because the caret only stops the tree going *backwards*.
+  # Dev scope (js-yaml reaches the tree via eslint) and absent from the shipped
+  # bundle, so nothing vulnerable was published.
+  js-yaml: ^4.3.1
+  # GHSA-fxqj-rqcc-2cmp (moderate): incomplete fix of GHSA-6g55-p6wh-862q — an
+  # attacker-controlled sourceMappingURL can read arbitrary .map files when `from`
+  # is unset. Patched in 8.5.23. This floor read `^8.5.15` — below the fix — so it
+  # was not actually enforcing it; the tree only resolved a safe 8.5.25 because
+  # vite's own range happened to pull it forward. Matches apple-notes/apple-photos.
+  # Development scope only (vitest -> vite -> postcss), not in the shipped bundle.
+  postcss: ^8.5.23


### PR DESCRIPTION
GHSA-5p4m-2wfm-xmqj (**high**) — quadratic CPU consumption resolving `!!omap` keys, where a malicious YAML document burns CPU superlinearly in the number of map entries. First complete release is **4.3.1**; the advisory notes the CVE-2026-59870 fix was never backported to 3.x.

## Nothing vulnerable ever shipped

`js-yaml` reaches the tree as `eslint` → `js-yaml` — **development scope** — and it does not appear in the committed `build/index.js` (verified: 0 references). The bundle is **byte-identical** before and after this change, so this owes **no version bump** and `require-version-bump` should pass without one.

## How the gap was found, and why it is worth writing down

The advisory fired on apple-mail-mcp, which *already had* a `js-yaml` override — pinned at `^4.2.0`, a floor written for an earlier advisory and **below** this fix. That is the failure mode worth naming: **a caret range does not protect against an out-of-date floor.** The caret stops the tree moving backwards; it never moves it forwards onto a newer fix. So an override can sit in the file looking like protection while enforcing a version that is no longer safe — the mirror image of the `fast-uri: 3.1.4` exact-pin-became-a-ceiling incident already documented beside it.

The other three repos carried no `js-yaml` entry at all, so all four are floored here in one pass.

## Also: the `postcss` floor here was under-set too

`postcss: ^8.5.15` sat below **8.5.23**, the patched release for GHSA-fxqj-rqcc-2cmp (moderate) — same defect, second entry. The tree resolved a safe 8.5.25 regardless because `vite`'s own range pulls it forward, so nothing was exposed; the override simply was not enforcing what its comment claimed. Raised to `^8.5.23`, matching apple-notes-mcp and apple-photos-mcp.

## Verification

- `js-yaml@4.3.1` resolved in all four lockfiles, with the override present in the lockfile's own `overrides:` section — the only proof an override is actually live.
- 4.3.1 published 2026-07-31, so it is **7 days past** the repos' 1440-minute `minimumReleaseAge` soak. No `minimumReleaseAgeExclude` carve-out was added.
- `pnpm audit`: **no known vulnerabilities** in all four.
- Bundle hash unchanged in all four.
- lint / typecheck / test / format:check clean — 449 (mail), 519 (notes), 111 (numbers), 290 (photos).