### PR TITLE
docs: fix the wrong backslash-escaping instruction in the shipped README, drop Windows examples, guard README.md

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.12",
+      "version": "2.10.13",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.12",
+      "version": "2.10.13",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.12",
+  "version": "2.10.13",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.12",
+  "version": "2.10.13",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.12",
+      "version": "2.10.13",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.12",
+  "version": "2.10.13",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## [Unreleased]
 
+## [2.10.13] - 2026-08-13
+
+### Documentation
+
+- **The README's backslash-escaping instruction was wrong, and the README is the copy that ships.** It told agents to send four backslashes to produce one literal backslash — `Windows paths: C:\Users\ → C:\\\\Users\\\\ in JSON`, and the same four-backslash form in the worked `send-email` example and in the shell-path and regex bullets. A JSON string literal containing four backslashes decodes to **two** literal backslashes, so an agent that followed the instruction sent `C:\\Users\\` and the recipient got a doubled backslash in every path, regex, and escaped space in the message body. The correct form is two backslashes per literal backslash, which is what this repo's `CLAUDE.md` already said — so one repo carried two contradictory instructions, and the wrong one was the published one (`README.md` is in `package.json` `files[]`; `CLAUDE.md` is not). Every four-backslash instruction is now the two-backslash form.
+- **The sentence explaining the rule was self-contradictory and is rewritten.** It read "The `\\\\` in JSON becomes `\\` in the actual string, which represents a single `\`" — but `\\` in the resulting string is two characters, not one. It now states the rule plainly: in a JSON string literal, `\\` (two characters) denotes one literal backslash, and four denote two.
+- **Dropped the Windows examples from `README.md` and `CLAUDE.md`.** This package is `os: ["darwin"]` and drives Mail.app through AppleScript; a `C:\Users\` example is generic MCP boilerplate that was never localized to these servers — and it is precisely where the four-backslash error lived. Replaced with macOS-native examples of equal teaching value: a shell path with an escaped space (`~/Library/Mobile\ Documents/…`, whose unescaped form is not even valid JSON, so the failure mode is real rather than cosmetic) and a regex (`\d+`). Nothing is lost for Windows users: the table's generic rows (`\` → `\\`, `\\` → `\\\\`) are platform-neutral and still cover drive paths.
+- **`README.md` is now covered by an executable doc guard** (`src/readmeEscaping.test.ts`), which is why this bug survived: the guard added a day earlier checked `CLAUDE.md` only — the file that does **not** ship — while the file that does ship went unchecked. It now asserts that every "common patterns" bullet is self-consistent (JSON-decoding the "send this" side yields the "you want" side — the exact assertion that would have caught this), that each worked example decodes to its `→ arrives as:` annotation (parsing the fenced JSON block as JSON and reading its `body` field, rather than eyeballing backslash counts), that every "Incorrect" example genuinely fails to parse, and that neither doc reintroduces a Windows drive path. Each assertion also fails when it finds nothing to check, so a doc rewrite cannot make the suite pass vacuously.
+
+No runtime code changed; the committed `build/` bundle is byte-identical.
+
 ## [2.10.12] - 2026-08-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,11 +24,11 @@ Keychain gotchas). Verify with the `doctor` tool.
 
 The MCP protocol uses JSON for parameters. In JSON, `\` is an escape character. To include a literal backslash:
 
-| You want    | Send in JSON parameter |
-|-------------|------------------------|
-| `\`         | `\\`                   |
-| `\\`        | `\\\\`                 |
-| `C:\Users\` | `C:\\Users\\`          |
+| You want            | Send in JSON parameter |
+|---------------------|------------------------|
+| `\`                 | `\\`                   |
+| `\\`                | `\\\\`                 |
+| `Mobile\ Documents` | `Mobile\\ Documents`   |
 
 ### Why This Matters
 
@@ -40,18 +40,26 @@ If you send a single backslash without escaping:
 
 ### Examples
 
-**Correct - Windows path in email:**
+**Correct - shell path with an escaped space:**
 
 ```text
