### PR TITLE
test(docs): guard that every documented example, knob and tool is real (2.10.14)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.13",
+      "version": "2.10.14",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.13",
+      "version": "2.10.14",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.13",
+      "version": "2.10.14",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [2.10.14] - 2026-08-13
+
+### Documentation
+
+- **`resolve-message-id` has been advertised since 2.8.0 and was never in the README's Tool Reference** — 50 tools on the wire, 49 documented. Nothing surfaced it: the tool works, `tools/list` returns it, and every check in this repo compared the README only to itself. It now has a full entry (parameters, return shape, the account/INBOX-first scoping), including the point 2.10.1 corrected everywhere else: it is **not** needed to apply a flag color any more. An agent that believes otherwise resolves `imap:` ids purely to color a flag and reintroduces the AppleScript/TCC dependency 2.10.0 removed — the dependency that previously killed four consecutive scheduled jobs.
+- **New guard: `src/docsTruth.test.ts`, which checks the docs against the CODE rather than against themselves.** `readmeEscaping.test.ts` and `claudeMdEscaping.test.ts` prove one section of one doc is internally consistent; they cannot see a doc that is coherent and wrong. This one asserts three things across `README.md`, `CLAUDE.md` and `docs/*.md`: every ` ```json ` fence parses as JSON (a malformed example in setup docs breaks whoever copies it); every `APPLE_*` environment variable the docs name exists somewhere under `src/`, with tests excluded, so a renamed or deleted knob cannot keep being advertised; and the README's `## Tool Reference` documents **exactly** the tool surface the built server advertises over stdio — both directions, so a tool shipped without docs and a renamed tool whose docs stayed behind each fail, with the offending names printed. The tool list is read off the wire, not regexed out of `src/index.ts`, because the wire is the contract users see. Every assertion also fails when it finds nothing to check, so deleting the inputs cannot make the suite pass on an empty set.
+- **Two fence retags, both honest rather than allowlisted.** The `"args": ["${CLAUDE_PROJECT_DIR:-.}/build/index.js"]` example is a one-line fragment, not a JSON document, so it is now ` ```text ` — the tag the escaping section already uses for the identically shaped `"body": "…"` fragment. The IMAP `env` blocks in `README.md` and `docs/IMAP-SETUP.md` were tagged ` ```jsonc ` while containing no comment: plain valid JSON, where the tag bought nothing but exemption from the parse check. They are now ` ```json ` and are checked, and a companion assertion makes that permanent — a ` ```jsonc ` block with no comment in it fails, so the tag cannot become a way to opt out.
+
+No runtime code changed; the committed `build/` bundle is byte-identical.
+
 ## [2.10.13] - 2026-08-13
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Dropped connections reconnect with backoff, and the watchers shut down cleanly o
 
 Enable it in your MCP client config alongside the IMAP settings:
 
