### PR TITLE
test: guard the ecosystem contract — real 2020-12 schema validation + executable doc examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ If you send a single backslash without escaping:
 body: "The file is at C:\\Users\\Documents\\report.pdf"
 ```
 
+→ arrives as: `The file is at C:\Users\Documents\report.pdf`
+
 **Incorrect - Will fail:**
 
 ```text

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitest/coverage-v8": "^4.1.9",
+    "ajv": "^8.17.1",
     "esbuild": "^0.28.1",
     "eslint": "^9.0.0",
     "globals": "^17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.10(vitest@4.1.10)
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1

--- a/src/claudeMdEscaping.test.ts
+++ b/src/claudeMdEscaping.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Executable documentation — CLAUDE.md's backslash-escaping rules.
+ *
+ * CLAUDE.md is the instruction sheet an AI agent reads before it calls these
+ * tools, so a wrong example there is a live defect: the agent copies it and the
+ * recipient gets the wrong bytes. A sibling repo (apple-notes-mcp) carried a
+ * Windows-path example that contradicted the escaping table three lines above
+ * it for a long time, because nothing ever checked the doc's examples against
+ * the doc's own rules.
+ *
+ * This test reads CLAUDE.md off disk and enforces exactly that:
+ *
+ *   a. the "You want | Send in JSON parameter" table is self-consistent —
+ *      JSON-decoding the right cell yields the left cell, literally;
+ *   b. every "Correct" example decodes to the result the doc annotates it with
+ *      (`→ arrives as: \`…\``), so the promised bytes are the real bytes;
+ *   c. every "Incorrect" example genuinely is incorrect — it either fails to
+ *      parse as JSON or decodes to something other than the correct result. A
+ *      doc that labels a working string "will fail" is its own kind of wrong;
+ *   d. the "Testing Your Understanding" checklist agrees with (a).
+ *
+ * Pure file I/O — no server boot, no Mail.app, no network.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+const CLAUDE_MD = new URL("../CLAUDE.md", import.meta.url);
+const DOC = readFileSync(CLAUDE_MD, "utf8");
+
+const ESCAPING_HEADING = "## Critical: Backslash Escaping";
+const CHECKLIST_HEADING = "## Testing Your Understanding";
+
+/** The body of a `## ` section, up to the next `## ` heading. */
+function section(heading: string): string {
+  const start = DOC.indexOf(heading);
+  expect(start, `CLAUDE.md is missing the "${heading}" section`).toBeGreaterThan(-1);
+  const rest = DOC.slice(start + heading.length);
+  const end = rest.search(/\n## /);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+/** Contents of a markdown code span, or null when the cell isn't one. */
+function codeSpan(cell: string): string | null {
+  const m = /^`(.*)`$/.exec(cell.trim());
+  return m ? m[1] : null;
+}
+
+/** JSON-decode a bare string body: what the JSON parser hands the server. */
+function decodeJsonStringBody(body: string): string {
+  return JSON.parse(`"${body}"`) as string;
+}
+
+interface Example {
+  kind: "Correct" | "Incorrect";
+  heading: string;
+  /** The raw `"…"` JSON string literal from the fenced block, quotes included. */
+  literal: string | null;
+  /** The `→ arrives as: \`…\`` annotation that follows the fence, if any. */
+  arrivesAs: string | null;
+}
+
+/**
+ * Split a section into its **Correct:** / **Incorrect:** examples. Each marker
+ * owns the text up to the next marker, so a fence and its annotation can never
+ * be attributed to the wrong example.
+ */
+function parseExamples(text: string): Example[] {
+  const marker = /\*\*(Correct|Incorrect)\b[^\n]*\*\*/g;
+  const hits: { kind: "Correct" | "Incorrect"; heading: string; at: number }[] = [];
+  for (let m = marker.exec(text); m !== null; m = marker.exec(text)) {
+    hits.push({ kind: m[1] as "Correct" | "Incorrect", heading: m[0], at: m.index });
+  }
+  return hits.map((hit, i) => {
+    const chunk = text.slice(hit.at, i + 1 < hits.length ? hits[i + 1].at : text.length);
+    const fence = /```[a-zA-Z]*\n([\s\S]*?)\n```/.exec(chunk);
+    // A `body:` / `content:` parameter carrying a JSON string literal.
+    const lit = fence ? /\b(?:body|content)\s*:\s*("(?:[^"\\]|\\.)*")/.exec(fence[1]) : null;
+    const annotation = /→ arrives as: `([^`]*)`/.exec(chunk);
+    return {
+      kind: hit.kind,
+      heading: hit.heading,
+      literal: lit ? lit[1] : null,
+      arrivesAs: annotation ? annotation[1] : null,
+    };
+  });
+}
+
+describe("CLAUDE.md backslash-escaping rules are self-consistent", () => {
+  const escaping = section(ESCAPING_HEADING);
+  const examples = parseExamples(escaping);
+
+  it("the escaping table decodes exactly as it claims", () => {
+    const rows: { want: string; send: string }[] = [];
+    for (const line of escaping.split("\n")) {
+      const t = line.trim();
+      if (!t.startsWith("|") || !t.endsWith("|")) continue;
+      const cells = t.slice(1, -1).split("|");
+      if (cells.length !== 2) continue;
+      const want = codeSpan(cells[0]);
+      const send = codeSpan(cells[1]);
+      // Header ("You want") and separator ("---") rows aren't code spans.
+      if (want === null || send === null) continue;
+      rows.push({ want, send });
+    }
+
+    expect(
+      rows.length,
+      "parsed no rows out of the escaping table — the table moved or the parser rotted"
+    ).toBeGreaterThan(0);
+
+    for (const row of rows) {
+      let decoded: string;
+      try {
+        decoded = decodeJsonStringBody(row.send);
+      } catch (err) {
+        throw new Error(
+          `escaping table row \`${row.want}\` | \`${row.send}\`: the "send" cell is ` +
+            `not a valid JSON string body (${(err as Error).message})`
+        );
+      }
+      expect(
+        decoded,
+        `escaping table row \`${row.want}\` | \`${row.send}\`: sending \`${row.send}\` ` +
+          `actually yields ${JSON.stringify(decoded)}, not ${JSON.stringify(row.want)}`
+      ).toBe(row.want);
+    }
+  });
+
+  it("every Correct example decodes to the result the doc annotates it with", () => {
+    const correct = examples.filter((e) => e.kind === "Correct");
+    expect(correct.length, "found no Correct example in the escaping section").toBeGreaterThan(0);
+
+    let checked = 0;
+    for (const ex of correct) {
+      expect(
+        ex.literal,
+        `Correct example "${ex.heading}" has no body:/content: JSON string literal`
+      ).not.toBeNull();
+      expect(
+        ex.arrivesAs,
+        `Correct example "${ex.heading}" is missing its "→ arrives as: \`…\`" annotation — ` +
+          `that annotation is what makes the example checkable; re-add it`
+      ).not.toBeNull();
+
+      let decoded: string;
+      try {
+        decoded = JSON.parse(ex.literal as string) as string;
+      } catch (err) {
+        throw new Error(
+          `Correct example "${ex.heading}" is not valid JSON: ${(err as Error).message}`
+        );
+      }
+      expect(
+        decoded,
+        `Correct example "${ex.heading}": ${ex.literal} arrives as ${JSON.stringify(decoded)}, ` +
+          `but the doc says it arrives as ${JSON.stringify(ex.arrivesAs)}`
+      ).toBe(ex.arrivesAs);
+      checked++;
+    }
+
+    // Guards against a doc rewrite that drops every annotation and leaves this
+    // suite passing vacuously.
+    expect(
+      checked,
+      "no annotated Correct example was checked — the annotations were dropped"
+    ).toBeGreaterThan(0);
+  });
+
+  it("every Incorrect example really is incorrect", () => {
+    const incorrect = examples.filter((e) => e.kind === "Incorrect");
+    expect(incorrect.length, "found no Incorrect example in the escaping section").toBeGreaterThan(
+      0
+    );
+
+    const correctResults = new Set(
+      examples
+        .filter((e) => e.kind === "Correct" && e.arrivesAs !== null)
+        .map((e) => e.arrivesAs as string)
+    );
+
+    for (const ex of incorrect) {
+      expect(
+        ex.literal,
+        `Incorrect example "${ex.heading}" has no body:/content: JSON string literal`
+      ).not.toBeNull();
+
+      let decoded: string | null = null;
+      try {
+        decoded = JSON.parse(ex.literal as string) as string;
+      } catch {
+        continue; // doesn't parse at all — incorrect, as advertised
+      }
+      expect(
+        correctResults.has(decoded),
+        `Incorrect example "${ex.heading}" is labelled as failing, but ${ex.literal} parses ` +
+          `cleanly and yields ${JSON.stringify(decoded)} — the same result as the Correct ` +
+          `example. Either the label or the example is wrong`
+      ).toBe(false);
+    }
+  });
+
+  it('the "Testing Your Understanding" checklist agrees with the escaping table', () => {
+    const checklist = section(CHECKLIST_HEADING);
+
+    const needs = /^- `([^`]*)` - Needs escaping: `([^`]*)`$/gm;
+    let claims = 0;
+    for (let m = needs.exec(checklist); m !== null; m = needs.exec(checklist)) {
+      const [, want, send] = m;
+      const decoded = decodeJsonStringBody(send);
+      expect(
+        decoded,
+        `checklist claims \`${want}\` needs escaping as \`${send}\`, but that decodes to ` +
+          `${JSON.stringify(decoded)}`
+      ).toBe(want);
+      claims++;
+    }
+    expect(claims, "parsed no escaping claims out of the checklist").toBeGreaterThan(0);
+
+    const none = /^- `([^`]*)` - No escaping needed/gm;
+    for (let m = none.exec(checklist); m !== null; m = none.exec(checklist)) {
+      expect(
+        m[1].includes("\\"),
+        `checklist says \`${m[1]}\` needs no escaping, but it contains a backslash`
+      ).toBe(false);
+    }
+  });
+});