-body: "The file is at C:\\Users\\Documents\\report.pdf"
+body: "Run: cp ~/Library/Mobile\\ Documents/report.pdf ~/Desktop/"
 ```
 
-→ arrives as: `The file is at C:\Users\Documents\report.pdf`
+→ arrives as: `Run: cp ~/Library/Mobile\ Documents/report.pdf ~/Desktop/`
+
+**Correct - regex in the body:**
+
+```text
+body: "Invoice numbers match \\d+"
+```
+
+→ arrives as: `Invoice numbers match \d+`
 
 **Incorrect - Will fail:**
 
 ```text
-body: "The file is at C:\Users\Documents\report.pdf"
+body: "Run: cp ~/Library/Mobile\ Documents/report.pdf ~/Desktop/"
 ```
 
 ## Tool Usage Tips
@@ -376,8 +384,9 @@ Replaced `with opening window` with `without opening window` for both `reply` an
 Before sending emails with paths or special characters, verify escaping:
 
 - `~/path/to/file` - No escaping needed (no backslashes)
-- `C:\Users\` - Needs escaping: `C:\\Users\\`
+- `~/Library/Mobile\ Documents` - Needs escaping: `~/Library/Mobile\\ Documents`
 - `file\ name.txt` - Needs escaping: `file\\ name.txt`
+- `\d+` - Needs escaping: `\\d+`
 
 ## Recurring macOS permission prompts → offer the official-Node fix
 

--- a/README.md
+++ b/README.md
@@ -1375,21 +1375,33 @@ When sending content containing backslashes (`\`) to this MCP server, **you must
 
 **Why:** The MCP protocol uses JSON for parameter passing. In JSON, a single backslash is an escape character. To include a literal backslash in content, it must be escaped as `\\`.
 
-**Example - Email with file path:**
+**Correct — email containing a shell path with an escaped space:**
+
 ```json
 {
   "to": ["colleague@company.com"],
   "subject": "File Location",
-  "body": "The file is at C:\\\\Users\\\\Documents\\\\report.pdf"
+  "body": "Run: cp ~/Library/Mobile\\ Documents/report.pdf ~/Desktop/"
 }
 ```
 
-The `\\\\` in JSON becomes `\\` in the actual string, which represents a single `\` in the email.
+→ arrives as: `Run: cp ~/Library/Mobile\ Documents/report.pdf ~/Desktop/`
+
+In a JSON string literal, `\\` — two characters — denotes **one** literal backslash. Four backslashes (`\\\\`) denote **two** literal backslashes, so send those only when the text genuinely contains `\\`.
+
+**Incorrect — the unescaped backslash makes this invalid JSON:**
+
+```text
+"body": "Run: cp ~/Library/Mobile\ Documents/report.pdf ~/Desktop/"
+```
+
+`\ ` (backslash-space) is not a valid JSON escape sequence, so the call is rejected — or, with a laxer parser, the backslash is silently dropped.
 
 **Common patterns requiring escaping:**
-- Windows paths: `C:\Users\` → `C:\\\\Users\\\\` in JSON
-- Shell escaped spaces: `Mobile\ Documents` → `Mobile\\\\ Documents` in JSON
-- Regex patterns: `\d+` → `\\\\d+` in JSON
+
+- Shell escaped spaces: `Mobile\ Documents` → `Mobile\\ Documents` in JSON
+- Regex patterns: `\d+` → `\\d+` in JSON
+- A literal double backslash: `\\` → `\\\\` in JSON
 
 **If you see errors** when sending emails with backslashes, double-check that backslashes are properly escaped in the JSON payload.
 

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.12",
+  "version": "2.10.13",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.12",
+  "version": "2.10.13",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/readmeEscaping.test.ts
+++ b/src/readmeEscaping.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Executable documentation — README.md's backslash-escaping rules.
+ *
+ * Sibling of `claudeMdEscaping.test.ts`, which does the same job for CLAUDE.md.
+ * README.md needs its own guard for a reason that is easy to get backwards:
+ * **README.md is listed in package.json `files[]`, so it ships in the npm
+ * tarball. CLAUDE.md does not.** The guard that existed first covered only the
+ * file that does not ship — and the file that does ship was the one carrying a
+ * wrong instruction.
+ *
+ * The bug this suite exists to catch: README.md told agents to send
+ * `C:\\\\Users\\\\` (four backslashes) to produce `C:\Users\`. A JSON string
+ * literal containing four backslashes decodes to **two** literal backslashes,
+ * so that instruction produced `C:\\Users\\` — while CLAUDE.md, three files
+ * away, correctly said two. One repo, two contradictory instructions, and the
+ * wrong one was the published one.
+ *
+ * What is enforced here:
+ *
+ *   a. every "common patterns" bullet (`- label: `A` → `B` in JSON`) is
+ *      self-consistent — JSON-decoding `B` yields exactly `A`;
+ *   b. every worked example decodes to the result the doc annotates it with
+ *      (`→ arrives as: `…``); for a ```json fence the block is parsed as JSON
+ *      and the `body`/`content` field is pulled out, rather than regexing the
+ *      raw line;
+ *   c. every "Incorrect" example genuinely is incorrect;
+ *   d. neither README.md nor CLAUDE.md teaches escaping with a Windows path.
+ *      These servers drive Apple Mail through AppleScript and are `os:
+ *      ["darwin"]` — a `C:\Users\` example is boilerplate that was never
+ *      localized, and it is where the four-backslash error lived.
+ *
+ * Each assertion also requires that it found something to check, so a doc
+ * rewrite that changes the format fails loudly instead of passing vacuously.
+ *
+ * Pure file I/O — no server boot, no Mail.app, no network.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+const README = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+const CLAUDE_MD = readFileSync(new URL("../CLAUDE.md", import.meta.url), "utf8");
+
+const README_HEADING = "### Backslash Escaping (Important for AI Agents)";
+const CLAUDE_HEADING = "## Critical: Backslash Escaping";
+
+/** The body of a markdown section, up to the next heading at the same or a higher level. */
+function section(doc: string, heading: string, label: string): string {
+  const start = doc.indexOf(heading);
+  expect(start, `${label} is missing the "${heading}" section`).toBeGreaterThan(-1);
+  const hashes = /^#+/.exec(heading);
+  const level = hashes ? hashes[0].length : 2;
+  const rest = doc.slice(start + heading.length);
+  const end = rest.search(new RegExp(`\\n#{1,${level}} `));
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+/** JSON-decode a bare string body: what the JSON parser hands the server. */
+function decodeJsonStringBody(body: string): string {
+  return JSON.parse(`"${body}"`) as string;
+}
+
+/** A `body:` / `"content":` parameter carrying a JSON string literal, quotes included. */
+const LITERAL = /(?:"(?:body|content)"|\b(?:body|content))\s*:\s*("(?:[^"\\]|\\.)*")/;
+
+interface Example {
+  kind: "Correct" | "Incorrect";
+  heading: string;
+  /** The fence language tag (`json`, `text`, …), or "" for a bare fence. */
+  lang: string | null;
+  /** The fenced block's contents. */
+  block: string | null;
+  /** The `→ arrives as: `…`` annotation that follows the fence, if any. */
+  arrivesAs: string | null;
+}
+
+/**
+ * Split a section into its **Correct:** / **Incorrect:** examples. Each marker
+ * owns the text up to the next marker, so a fence and its annotation can never
+ * be attributed to the wrong example.
+ */
+function parseExamples(text: string): Example[] {
+  const marker = /\*\*(Correct|Incorrect)\b[^\n]*\*\*/g;
+  const hits: { kind: "Correct" | "Incorrect"; heading: string; at: number }[] = [];
+  for (let m = marker.exec(text); m !== null; m = marker.exec(text)) {
+    hits.push({ kind: m[1] as "Correct" | "Incorrect", heading: m[0], at: m.index });
+  }
+  return hits.map((hit, i) => {
+    const chunk = text.slice(hit.at, i + 1 < hits.length ? hits[i + 1].at : text.length);
+    const fence = /```([a-zA-Z]*)\n([\s\S]*?)\n```/.exec(chunk);
+    const annotation = /→ arrives as: `([^`]*)`/.exec(chunk);
+    return {
+      kind: hit.kind,
+      heading: hit.heading,
+      lang: fence ? fence[1] : null,
+      block: fence ? fence[2] : null,
+      arrivesAs: annotation ? annotation[1] : null,
+    };
+  });
+}
+
+/**
+ * What the server actually receives for an example: a ```json fence is parsed
+ * as JSON and its `body`/`content` field returned; any other fence has its
+ * `body: "…"` string literal extracted and decoded. Throws when the payload is
+ * not valid JSON — which is exactly what an "Incorrect" example should do.
+ */
+function decodeExample(ex: Example): string {
+  expect(ex.block, `example "${ex.heading}" has no fenced code block`).not.toBeNull();
+  const block = ex.block as string;
+
+  if (ex.lang === "json") {
+    const payload = JSON.parse(block) as Record<string, unknown>;
+    const field = payload.body ?? payload.content;
+    expect(
+      typeof field,
+      `example "${ex.heading}": the JSON payload has no string body/content field`
+    ).toBe("string");
+    return field as string;
+  }
+
+  const lit = LITERAL.exec(block);
+  expect(lit, `example "${ex.heading}" has no body:/content: JSON string literal`).not.toBeNull();
+  return JSON.parse((lit as RegExpExecArray)[1]) as string;
+}
+
+describe("README.md backslash-escaping rules are self-consistent", () => {
+  const escaping = section(README, README_HEADING, "README.md");
+  const examples = parseExamples(escaping);
+
+  it("every common-patterns bullet decodes exactly as it claims", () => {
+    const bullets = /^- ([^:\n]+): `([^`]*)` → `([^`]*)` in JSON\s*$/gm;
+    const rows: { label: string; want: string; send: string }[] = [];
+    for (let m = bullets.exec(escaping); m !== null; m = bullets.exec(escaping)) {
+      rows.push({ label: m[1], want: m[2], send: m[3] });
+    }
+
+    expect(
+      rows.length,
+      'parsed no "- label: `A` → `B` in JSON" bullets out of the README escaping section — ' +
+        "the list moved or the parser rotted"
+    ).toBeGreaterThan(0);
+
+    for (const row of rows) {
+      let decoded: string;
+      try {
+        decoded = decodeJsonStringBody(row.send);
+      } catch (err) {
+        throw new Error(
+          `README pattern "${row.label}": sending \`${row.send}\` is not a valid JSON ` +
+            `string body (${(err as Error).message})`
+        );
+      }
+      expect(
+        decoded,
+        `README pattern "${row.label}": the doc says send \`${row.send}\` to get ` +
+          `\`${row.want}\`, but that actually yields ${JSON.stringify(decoded)}`
+      ).toBe(row.want);
+    }
+  });
+
+  it("every Correct example decodes to the result the doc annotates it with", () => {
+    const correct = examples.filter((e) => e.kind === "Correct");
+    expect(
+      correct.length,
+      "found no Correct example in the README escaping section"
+    ).toBeGreaterThan(0);
+
+    let checked = 0;
+    for (const ex of correct) {
+      expect(
+        ex.arrivesAs,
+        `Correct example "${ex.heading}" is missing its "→ arrives as: \`…\`" annotation — ` +
+          `that annotation is what makes the example checkable; re-add it`
+      ).not.toBeNull();
+
+      let decoded: string;
+      try {
+        decoded = decodeExample(ex);
+      } catch (err) {
+        throw new Error(
+          `Correct example "${ex.heading}" is not valid JSON: ${(err as Error).message}`
+        );
+      }
+      expect(
+        decoded,
+        `Correct example "${ex.heading}": the payload arrives as ${JSON.stringify(decoded)}, ` +
+          `but the doc says it arrives as ${JSON.stringify(ex.arrivesAs)}`
+      ).toBe(ex.arrivesAs);
+      checked++;
+    }
+
+    expect(
+      checked,
+      "no annotated Correct example was checked — the annotations were dropped"
+    ).toBeGreaterThan(0);
+  });
+
+  it("every Incorrect example really is incorrect", () => {
+    const incorrect = examples.filter((e) => e.kind === "Incorrect");
+    expect(
+      incorrect.length,
+      "found no Incorrect example in the README escaping section"
+    ).toBeGreaterThan(0);
+
+    const correctResults = new Set(
+      examples
+        .filter((e) => e.kind === "Correct" && e.arrivesAs !== null)
+        .map((e) => e.arrivesAs as string)
+    );
+
+    for (const ex of incorrect) {
+      let decoded: string;
+      try {
+        decoded = decodeExample(ex);
+      } catch {
+        continue; // doesn't parse at all — incorrect, as advertised
+      }
+      expect(
+        correctResults.has(decoded),
+        `Incorrect example "${ex.heading}" is labelled as failing, but it parses cleanly and ` +
+          `yields ${JSON.stringify(decoded)} — the same result as the Correct example. ` +
+          `Either the label or the example is wrong`
+      ).toBe(false);
+    }
+  });
+});
+
+describe("the escaping docs stay macOS-native", () => {
+  // apple-mail-mcp is `os: ["darwin"]` and drives Mail.app through AppleScript.
+  // A `C:\Users\` example is generic MCP boilerplate that was never localized —
+  // and it is where the four-backslash error lived in both this repo and
+  // apple-notes-mcp. The generic `\` → `\\` rule already covers every platform.
+  const windowsPath = /[A-Za-z]:\\/;
+
+  for (const [label, doc, heading] of [
+    ["README.md", README, README_HEADING],
+    ["CLAUDE.md", CLAUDE_MD, CLAUDE_HEADING],
+    ["CLAUDE.md checklist", CLAUDE_MD, "## Testing Your Understanding"],
+  ] as const) {
+    it(`${label} teaches escaping without a Windows path`, () => {
+      const escaping = section(doc, heading, label);
+      const offender = escaping.split("\n").find((line) => windowsPath.test(line));
+      expect(
+        offender,
+        `${label} still uses a Windows drive path as an escaping example ` +
+          `(${JSON.stringify(offender)}). These servers are macOS-only; use a shell path with ` +
+          `an escaped space or a regex instead.`
+      ).toBeUndefined();
+    });
+  }
+});


### PR DESCRIPTION
## The shipped README told agents to send the wrong number of backslashes

`README.md` instructed:

```
- Windows paths: `C:\Users\` → `C:\\\\Users\\\\` in JSON
```

A JSON string literal containing **four** backslashes decodes to **two** literal
backslashes, not one. So an agent that followed the published instruction sent
`C:\\Users\\` — a doubled backslash in every path, regex, and escaped space it
put in a message body. The correct form is two backslashes per literal
backslash, which is exactly what this repo's `CLAUDE.md` already said. One repo,
two contradictory instructions.

The four-backslash form appeared **twice** in `README.md` — in the worked
```json` example body and in the "common patterns" list (all three bullets) —
plus a self-contradictory explanatory sentence:

> The `\\\\` in JSON becomes `\\` in the actual string, which represents a single `\`.

`\\` in the resulting string is two characters, not one.

**Why this is the embarrassing one:** `README.md` is in `package.json` `files[]`,
so it ships in the npm tarball. `CLAUDE.md` is not. The doc guard added
yesterday (#149) checks `CLAUDE.md` only — it covered the file that does **not**
ship and missed the file that does, while the shipping file carried the bug.

### Corrected

| `README.md` line | was | now |
|---|---|---|
| worked example `body` | `"The file is at C:\\\\Users\\\\Documents\\\\report.pdf"` | `"Run: cp ~/Library/Mobile\\ Documents/report.pdf ~/Desktop/"` |
| explanatory sentence | "`\\\\` in JSON becomes `\\`, which represents a single `\`" | "in a JSON string literal, `\\` — two characters — denotes **one** literal backslash" |
| pattern bullet 1 | `Windows paths: C:\Users\ → C:\\\\Users\\\\` | *removed* → `Shell escaped spaces: Mobile\ Documents → Mobile\\ Documents` |
| pattern bullet 2 | `Shell escaped spaces: … → Mobile\\\\ Documents` | `Regex patterns: \d+ → \\d+` |
| pattern bullet 3 | `Regex patterns: \d+ → \\\\d+` | `A literal double backslash: \\ → \\\\` |

Every corrected example was verified by actually `JSON.parse`-ing it, not by
counting backslashes — counting them is how the original error survived review.

## Windows examples removed

This package is `os: ["darwin"]` and drives Mail.app through AppleScript. A
`C:\Users\` example is generic MCP boilerplate that was never localized to these
servers — and it is precisely where the four-backslash error lived.

Replaced with macOS-native examples of equal teaching value, in both
`README.md` and `CLAUDE.md`:

- a shell path with an escaped space — `~/Library/Mobile\ Documents/…`. This is
  the genuinely tricky case: `\ ` is not a valid JSON escape, so the unescaped
  form is rejected outright rather than merely arriving wrong.
- a regex — `\d+`.

Touched in `CLAUDE.md`: the escaping table's third row, the worked example (now
two: the shell path and the regex), and the "Testing Your Understanding"
checklist. **The generic table rows stay** (`\` → `\\`, `\\` → `\\\\`) — they
are correct and platform-neutral, so nothing is lost for Windows users.

## The guard now covers the file that ships

New `src/readmeEscaping.test.ts`, sibling to the existing
`src/claudeMdEscaping.test.ts` (whose assertions are unchanged and still pass):

- **every "common patterns" bullet is self-consistent** — parses each
  `- label: \`A\` → \`B\` in JSON` bullet and asserts `JSON.parse('"' + B + '"') === A`.
  This is the assertion that would have caught the shipped bug.
- **worked examples decode to their annotation** — the `→ arrives as: \`…\``
  convention already used in `CLAUDE.md` is now applied to the README's example,
  and for a ```json fence the block is parsed **as JSON** and its `body` field
  pulled out, rather than regexing the raw line.
- **"Incorrect" examples genuinely are incorrect** — they must fail to parse, or
  decode to something other than the Correct result.
- **neither doc reintroduces a Windows drive path** in its escaping section or
  the checklist.

Every assertion also requires that it found something to check, so a doc rewrite
that changes the format fails loudly instead of passing vacuously.

It lives under `src/` deliberately: `vitest.config.ts` only includes
`src/**/*.test.ts`, and CI's required `test (22)` / `test (24)` contexts run
`pnpm test` — a test placed in `test/` would not run in CI.

### Proof the guard has teeth against the real bug

Temporarily restoring the four-backslash bullet:

```
AssertionError: README pattern "Shell escaped spaces": the doc says send
`Mobile\\\\ Documents` to get `Mobile\ Documents`, but that actually yields
"Mobile\\ Documents"
```

Temporarily restoring the four-backslash Windows worked example:

```
AssertionError: Correct example "**Correct — email containing a shell path with an
escaped space:**": the payload arrives as "The file is at C:\\\\Users\\\\Documents\\\\report.pdf",
but the doc says it arrives as "The file is at C:\\Users\\Documents\\report.pdf"

AssertionError: README.md still uses a Windows drive path as an escaping example
("  \"body\": \"The file is at C:\\\\\\\\Users\\\\\\\\Documents\\\\\\\\report.pdf\"").
These servers are macOS-only; use a shell path with an escaped space or a regex instead.
```

Both restored afterwards; the suite is green.

## Version bump

Bumped to **2.10.13** with a `## [2.10.13] - 2026-08-13` CHANGELOG heading
(`## [Unreleased]` left present and empty).

`version-guard.yml` does **not** force this — it keys on `build/**`,
`requirements.txt` and non-`.ts` files under `src/` — but `README.md` is in
`package.json` `files[]`, so it ships, and `publish.yml` skips a version already
on npm. Without the bump, a correction to instructions users are actively
following would never reach them.

## Verification

- `pnpm run lint` — 0 errors (10 pre-existing `no-explicit-any` warnings)
- `pnpm run typecheck` — clean
- `pnpm test` — 35 files, 503 tests passed
- `pnpm run format:check` — clean
- `test/output-schema.test.ts` (boots the real bundle over stdio) — 8 passed
- **Committed bundle unchanged.** `build/index.js` and `build/cli.js` are
  byte-identical to `origin/main` across a fresh `pnpm run build`:
  `f64a4b41c831131a5d7fe363e1374ec5af75c04fc51d014707bde58f1753bb40` and
  `cebf87819390757db813219f6551ce12ffa88d6e9c24fbcf9895d348508e9200`.
  `git diff origin/main...HEAD -- build` is empty.

The live-Mail.app half of `test/integration.test.ts` fails locally with
`Not authorized to send Apple events to Mail. (-1743)` — a TCC denial in this
shell, unrelated to this change (no runtime code touched, bundle identical).

## Follow-up

`apple-notes-mcp` still carries the same four-backslash bullet in its README and
a Windows example in its `CLAUDE.md`. Not touched here — separate repo, separate
PR.