-```jsonc
+```json
 {
   "mcpServers": {
     "apple-mail": {
@@ -677,6 +677,20 @@ Return an attachment's bytes as base64 (the read counterpart to inline-base64 se
 | `attachmentName` | string | Yes | Attachment filename (from `list-attachments`) |
 
 **Returns:** The attachment bytes, base64-encoded (also in `structuredContent.contentBase64`).
+
+---
+
+#### `resolve-message-id`
+
+Map `imap:` message IDs to their numeric Mail.app IDs, via each message's RFC 5322 `Message-ID` (the join key both backends share). Needed only for the two tools that are numeric-ID-only — `reply-to-message` and `forward-message`. Numeric IDs pass through unchanged.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `ids` | string[] | Yes | 1–100 message IDs, each numeric or `imap:…` |
+
+**Returns:** For each input ID, its `numericId` (or `null` when it can't be resolved) and the `messageId` used, plus `count` and `resolvedCount`. The lookup scopes to the message's account and checks its INBOX first, to avoid scanning a large All Mail/Archive mailbox.
+
+> **You do not need this for flag colors (v2.10.0+).** Colors used to require the numeric-ID path, and older docs and tool descriptions said so. `flag-message` and `batch-flag-messages` now write the color over IMAP directly, as Mail.app's `$MailFlagBit0/1/2` keywords, so a smart mailbox keyed on flag color matches an IMAP-flagged message. Resolving IDs just to apply a color reintroduces the AppleScript/TCC dependency 2.10.0 removed. Flag, move, mark, and delete all accept `imap:` IDs as-is.
 
 ---
 
@@ -1309,7 +1323,7 @@ This repo ships a `.mcp.json` at its root so that, when you run `claude` from in
 
 The entrypoint is written as:
 
-```json
+```text
 "args": ["${CLAUDE_PROJECT_DIR:-.}/build/index.js"]
 ```
 

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/docs/IMAP-SETUP.md
+++ b/docs/IMAP-SETUP.md
@@ -111,7 +111,7 @@ The server reads `APPLE_MAIL_MCP_*` settings. There are two ways to supply them;
 Works with clients that pass an `env` block through to the server (e.g. **Claude
 Code** via `~/.claude.json`, and most standard `mcpServers` configs).
 
-```jsonc
+```json
 {
   "mcpServers": {
     "apple-mail": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/docsTruth.test.ts
+++ b/src/docsTruth.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Executable documentation — every example, knob and tool name in the docs
+ * describes something that actually exists.
+ *
+ * Sibling of `readmeEscaping.test.ts` / `claudeMdEscaping.test.ts`, which prove
+ * one *section* of one doc is internally consistent. This file proves the whole
+ * doc set agrees with the *code*, which is the failure mode those two cannot
+ * see. Two shipped defects motivate it, and nothing mechanical caught either:
+ *
+ *   • README.md's backslash-escaping instructions were wrong while CLAUDE.md,
+ *     three files away, said the opposite — one repo, two contradictory
+ *     instructions, and the published one was the wrong one. Nothing compared
+ *     a doc to reality.
+ *   • apple-notes-mcp's CLAUDE.md kept asserting "the default account is
+ *     iCloud" after the code stopped assuming that name. A behaviour change
+ *     shipped; the sentence describing it did not move.
+ *
+ * What is enforced:
+ *
+ *   A(a) Every ```json fence in README.md, CLAUDE.md and docs/*.md parses as
+ *        JSON. A malformed JSON example in setup docs actively breaks the user
+ *        who copies it. Deliberate FRAGMENTS are retagged ```text — honestly
+ *        not-JSON — rather than allowlisted, because an allowlist is exactly
+ *        how a guard becomes decorative. ```jsonc is accepted only when the
+ *        block really does carry a comment; otherwise it is plain JSON wearing
+ *        a tag that dodges this check, and it belongs under ```json.
+ *   A(b) Every `APPLE_*` environment variable named in those docs exists
+ *        somewhere under `src/` (excluding tests — a knob referenced only by a
+ *        test is not a knob). Catches a doc still advertising a renamed or
+ *        deleted setting.
+ *   B    README.md's "## Tool Reference" documents EXACTLY the tools the built
+ *        server advertises, in BOTH directions: nothing advertised is
+ *        undocumented (a tool shipped without docs — which is how
+ *        `resolve-message-id`, added in 2.8.0, had no Tool Reference entry
+ *        through 2.10.13), and nothing documented is absent from the server (a
+ *        renamed or removed tool whose docs stayed behind).
+ *
+ * Every assertion also requires that it found something to check, so deleting
+ * the inputs makes the suite FAIL rather than pass on an empty set.
+ *
+ * ── Why this file lives in src/ ────────────────────────────────────────────
+ * `vitest.config.ts` includes `src/**\/*.test.ts` and is what `pnpm test` /
+ * `pnpm run test:coverage` run — the job behind the REQUIRED branch-protection
+ * contexts `test (22)` and `test (24)`. The integration config is invoked in
+ * ci.yml by explicitly named file, so a new file dropped in `test/` would never
+ * run. A guard that is not in the required job is not a guard.
+ *
+ * Guard B boots the committed bundle, and ci.yml runs `test:coverage` BEFORE
+ * its `build` step — which is fine, and deliberately not papered over with a
+ * skip-if-missing branch: `build/index.js` is git-tracked (`.gitignore`
+ * re-includes it), so it is present from checkout, and the later "Verify
+ * committed build/ matches source" step fails the same job if that committed
+ * bundle does not match `src/`. So the bundle this test interrogates is
+ * provably the bundle users receive. If it is ever missing, this fails loudly.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const SERVER = join(ROOT, "build", "index.js");
+
+/**
+ * Tripwires against a "make it pass" regression. Both are floors well below
+ * today's counts (16 JSON fences, 29 env tokens), so ordinary doc edits never
+ * trip them — but retagging every fence, or gutting the docs, does.
+ */
+const MIN_JSON_FENCES = 8;
+const MIN_ENV_TOKENS = 10;
+
+/** README.md, CLAUDE.md and every docs/*.md — discovered, never hardcoded. */
+const DOC_FILES: string[] = (() => {
+  const docsDir = join(ROOT, "docs");
+  const extra = existsSync(docsDir)
+    ? readdirSync(docsDir)
+        .filter((f) => f.endsWith(".md"))
+        .sort()
+        .map((f) => join("docs", f))
+    : [];
+  return ["README.md", "CLAUDE.md", ...extra];
+})();
+
+const read = (rel: string): string => readFileSync(join(ROOT, rel), "utf8");
+
+interface Fence {
+  file: string;
+  /** 1-based line of the opening fence. */
+  line: number;
+  /** Lowercased info string (`json`, `jsonc`, `bash`, …); "" for a bare fence. */
+  lang: string;
+  body: string;
+}
+
+/**
+ * Fenced code blocks, indent- and length-aware: a fence may be indented inside
+ * a list item, and it closes on a backtick run at least as long as the opener.
+ */
+function fences(file: string, text: string): Fence[] {
+  const lines = text.split("\n");
+  const out: Fence[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const open = /^(\s*)(`{3,})[ \t]*([^`\s]*)/.exec(lines[i]);
+    if (!open) {
+      i++;
+      continue;
+    }
+    const [, indent, ticks, info] = open;
+    const close = new RegExp(`^\\s{0,${indent.length + 3}}\`{${ticks.length},}\\s*$`);
+    let j = i + 1;
+    while (j < lines.length && !close.test(lines[j])) j++;
+    out.push({
+      file,
+      line: i + 1,
+      lang: info.toLowerCase(),
+      body: lines.slice(i + 1, j).join("\n"),
+    });
+    i = j + 1;
+  }
+  return out;
+}
+
+/**
+ * The same text with every fenced block's contents blanked, line count
+ * preserved. Headings and env-var tokens are read from this so a markdown
+ * EXAMPLE inside a code sample is never mistaken for the document's own.
+ */
+function withoutFences(file: string, text: string): string {
+  const lines = text.split("\n");
+  for (const f of fences(file, text)) {
+    const bodyLines = f.body === "" ? 0 : f.body.split("\n").length;
+    for (let k = f.line - 1; k < f.line + bodyLines + 1 && k < lines.length; k++) lines[k] = "";
+  }
+  return lines.join("\n");
+}
+
+const ALL_FENCES: Fence[] = DOC_FILES.flatMap((f) => fences(f, read(f)));
+
+const preview = (body: string): string =>
+  body
+    .split("\n")
+    .slice(0, 12)
+    .map((l) => `    ${l}`)
+    .join("\n");
+
+describe("Guard A(a): every documented JSON example really is JSON", () => {
+  const jsonFences = ALL_FENCES.filter((f) => f.lang === "json");
+
+  it("parses every ```json block in README.md, CLAUDE.md and docs/*.md", () => {
+    const failures: string[] = [];
+    for (const f of jsonFences) {
+      try {
+        JSON.parse(f.body);
+      } catch (err) {
+        failures.push(`${f.file}:${f.line} — ${(err as Error).message}\n${preview(f.body)}`);
+      }
+    }
+    expect(
+      failures,
+      `these \`\`\`json blocks do not parse. A user who copies one gets a broken config or a ` +
+        `rejected tool call. If the block is a deliberate FRAGMENT, retag it \`\`\`text so it is ` +
+        `honestly not-JSON; if it is meant to be valid JSON, it is a real bug — fix it:\n` +
+        failures.join("\n")
+    ).toEqual([]);
+  });
+
+  it("checked a real population of JSON blocks", () => {
+    // Retagging every fence to dodge the parser would leave the assertion above
+    // trivially green. This is the tripwire for that, and for a docs wipe.
+    expect(
+      jsonFences.length,
+      `only ${jsonFences.length} \`\`\`json block(s) found across ${DOC_FILES.join(", ")} — ` +
+        `expected at least ${MIN_JSON_FENCES}. Either the docs lost their examples or the ` +
+        `fences were retagged en masse to make the parse check vacuous.`
+    ).toBeGreaterThanOrEqual(MIN_JSON_FENCES);
+  });
+
+  it("no ```jsonc block is plain JSON wearing a comment-tolerant tag", () => {
+    // ```jsonc is the one honest escape hatch from the parse check, so it must
+    // be earned: a block with no comment in it is ordinary JSON, and tagging it
+    // jsonc buys nothing but exemption from being checked.
+    const hasComment = (body: string): boolean => /(^|[^:])\/\/|\/\*/.test(body);
+    const offenders = ALL_FENCES.filter((f) => f.lang === "jsonc" && !hasComment(f.body)).map(
+      (f) => `${f.file}:${f.line}`
+    );
+    expect(
+      offenders,
+      `these \`\`\`jsonc blocks contain no comment, so they are plain JSON and the tag only ` +
+        `exempts them from the parse check above. Retag them \`\`\`json: ${offenders.join(", ")}`
+    ).toEqual([]);
+  });
+});
+
+describe("Guard A(b): every environment variable the docs name exists in src/", () => {
+  /**
+   * `APPLE_…` in SCREAMING_SNAKE_CASE. Deliberately wider than
+   * `APPLE_MAIL_MCP_*`: this repo also ships `APPLE_MAIL_MAX_SEARCH_MAILBOX`,
+   * which the narrower family pattern would silently skip. A trailing
+   * underscore is captured on purpose — it is what marks a family name.
+   */
+  const ENV_TOKEN = /\bAPPLE_[A-Z0-9_]+/g;
+
+  function walk(dir: string): string[] {
+    return readdirSync(dir).flatMap((entry) => {
+      const p = join(dir, entry);
+      return statSync(p).isDirectory() ? walk(p) : [p];
+    });
+  }
+
+  // Tests excluded: a knob that exists only in a test does not exist for users,
+  // and a doc naming it is still wrong.
+  const srcTokens = new Set<string>();
+  for (const file of walk(join(ROOT, "src")).filter((p) => !/\.test\.ts$/.test(p))) {
+    for (const m of readFileSync(file, "utf8").matchAll(ENV_TOKEN)) srcTokens.add(m[0]);
+  }
+
+  /**
+   * Structural, not an allowlist. A token is real if `src/` names it verbatim,
+   * or — for a token written with a trailing underscore, i.e. a FAMILY named in
+   * prose ("the …_IMAP_ settings") — if some real variable starts with it. A
+   * renamed, typo'd or deleted knob is a strict prefix of nothing and still
+   * fails, so nothing here is softened by knowing which strings happen to
+   * appear today.
+   */
+  function existsInSrc(token: string): boolean {
+    if (srcTokens.has(token)) return true;
+    if (!token.endsWith("_")) return false;
+    for (const real of srcTokens) {
+      if (real.length > token.length && real.startsWith(token)) return true;
+    }
+    return false;
+  }
+
+  // Raw text on purpose — the copy-pasteable `env` blocks live inside fences,
+  // and a phantom variable there is the most harmful kind.
+  const documented = new Map<string, Set<string>>();
+  for (const file of DOC_FILES) {
+    for (const m of read(file).matchAll(ENV_TOKEN)) {
+      if (!documented.has(m[0])) documented.set(m[0], new Set());
+      (documented.get(m[0]) as Set<string>).add(file);
+    }
+  }
+
+  it("names no environment variable that src/ does not define", () => {
+    const phantom = [...documented.entries()]
+      .filter(([token]) => !existsInSrc(token))
+      .map(([token, where]) => `${token} (documented in ${[...where].sort().join(", ")})`)
+      .sort();
+    expect(
+      phantom,
+      `the docs advertise environment variables that appear nowhere under src/. Either the ` +
+        `knob was renamed or removed and the doc was not updated, or the doc has a typo — ` +
+        `users will set these and nothing will happen:\n  ${phantom.join("\n  ")}`
+    ).toEqual([]);
+  });
+
+  it("checked a real population of environment variables", () => {
+    expect(
+      documented.size,
+      `only ${documented.size} APPLE_* token(s) found in the docs — expected at least ` +
+        `${MIN_ENV_TOKENS}. The configuration documentation was gutted, or the extractor rotted.`
+    ).toBeGreaterThanOrEqual(MIN_ENV_TOKENS);
+  });
+});
+
+describe("Guard B: README Tool Reference == the tool surface the server advertises", () => {
+  const TOOL_REFERENCE = "## Tool Reference";
+
+  /** Documented tool names: backticked kebab tokens in the section's `####` headings. */
+  const documented: string[] = (() => {
+    const readme = withoutFences("README.md", read("README.md")).split("\n");
+    const start = readme.findIndex((l) => l.trim() === TOOL_REFERENCE);
+    if (start === -1) return [];
+    let end = readme.length;
+    for (let i = start + 1; i < readme.length; i++) {
+      if (/^## /.test(readme[i])) {
+        end = i;
+        break;
+      }
+    }
+    const names = new Set<string>();
+    for (let i = start + 1; i < end; i++) {
+      const heading = /^#### (.+)$/.exec(readme[i]);
+      if (!heading) continue;
+      // One heading may cover a pair, e.g. `mark-as-read` / `mark-as-unread`.
+      for (const m of heading[1].matchAll(/`([a-z][a-z0-9-]*)`/g)) names.add(m[1]);
+    }
+    return [...names].sort();
+  })();
+
+  let client: Client | undefined;
+  let advertised: string[] = [];
+
+  beforeAll(async () => {
+    if (!existsSync(SERVER)) {
+      throw new Error(
+        `${SERVER} is missing. The bundle is git-tracked (.gitignore re-includes build/index.js), ` +
+          `so it is present from checkout in CI and this should be unreachable. Run ` +
+          `\`pnpm run build\` — do NOT make this test skip itself, which would pass vacuously forever.`
+      );
+    }
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [SERVER],
+      env: { ...process.env } as Record<string, string>,
+    });
+    client = new Client({ name: "docs-truth-test", version: "0.0.0" });
+    await client.connect(transport);
+    advertised = (await client.listTools()).tools.map((t) => t.name).sort();
+  }, 60_000);
+
+  afterAll(async () => {
+    await client?.close();
+  });
+
+  it("the built server advertises tools, and the README has a Tool Reference", () => {
+    // Both halves of the comparison must be non-empty, or the two set
+    // assertions below would agree perfectly about nothing.
+    expect(advertised.length, "the built server advertised no tools over stdio").toBeGreaterThan(0);
+    expect(
+      documented.length,
+      `README.md's "${TOOL_REFERENCE}" section documented no tools. Either the section was ` +
+        `removed/renamed, or its "#### \`tool-name\`" heading convention changed and this guard ` +
+        `is now reading nothing.`
+    ).toBeGreaterThan(0);
+  });
+
+  it("documents every tool the server advertises", () => {
+    const undocumented = advertised.filter((t) => !documented.includes(t));
+    expect(
+      undocumented,
+      `these tools are advertised over the wire but have no "${TOOL_REFERENCE}" entry, so users ` +
+        `and agents cannot discover their parameters: ${undocumented.join(", ")}`
+    ).toEqual([]);
+  });
+
+  it("documents no tool the server does not advertise", () => {
+    const phantom = documented.filter((t) => !advertised.includes(t));
+    expect(
+      phantom,
+      `these tools have a "${TOOL_REFERENCE}" entry but the server does not advertise them — a ` +
+        `renamed or removed tool whose docs stayed behind. Calling one fails: ${phantom.join(", ")}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two documentation defects shipped this week and nothing mechanical caught either: the published README's backslash-escaping rules contradicted `CLAUDE.md` inside one repo, and apple-notes-mcp's `CLAUDE.md` kept asserting a default account name the code had stopped assuming. Same class — a doc describing something that is not so — and unreachable by a guard that only checks a doc against itself.

`src/docsTruth.test.ts` checks the docs against the **code**.

## What it enforces

**A(a) — every ` ```json ` fence in `README.md`, `CLAUDE.md` and `docs/*.md` parses as JSON.** A malformed example in setup docs breaks whoever copies it. Fragments are retagged honestly, not allowlisted; a companion assertion makes ` ```jsonc ` an earned exemption rather than a free one.

**A(b) — every `APPLE_*` environment variable the docs name exists somewhere under `src/`** (tests excluded — a knob referenced only by a test is not a knob). A trailing-underscore token is treated as a *family* name and accepted when it is a strict prefix of a real variable; that is a structural rule, not a list of the strings that happen to appear today, so a renamed or typo'd knob is a prefix of nothing and still fails.

**B — the README's `## Tool Reference` documents exactly the tool surface the server advertises**, checked in **both** directions and read off the **wire** (`initialize` → `tools/list` against the built bundle over stdio), not regexed out of `src/index.ts`. The wire is the contract users see.

## Real drift found

`resolve-message-id` has been advertised since **2.8.0** and had **no Tool Reference entry at all** — 50 tools on the wire, 49 in the README. Fixed here, including the 2.10.0 correction that it is no longer needed to apply a flag color; an agent that believes otherwise resolves `imap:` ids purely to color a flag and reintroduces the AppleScript/TCC dependency 2.10.0 removed.

Two fence retags, both honest rather than allowlisted:

- `"args": ["${CLAUDE_PROJECT_DIR:-.}/build/index.js"]` is a one-line **fragment**, not a JSON document → ` ```text `, the same tag the escaping section already uses for the identically shaped `"body": "…"` fragment.
- The IMAP `env` blocks in `README.md` and `docs/IMAP-SETUP.md` were tagged ` ```jsonc ` while containing **no comment** — plain valid JSON, where the tag bought nothing but exemption from the parse check. Now ` ```json `, and now checked.

## Placement

Both guards are in `src/`, which `vitest.config.ts` includes and `pnpm run test:coverage` runs — the job behind the **required** contexts `test (22)` / `test (24)`. `test/` would not have worked: ci.yml invokes the integration config by explicitly named file, so a new file dropped there never runs.

Guard B boots `build/index.js`, and ci.yml runs `test:coverage` **before** its `build` step. That is fine and deliberately not papered over with a skip-if-missing branch (which would pass vacuously forever): the bundle is git-tracked, so it exists from checkout, and the later *"Verify committed build/ matches source"* step fails the same job if it does not match `src/`. If it is ever genuinely missing, the test throws with that explanation.

## Teeth

Every assertion was proven by breaking what it protects:

| Perturbation | Result |
|---|---|
| trailing comma in a ` ```json ` fence | ✗ `README.md:709 — Expected double-quoted property name in JSON` |
| document `APPLE_MAIL_MCP_IMAP_TIMEOUT_MS` | ✗ `the docs advertise environment variables that appear nowhere under src/` |
| delete `get-unread-count`'s entry | ✗ `advertised over the wire but have no "## Tool Reference" entry: get-unread-count` |
| add a phantom `archive-message` entry | ✗ `have a "## Tool Reference" entry but the server does not advertise them: archive-message` |
| retag a ` ```jsonc ` fence with no comment | ✗ `contain no comment … Retag them ` + "```json" |
| **vacuity:** retag *all* json fences | ✗ `only 0 ```json block(s) found … expected at least 8` |
| **vacuity:** delete the *whole* Tool Reference | ✗ section-empty assertion **and** all 50 tools reported undocumented |
| **vacuity:** strip every `APPLE_*` token | ✗ `only 0 APPLE_* token(s) found … expected at least 10` |

## Bump

`README.md` and `docs/` are both in `package.json` `files[]`, so the Tool Reference fix ships in the tarball and reaches users only on the next publish → **2.10.14** + a real `## [2.10.14] - 2026-08-13` heading, `## [Unreleased]` kept empty.

Worth flagging: `version-guard.yml` would **not** have demanded this. Its shipped-bytes detector is `^(build/.*|requirements\.txt|src/.*)$`, which omits `README.md` and `docs/` even though `files[]` ships both verbatim. The bump is owed on the substance, not because CI asked — but that gap is real and identical in all four repos.

No runtime code changed. `build/index.js` and `build/cli.js` are byte-identical across a rebuild:

```text
f64a4b41c831131a5d7fe363e1374ec5af75c04fc51d014707bde58f1753bb40  build/index.js
cebf87819390757db813219f6551ce12ffa88d6e9c24fbcf9895d348508e9200  build/cli.js
```

Gates: lint ✅ (0 errors; 10 pre-existing warnings, none in the new file) · typecheck ✅ · `pnpm test` ✅ 511/511 across 36 files · `format:check` ✅ · `sync-skills --check` ✅ · `test/output-schema.test.ts` (the file ci.yml invokes) ✅ 8/8.