--- a/test/output-schema.test.ts
+++ b/test/output-schema.test.ts
@@ -10,7 +10,11 @@
  *   3. every advertised schema declares the JSON Schema 2020-12 dialect and
  *      carries no draft-07-only construct — the SDK emits draft-07 and current
  *      clients refuse every such tool outright (#147)
- *   4. the diagnostic tools round-trip without a validation rejection. The SDK's
+ *   4. every advertised schema actually COMPILES under a real 2020-12 validator
+ *      (ajv's Ajv2020 — the same library the MCP SDK validates with), because a
+ *      schema can declare the right dialect and still be structurally invalid
+ *      under it. Asserting the "$schema" string is a claim; compiling is proof.
+ *   5. the diagnostic tools round-trip without a validation rejection. The SDK's
  *      validateToolOutput (server mcp.js) THROWS McpError when a success result's
  *      structuredContent is missing or fails the schema, which rejects callTool —
  *      so a resolving call proves a real payload validates against its schema.
@@ -23,6 +27,16 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { resolve } from "path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+// ajv's 2020-12 entrypoint is CommonJS with `module.exports = Ajv2020` AND an
+// `exports.default` alias, so the ESM default import lands on the namespace-ish
+// object under some loaders and on the class under others — unwrap `.default`
+// when it is there. ajv is a DIRECT devDependency on purpose: it reaches the
+// tree transitively via @modelcontextprotocol/sdk, but pnpm's strict
+// node_modules layout makes a transitive package unimportable.
+import Ajv2020Entry from "ajv/dist/2020.js";
+
+const Ajv2020 = ((Ajv2020Entry as unknown as { default?: unknown }).default ??
+  Ajv2020Entry) as typeof Ajv2020Entry;
 
 const SERVER = resolve(__dirname, "../build/index.js");
 
@@ -211,6 +225,49 @@ describe("outputSchema contract (real server over stdio)", () => {
       }
     }
     expect(offenders, `nested dialect declarations: ${offenders.join("; ")}`).toEqual([]);
+  });
+
+  it("every advertised schema compiles under a REAL 2020-12 validator (ajv)", async () => {
+    // The dialect assertions above check what we CLAIM; this checks whether the
+    // claim holds. A schema can carry `"$schema": ".../2020-12/schema"` and
+    // still be structurally invalid under it (bad `type`, malformed `$ref`,
+    // non-schema in a `properties` slot, a keyword whose value has the wrong
+    // shape) — every one of those is a tool a strict client drops on the floor.
+    //
+    // ajv IS the validator the MCP SDK itself uses, and Ajv2020 will refuse a
+    // schema whose declared meta-schema it doesn't know — so this also
+    // independently re-catches the #147 draft-07 regression from the other end,
+    // via a library rather than a string comparison.
+    //
+    // strict:false on purpose: ajv's strict mode rejects unknown keywords and
+    // benign annotations (title/examples/x-*), which is a style opinion, not a
+    // portability fact. What we need to know is whether the schema is
+    // STRUCTURALLY VALID under 2020-12.
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(0);
+
+    const failures: string[] = [];
+    for (const tool of tools) {
+      for (const [kind, schema] of [
+        ["inputSchema", tool.inputSchema],
+        ["outputSchema", tool.outputSchema],
+      ] as const) {
+        if (!schema) continue;
+        // A fresh instance per schema: ajv caches by $id/serialized schema, and
+        // one poisoned instance must not mask or manufacture later failures.
+        const ajv = new Ajv2020({ strict: false });
+        try {
+          ajv.compile(schema as object);
+        } catch (err) {
+          failures.push(`${tool.name}.${kind}: ${(err as Error).message}`);
+        }
+      }
+    }
+    expect(
+      failures,
+      `every advertised schema must compile under JSON Schema 2020-12 — ` +
+        `a client that validates schemas will refuse these tools outright: ${failures.join("; ")}`
+    ).toEqual([]);
   });
 
   it("diagnostic tools' real output validates against their outputSchema (when reachable)", async () => {


### PR DESCRIPTION
## The incident behind this

All four `apple-*-mcp` servers shipped tool schemas declaring JSON Schema **draft-07**, and current MCP clients refuse every such tool outright ("declares an unsupported dialect"). That was fixed today in #148 / #147 — but the interesting part is *why nothing caught it*: this repo has a thorough `outputSchema` contract suite that boots the real server over stdio, and it contained **not one assertion about the dialect we advertise**. We assert our own behaviour exhaustively; we almost never assert our **contract with the ecosystem** — or with our own documentation.

Two guards close that class. Neither changes shipped bytes.

## Guard 1 — compile every advertised schema with a REAL 2020-12 validator

Asserting the `"$schema"` string is a *claim*. A schema can declare 2020-12 and still be structurally invalid under it (bad `type`, malformed `$ref`, a non-schema in a `properties` slot) — and a client that validates schemas drops those tools just as hard as it drops draft-07 ones.

`test/output-schema.test.ts` now compiles **both** `inputSchema` and `outputSchema` of **every** tool (50 here) with ajv's `Ajv2020` — the same library the MCP SDK itself validates with — and fails with the tool name and ajv's own message. It re-catches the original draft-07 regression independently, from the library side rather than by string comparison: `Ajv2020` refuses a schema whose declared meta-schema it doesn't know (`no schema with key or ref "http://json-schema.org/draft-07/schema#"`).

- **ajv `^8.17.1` becomes a direct devDependency** (the SDK's own range). It is already in the tree transitively via `@modelcontextprotocol/sdk`, but pnpm's strict `node_modules` layout makes a transitive package unimportable — so it has to be direct or the import fails.
- **`strict: false`** on purpose: ajv's strict mode rejects unknown keywords and benign annotations, which is a style opinion. What this guard needs to know is whether the schema is *structurally valid* under 2020-12.
- **No advertised schema uses `format`** — checked across all 50 tools, input and output, at every depth (0 occurrences) — so `ajv-formats` is not needed. With `strict: false` a future `format` would be ignored rather than break the guard.

## Guard 2 — executable doc examples (`CLAUDE.md`)

`apple-notes-mcp`'s `CLAUDE.md` carried a Windows-path escaping example that contradicted the escaping table **three lines above it** — it told the agent to send `\\\\`, which decodes to a literal *double* backslash. It was wrong for a long time because nothing ever checked doc examples against the doc's own rules. `CLAUDE.md` is the instruction sheet an agent reads *before* it calls these tools, so a wrong example there is a live defect: the agent copies it and the recipient gets the wrong bytes.

New unit test `src/claudeMdEscaping.test.ts` (plain vitest, no server boot — it only reads `CLAUDE.md` from disk) enforces the file's own rules:

1. **The escaping table is self-consistent** — JSON-decoding each "Send in JSON parameter" cell yields the "You want" cell exactly.
2. **Every "Correct" example decodes to its documented result.** This needed a machine-readable expected value, so each Correct example gains one line after the closing fence:
   `→ arrives as: ` + backtick + the literal text the recipient actually gets + backtick.
   The test extracts the `body:` / `content:` JSON string literal from the fenced block, decodes it, and asserts equality. It also asserts at least one such pair was found, so a doc rewrite that drops the annotations fails loudly instead of passing vacuously.
3. **Every "Incorrect" example really is incorrect** — it either fails to parse as JSON or decodes to something other than the correct result. A doc that labels a working string "will fail" is its own kind of wrong.
4. **The "Testing Your Understanding" checklist agrees with the table** (same decode rule applied to its `Needs escaping:` bullets, plus: anything marked "no escaping needed" must contain no backslash).

**This repo's escaping content was already correct** — its table and its `C:\\Users\\Documents` example agree — so `CLAUDE.md` gains exactly one line (the annotation). No example changed what it teaches.

## Proof of teeth

A guard that passes but wouldn't have caught its bug is worthless, so each was deliberately broken and the failure observed, then restored:

| Guard | Break | Observed failure |
|---|---|---|
| 1 | fed a schema with `"type": "definitely-not-a-type"` to the validator | `every advertised schema must compile under JSON Schema 2020-12 …: TEETH-PROBE.inputSchema: schema is invalid: data/properties/broken/type must be equal to one of the allowed values, …` |
| 1 (dialect) | compiled a schema declaring draft-07 | `no schema with key or ref "http://json-schema.org/draft-07/schema#"` |
| 2b | doubled the backslashes in the `→ arrives as:` annotation — i.e. reproduced the notes-repo bug shape | `Correct example "**Correct - Windows path in email:**": … arrives as "The file is at C:\Users\Documents\report.pdf", but the doc says it arrives as "The file is at C:\\Users\\Documents\\report.pdf"` |
| 2a | changed a table row's send-cell to `C:\\\\Users\\\\` | `escaping table row … sending \`C:\\\\Users\\\\\` actually yields "C:\\Users\\", not "C:\Users\"` |
| 2c | made the "Incorrect" example's literal identical to the correct one | `Incorrect example "**Incorrect - Will fail:**" is labelled as failing, but … parses cleanly and yields … the same result as the Correct example` |

## No version bump — deliberately

Nothing here changes shipped bytes: tests are not bundled, `CLAUDE.md` is not in `package.json` `files[]`, and the only dependency added is a devDependency. `build/index.js` and `build/cli.js` are **byte-identical** to `main` after a rebuild (`sha256 f64a4b41…` / `cebf8781…`; `git diff origin/main -- build/` is empty).

## Gates

`pnpm run lint` (0 errors), `pnpm run typecheck`, `pnpm test` (34 files / 497 tests), `pnpm run format:check`, and `pnpm exec vitest run --config vitest.integration.config.ts test/output-schema.test.ts` (8/8, up from 7 — the new ajv test) all pass locally.

The 7 failures in `test/integration.test.ts` on this machine are pre-existing and environmental — this session's process tree holds no Apple Events grant for Mail (`osascript … -1743 Not authorized to send Apple events to Mail`), and that suite is not run by CI.