### PR TITLE
fix(count): don't treat a Mail-disabled account as an unreadable one

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.9",
+      "version": "2.10.10",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.9",
+      "version": "2.10.10",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.9",
+  "version": "2.10.10",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.9",
+  "version": "2.10.10",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.9",
+      "version": "2.10.10",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.9",
+  "version": "2.10.10",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+## [2.10.10] - 2026-08-10
+
+### Fixed
+
+- **An account switched OFF in Mail.app is no longer counted as an unreadable one, which was making every unscoped `get-unread-count` / `get-mail-stats` permanently `partial`** (#143). `planCountSources` assigned every Mail.app account a source — its matching IMAP config, else AppleScript — without consulting the account's `enabled` flag. A disabled account has no live connection, so an AppleScript count against it fails server-side (AppleEvent -10000); that failure was folded into `failedAccounts` and the result marked `partial: true`, whose text tells the caller "the real total is higher". For a deliberately-disabled account that is simply untrue — nothing is missing and the total is exact. This is the same condition `guardAccountEnabled` already refuses for mailbox writes; the count planner just never applied it. A disabled account with no IMAP config is now **not a source at all** rather than a failing one.
+- Scope is deliberately narrow: a disabled Mail account that **does** have an IMAP config is still counted, over IMAP. IMAP talks to the server directly and does not care about Mail's toggle, and the config is an explicit "read this account" instruction — that is how a mailbox stays readable by this server while staying out of Mail.app's UI. An account whose `enabled` flag is absent is treated as enabled, so backends that don't report it are unaffected.
+
+Found by a scheduled TCC watchdog whose canary read the resulting partial as a possible Apple Events reset. It was not one: a real grant loss fails *every* AppleScript account, not a single named one while the others return counts.
+
 ## [2.10.9] - 2026-08-08
 
 ### Fixed

--- a/build/index.js
+++ b/build/index.js
@@ -82788,6 +82788,7 @@ function planCountSources(accounts, configs) {
       usedConfigs.add(match);
       sources.push({ kind: "imap", config: match, label: account.name });
     } else {
+      if (account.enabled === false) continue;
       sources.push({ kind: "applescript", account, label: account.name });
     }
   }

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.9",
+  "version": "2.10.10",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.9",
+  "version": "2.10.10",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/imapMultiAccount.test.ts
+++ b/src/services/imapMultiAccount.test.ts
@@ -319,6 +319,45 @@ describe("planCountSources (each account counted exactly once)", () => {
     expect(sources.every((s) => s.kind === "applescript")).toBe(true);
     expect(sources).toHaveLength(3);
   });
+
+  // #143: a Mail account the user has switched OFF has no live connection, so
+  // an AppleScript count against it fails and lands in `failedAccounts` —
+  // turning a deliberately-disabled account into a permanent `partial: true`
+  // that claims the real total is higher when it is not.
+  it("SKIPS a disabled account that has no IMAP config (not a source at all)", () => {
+    const withDisabled: Account[] = [
+      ...accounts,
+      {
+        name: "robert.sweet@parkplacetech.com",
+        email: "robert.sweet@parkplacetech.com",
+        enabled: false,
+      },
+    ];
+    const sources = planCountSources(withDisabled, [cfgA, cfgB]);
+    expect(sources.map((s) => s.label)).not.toContain("robert.sweet@parkplacetech.com");
+    expect(sources).toHaveLength(3);
+  });
+
+  it("still counts a DISABLED account that HAS an IMAP config — IMAP ignores Mail's toggle", () => {
+    // The config is an explicit "read this account over IMAP" instruction, and
+    // IMAP talks to the server directly, so Mail's enabled flag is irrelevant.
+    const disabledButConfigured: Account = {
+      name: "Personal",
+      email: "a@gmail.com",
+      enabled: false,
+    };
+    const sources = planCountSources([disabledButConfigured], [cfgA]);
+    expect(sources).toHaveLength(1);
+    expect(sources[0].kind).toBe("imap");
+    expect(sources[0].label).toBe("Personal");
+  });
+
+  it("treats an account with no `enabled` field as enabled (back-compat)", () => {
+    const noFlag = [{ name: "Legacy", email: "l@x.com" } as Account];
+    const sources = planCountSources(noFlag, []);
+    expect(sources).toHaveLength(1);
+    expect(sources[0].kind).toBe("applescript");
+  });
 });
 
 describe("formatMergedRows", () => {

--- a/src/services/imapMultiAccount.ts
+++ b/src/services/imapMultiAccount.ts
@@ -259,6 +259,20 @@ export function planCountSources(accounts: Account[], configs: ImapConfig[]): Co
       usedConfigs.add(match);
       sources.push({ kind: "imap", config: match, label: account.name });
     } else {
+      // An account DISABLED in Mail has no live connection, so an AppleScript
+      // count against it fails server-side (AppleEvent -10000) — the same
+      // condition `guardAccountEnabled` already refuses for mailbox writes.
+      // Emitting it as a source turned a deliberately-off account into a
+      // permanent `partial: true` + `failedAccounts` on every unscoped
+      // get-unread-count / get-mail-stats, which reads as "the real total is
+      // higher" when it is not. A disabled account is not an unreadable
+      // source; it is not a source at all. (#143)
+      //
+      // Note this is deliberately only the no-IMAP-config branch: a disabled
+      // Mail account that DOES have an IMAP config stays counted above, because
+      // IMAP talks to the server directly and doesn't care about Mail's toggle
+      // — that config is an explicit "read this account" instruction.
+      if (account.enabled === false) continue;
       sources.push({ kind: "applescript", account, label: account.name });
     }
   }


### PR DESCRIPTION
A Mail.app account switched **OFF** was still being planned as a count source, so every unscoped `get-unread-count` / `get-mail-stats` came back `partial: true` with that account in `failedAccounts` — text that tells the caller *"the real total is higher"*. For a deliberately-disabled account that is untrue: nothing is missing and the total is exact.

### Root cause

`planCountSources` assigned every Mail.app account a source — its matching IMAP config, else AppleScript — without consulting `account.enabled`. A disabled account has no live connection, so the AppleScript count fails server-side (AppleEvent `-10000`) and lands in `failedAccounts`.

This is the same condition [`guardAccountEnabled`](https://github.com/sweetrb/apple-mail-mcp/blob/main/src/services/appleMailManager.ts) already refuses for mailbox writes (*"disabled in Mail, so Mail has no live connection to it"*). The count planner just never applied it.

### How it surfaced

A scheduled TCC watchdog on this fleet has a canary that calls `get-unread-count`. A dormant client account left disabled in Mail made that canary report a possible Apple Events reset three times a day:

```
FAIL partial read — {"unread":1,"mailbox":"INBOX","partial":true,
                     "failedAccounts":["<redacted>@<client>.com"]}
```

It was never a grant problem. **A real TCC reset fails *every* AppleScript account, not one named account while the others return counts** — the successful `"unread":1` in that same payload is the proof.

### Scope

Deliberately narrow — a disabled Mail account that **does** have an IMAP config is still counted, over IMAP. IMAP talks to the server directly and does not care about Mail's toggle, and the config is an explicit "read this account" instruction; that is how a mailbox stays readable by this server while staying out of Mail.app's UI. An account with no `enabled` field is treated as enabled, so backends that don't report it are unaffected.

### Tests

Three added to `planCountSources`, covering each branch: disabled + no config → **not a source at all**; disabled + config → **still counted via IMAP**; `enabled` absent → **treated as enabled**. 458 tests pass; lint/typecheck/format clean; bundle rebuilt and committed.

Bumps 2.10.9 → 2.10.10.