### PR TITLE
fix: scope by-id message mutations to the mailbox the id came from (#152)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.14",
+      "version": "2.10.15",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.14",
+      "version": "2.10.15",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.14",
+      "version": "2.10.15",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+## [2.10.15] - 2026-08-13
+
+### Fixed
+
+- **Every by-id message mutation could land on a different message than the one you named, and report success for it** (#152). A Mail.app numeric message id is unique only *within a mailbox*, and a label store (Gmail, iCloud) exposes one message in several mailboxes under the **same** id — verified on a real account, id `75815` is reported simultaneously by `All Mail`, `Sent Mail` and `INBOX`. `move-message`, `delete-message`, `batch-move-messages`, `batch-delete-messages` and the batch read/flag ops all walked every account's every mailbox and applied the operation to the **first** match. `mailboxes of account` yields `INBOX` late, so an id listed from INBOX was reliably operated on in `All Mail`/`Important` instead: the call reported success, the INBOX message stayed where it was, and a different copy was moved or deleted. The reported `success` count was the number of ids passed, not the number of messages actually affected, so it could not be used to verify the outcome either.
+- **Mutations are now scoped to the mailbox the id was listed from.** The fix reuses `idLocationIndex` — the id→(account, mailbox) map that every `list-messages`/`search-messages` already populates, and that the read paths already consult for exactly this reason — so the normal list-then-mutate flow now opens the one right mailbox instead of guessing. This also removes the full account→mailbox tree walk from the batch path, so batches touch far fewer mailboxes than before.
+- **An id with no recorded source mailbox is refused when it is ambiguous, rather than resolved to an arbitrary copy.** Ids supplied out-of-band (or evicted from the index) are looked up across all mailboxes; if exactly one holds the id the operation proceeds as before, and if several do the call fails naming the candidate mailboxes and asking you to list or search that mailbox first. Silently mutating whichever copy sorted first is what made the original bug invisible.
+- Note for callers that already use `imap:` ids: those were never affected. They encode account + mailbox path + UID, so they were always unambiguous — this bug was specific to the bare-numeric AppleScript ids returned when no IMAP account is configured.
+
 ## [2.10.14] - 2026-08-13
 
 ### Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,25 @@ body: "Run: cp ~/Library/Mobile\ Documents/report.pdf ~/Desktop/"
 
 All message operations require an `id` parameter. **Always get IDs first** using `list-messages` or `search-messages`:
 
+**A bare numeric ID is only meaningful together with the mailbox it came from.** Mail.app numbers
+messages per mailbox, and a label store (Gmail, iCloud) reports the *same* message under the *same*
+id in several mailboxes at once — `INBOX`, `Important` and `All Mail` will all answer to id `75815`.
+Moving or deleting the `All Mail` copy is a different operation from moving or deleting the `INBOX`
+copy, so the server binds each id to the mailbox you listed it from and operates only there.
+
+Practical consequences:
+
+- **List or search the mailbox you intend to act on, immediately before acting on it.** Don't carry
+  numeric ids across from an unrelated listing, and don't invent them.
+- An id the server has never seen listed is resolved only if exactly one mailbox holds it. If
+  several do, the call **fails** and names them — re-list the mailbox you meant rather than retrying
+  the same id or trying a different tool.
+- `imap:…` ids (returned when an IMAP account is configured) already encode account + mailbox +
+  UID, so they are unambiguous anywhere and are never subject to this.
+- A batch call's success count reports messages the server actually operated on. Treat a `notfound`
+  or an ambiguity error for some ids as a partial result and re-list, rather than assuming the whole
+  batch applied.
+
 ```text
 # List messages returns IDs
 list-messages mailbox="INBOX"

--- a/README.md
+++ b/README.md
@@ -829,6 +829,15 @@ Save a message attachment to disk.
 
 All batch operations accept an array of message IDs (max 100 per batch) and return per-item success/failure results.
 
+**Numeric IDs are scoped to the mailbox you listed them from.** Mail.app numbers messages per
+mailbox, so on a label store (Gmail, iCloud) one message answers to the same id in `INBOX`,
+`Important` and `All Mail` at once — and deleting the `All Mail` copy is not the same operation as
+deleting the `INBOX` copy. Each id is therefore bound to the mailbox it was listed/searched from and
+the operation is applied only there, so **list or search the mailbox immediately before acting on
+it**. An id the server hasn't seen listed is accepted only when exactly one mailbox holds it;
+if several do, that id fails with the candidate mailboxes named instead of being applied to an
+arbitrary copy. `imap:…` ids carry their own account + mailbox + UID and are never ambiguous.
+
 #### `batch-delete-messages`
 
 | Parameter | Type | Required | Description |
@@ -1437,6 +1446,15 @@ In a JSON string literal, `\\` — two characters — denotes **one** literal ba
 - Message may have been deleted or moved
 - Message IDs change if the message is moved between mailboxes
 - Use `search-messages` to find the current message ID
+
+### "... is present in more than one mailbox"
+- A bare numeric ID identifies a message only *within a mailbox*, and a label store (Gmail, iCloud)
+  reports the same message under the same ID in `INBOX`, `Important` and `All Mail` at once. The
+  server refuses rather than guessing which copy you meant.
+- Fix it by running `list-messages`/`search-messages` on the mailbox you actually want to act on,
+  then using the IDs from that result — the operation is then scoped to that mailbox.
+- It only affects IDs the server hasn't seen listed (carried over from an earlier session, or typed
+  by hand). `imap:…` IDs encode their own mailbox and never hit this.
 
 ### `search-messages` says "Partial results" or skips a mailbox
 - This is expected for very large IMAP/Gmail mailboxes (e.g. Gmail's `All Mail`, `Important`): Apple Mail can't scan them via AppleScript before timing out, so they're skipped and named in the result rather than silently returning empty.

--- a/build/index.js
+++ b/build/index.js
@@ -78237,6 +78237,8 @@ var CONTENT_MARKER = "CONTENT";
 var MSGID_MARKER = "MSGID";
 var HTML_MARKER = "HTML";
 var BATCH_FATAL = "FATAL";
+var AMBIGUOUS_ID_PREFIX = "Message id ";
+var AMBIGUOUS_ID_BATCH = "This message id is present in more than one mailbox ";
 function normalizeRfcMessageId(mid) {
   return (mid || "").trim().replace(/^<+/, "").replace(/>+$/, "").trim();
 }
@@ -78574,6 +78576,32 @@ var AppleMailManager = class {
       const oldest = this.idLocationIndex.keys().next().value;
       if (oldest !== void 0) this.idLocationIndex.delete(oldest);
     }
+  }
+  /** Where a message id was last listed/searched from, if we've seen it. */
+  locationFor(id) {
+    return this.idLocationIndex.get(String(id));
+  }
+  /**
+   * AppleScript fragment resolving `account` + `mailbox` into `_tmb`, leaving
+   * `_tmb` as `missing value` when it can't be pinned down. Exact-name match
+   * only, and a name matching more than one mailbox resolves to nothing rather
+   * than guessing — the same rule the move destination already applies.
+   */
+  resolveMailboxFragment(account, mailbox) {
+    const resolved = this.resolveMailbox(mailbox, account);
+    return `
+        set _tmb to missing value
+        set _acctM to {}
+        repeat with _a in accounts
+          if (name of _a) is "${escapeForAppleScript(account)}" then set end of _acctM to _a
+        end repeat
+        if (count of _acctM) is 1 then
+          set _mbM to {}
+          repeat with _m in (mailboxes of (item 1 of _acctM))
+            if (name of _m) is "${escapeForAppleScript(resolved)}" then set end of _mbM to _m
+          end repeat
+          if (count of _mbM) is 1 then set _tmb to item 1 of _mbM
+        end if`;
   }
   /**
    * Returns cached accounts or fetches fresh data if cache is expired/empty.
@@ -79781,24 +79809,61 @@ var AppleMailManager = class {
     return true;
   }
   /**
-   * Helper to find and operate on a message by ID.
+   * Helper to find and operate on a message by ID, scoped to the mailbox the id
+   * was listed from.
+   *
+   * Mail.app numeric ids are per-mailbox, and on a label store (Gmail, iCloud)
+   * ONE message is present in several mailboxes under the SAME id — INBOX,
+   * "Important" and "All Mail" all report id 75816 for the same mail. This used
+   * to walk every account's every mailbox and mutate the FIRST hit; because
+   * `mailboxes of account` yields INBOX late, an id listed from INBOX was
+   * reliably mutated in "Important" instead, so the op reported success while
+   * the INBOX copy stayed put and a different copy was moved/deleted (#152).
+   *
+   * Which mailbox a mutation lands in is semantic — deleting the INBOX copy and
+   * deleting the "All Mail" copy are different operations — so scope to the
+   * mailbox the id actually came from (`idLocationIndex`, populated by every
+   * list/search) and never guess.
    */
   findMessageScript(id, operation) {
+    const loc = this.locationFor(id);
+    if (loc) {
+      return buildAppLevelScript(`
+      try
+        ${this.resolveMailboxFragment(loc.account, loc.mailbox)}
+        if _tmb is missing value then return "error:Message not found"
+        set matchingMsgs to (messages of _tmb whose id is ${Number(id)})
+        if (count of matchingMsgs) > 0 then
+          set msg to item 1 of matchingMsgs
+          ${operation}
+          return "ok"
+        end if
+        return "error:Message not found"
+      on error errMsg
+        return "error:" & errMsg
+      end try
+    `);
+    }
     return buildAppLevelScript(`
       try
+        set _hits to {}
+        set _names to ""
         repeat with acct in accounts
           repeat with mb in mailboxes of acct
             try
               set matchingMsgs to (messages of mb whose id is ${Number(id)})
               if (count of matchingMsgs) > 0 then
-                set msg to item 1 of matchingMsgs
-                ${operation}
-                return "ok"
+                set end of _hits to (item 1 of matchingMsgs)
+                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
               end if
             end try
           end repeat
         end repeat
-        return "error:Message not found"
+        if (count of _hits) is 0 then return "error:Message not found"
+        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the operation targets the right copy"
+        set msg to item 1 of _hits
+        ${operation}
+        return "ok"
       on error errMsg
         return "error:" & errMsg
       end try
@@ -79983,6 +80048,31 @@ var AppleMailManager = class {
     const targetMailbox = this.resolveMailbox(mailbox, targetAccount);
     const safeMailbox = escapeForAppleScript(targetMailbox);
     const safeAccount = escapeForAppleScript(targetAccount);
+    const loc = this.locationFor(id);
+    const findAndMove = loc ? `
+        ${this.resolveMailboxFragment(loc.account, loc.mailbox)}
+        if _tmb is missing value then return "error:Message not found"
+        set matchingMsgs to (messages of _tmb whose id is ${Number(id)})
+        if (count of matchingMsgs) is 0 then return "error:Message not found"
+        move (item 1 of matchingMsgs) to destMailbox
+        return "ok"` : `
+        set _hits to {}
+        set _names to ""
+        repeat with acct in accounts
+          repeat with mb in (mailboxes of acct)
+            try
+              set matchingMsgs to (messages of mb whose id is ${Number(id)})
+              if (count of matchingMsgs) > 0 then
+                set end of _hits to (item 1 of matchingMsgs)
+                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
+              end if
+            end try
+          end repeat
+        end repeat
+        if (count of _hits) is 0 then return "error:Message not found"
+        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the move targets the right copy"
+        move (item 1 of _hits) to destMailbox
+        return "ok"`;
     const script = buildAppLevelScript(`
       try
         -- \`mailboxes of account\` is already flat: it includes nested mailboxes
@@ -79998,21 +80088,7 @@ var AppleMailManager = class {
         if (count of destMatches) is 0 then return "error:Destination mailbox \\"" & destName & "\\" not found in account \\"${safeAccount}\\""
         if (count of destMatches) > 1 then return "error:Destination mailbox \\"" & destName & "\\" is ambiguous (" & (count of destMatches) & " matches) in account \\"${safeAccount}\\"; disambiguate or move by full path"
         set destMailbox to item 1 of destMatches
-
-        -- Find the message by id. The flat mailbox list already covers nested
-        -- mailboxes, so this reaches messages in subfolders without recursing.
-        repeat with acct in accounts
-          repeat with mb in (mailboxes of acct)
-            try
-              set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                move (item 1 of matchingMsgs) to destMailbox
-                return "ok"
-              end if
-            end try
-          end repeat
-        end repeat
-        return "error:Message not found"
+        ${findAndMove}
       on error errMsg
         return "error:" & errMsg
       end try
@@ -80046,15 +80122,26 @@ var AppleMailManager = class {
    * Previously each batch method looped and called the per-id method, so a
    * 100-id batch spawned 100 osascript processes — each one re-resolving
    * accounts and walking the whole account→mailbox tree — all serialized
-   * through the gate (issue #31). This walks the tree exactly once: for each
-   * mailbox it probes the still-pending IDs with `whose id is` (indexed, so
-   * effectively free) and applies `operation` to any match, tracking found IDs
-   * so it can stop early once all are accounted for. Per-id outcomes come back
-   * as control-char-delimited `id<FS>status` records (status: `ok`,
-   * `notfound`, or `error:<msg>`), and results are returned in input order.
+   * through the gate (issue #31). Still one osascript invocation, but the ids
+   * are now grouped by the mailbox they were listed from and each group opens
+   * exactly that one mailbox. Per-id outcomes come back as control-char
+   * delimited `position<FS>status` records (status: `ok`, `notfound`, or
+   * `error:<msg>`), and results are returned in input order.
    *
-   * `setup` runs once before the walk (used by move to resolve the destination);
-   * it may bail the whole batch by returning a `BATCH_FATAL`-prefixed string.
+   * Scoping is a CORRECTNESS requirement, not an optimization (#152). A Mail.app
+   * numeric id is unique only within a mailbox, and a label store (Gmail,
+   * iCloud) exposes one message in several mailboxes under the same id — INBOX,
+   * "Important" and "All Mail" all report id 75816 for the same mail. The old
+   * tree walk applied `operation` to the FIRST mailbox that matched, and
+   * `mailboxes of account` yields INBOX late, so a batch of ids listed from
+   * INBOX was reliably applied to the "Important" copies instead: every id
+   * reported `ok` while the INBOX messages stayed put and other copies were
+   * moved/deleted. Grouping by recorded source mailbox makes the op land on the
+   * copy the caller actually listed; ids with no recorded mailbox are refused
+   * when ambiguous rather than applied to an arbitrary copy.
+   *
+   * `setup` runs once up front (used by move to resolve the destination); it may
+   * bail the whole batch by returning a `BATCH_FATAL`-prefixed string.
    */
   runBatchOperation(ids, operation, setup = "") {
     const valid = [];
@@ -80065,39 +80152,96 @@ var AppleMailManager = class {
     if (valid.length === 0) {
       return ids.map((id) => ({ id, success: false, error: "Invalid message ID" }));
     }
+    const groups = /* @__PURE__ */ new Map();
+    const unlocated = [];
+    valid.forEach((v, i) => {
+      const pos = i + 1;
+      const loc = this.locationFor(v.id);
+      if (!loc) {
+        unlocated.push({ num: v.num, pos });
+        return;
+      }
+      const key = `${loc.account}\0${loc.mailbox}`;
+      const g = groups.get(key) ?? { account: loc.account, mailbox: loc.mailbox, items: [] };
+      g.items.push({ num: v.num, pos });
+      groups.set(key, g);
+    });
+    const asList = (nums) => `{${nums.join(", ")}}`;
+    const scopedBlocks = [...groups.values()].map(
+      (g) => `
+        ${this.resolveMailboxFragment(g.account, g.mailbox)}
+        set _gids to ${asList(g.items.map((it) => it.num))}
+        set _gpos to ${asList(g.items.map((it) => it.pos))}
+        if _tmb is missing value then
+          repeat with _k from 1 to (count of _gpos)
+            set _out to _out & ((item _k of _gpos) as string) & "${FIELD_SEP}error:source mailbox \\"${escapeForAppleScript(g.mailbox)}\\" not found in account \\"${escapeForAppleScript(g.account)}\\"${RECORD_SEP}"
+          end repeat
+        else
+          repeat with _k from 1 to (count of _gids)
+            set _idx to item _k of _gpos
+            try
+              set _m to (messages of _tmb whose id is (item _k of _gids))
+              if (count of _m) > 0 then
+                set _msg to item 1 of _m
+                ${operation}
+                set _out to _out & (_idx as string) & "${FIELD_SEP}ok${RECORD_SEP}"
+              else
+                set _out to _out & (_idx as string) & "${FIELD_SEP}notfound${RECORD_SEP}"
+              end if
+            on error _e
+              set _out to _out & (_idx as string) & "${FIELD_SEP}error:" & _e & "${RECORD_SEP}"
+            end try
+          end repeat
+        end if`
+    ).join("\n");
+    const unlocatedBlock = unlocated.length ? `
+        set _uids to ${asList(unlocated.map((it) => it.num))}
+        set _upos to ${asList(unlocated.map((it) => it.pos))}
+        set _ucount to count of _uids
+        set _uhit to {}
+        set _umsg to {}
+        set _unames to {}
+        repeat with _k from 1 to _ucount
+          set end of _uhit to 0
+          set end of _umsg to missing value
+          set end of _unames to ""
+        end repeat
+        repeat with acct in accounts
+          repeat with mb in (mailboxes of acct)
+            repeat with _k from 1 to _ucount
+              try
+                set _m to (messages of mb whose id is (item _k of _uids))
+                if (count of _m) > 0 then
+                  set item _k of _uhit to ((item _k of _uhit) + 1)
+                  if (item _k of _uhit) is 1 then set item _k of _umsg to (item 1 of _m)
+                  set item _k of _unames to ((item _k of _unames) & (name of acct) & "/" & (name of mb) & ", ")
+                end if
+              end try
+            end repeat
+          end repeat
+        end repeat
+        repeat with _k from 1 to _ucount
+          set _idx to item _k of _upos
+          if (item _k of _uhit) is 0 then
+            set _out to _out & (_idx as string) & "${FIELD_SEP}notfound${RECORD_SEP}"
+          else if (item _k of _uhit) > 1 then
+            set _out to _out & (_idx as string) & "${FIELD_SEP}error:${AMBIGUOUS_ID_BATCH}(" & (item _k of _unames) & "); list or search that mailbox first so the operation targets the right copy${RECORD_SEP}"
+          else
+            try
+              set _msg to item _k of _umsg
+              ${operation}
+              set _out to _out & (_idx as string) & "${FIELD_SEP}ok${RECORD_SEP}"
+            on error _e
+              set _out to _out & (_idx as string) & "${FIELD_SEP}error:" & _e & "${RECORD_SEP}"
+            end try
+          end if
+        end repeat` : "";
     const script = buildAppLevelScript(`
       try
         ${setup}
         set _out to ""
-        set _done to {}
-        set _ids to {${valid.map((v) => v.num).join(", ")}}
-        set _total to count of _ids
-        repeat with acct in accounts
-          if (count of _done) is _total then exit repeat
-          repeat with mb in (mailboxes of acct)
-            if (count of _done) is _total then exit repeat
-            repeat with _idx from 1 to _total
-              if _idx is not in _done then
-                set _theId to item _idx of _ids
-                try
-                  set _m to (messages of mb whose id is _theId)
-                  if (count of _m) > 0 then
-                    set _msg to item 1 of _m
-                    ${operation}
-                    set end of _done to _idx
-                    set _out to _out & (_idx as string) & "${FIELD_SEP}ok${RECORD_SEP}"
-                  end if
-                on error _e
-                  set end of _done to _idx
-                  set _out to _out & (_idx as string) & "${FIELD_SEP}error:" & _e & "${RECORD_SEP}"
-                end try
-              end if
-            end repeat
-          end repeat
-        end repeat
-        repeat with _idx from 1 to _total
-          if _idx is not in _done then set _out to _out & (_idx as string) & "${FIELD_SEP}notfound${RECORD_SEP}"
-        end repeat
+        ${scopedBlocks}
+        ${unlocatedBlock}
         return _out
       on error errMsg
         return "${BATCH_FATAL}" & errMsg

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleMailManager.batchScope.test.ts
+++ b/src/services/appleMailManager.batchScope.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Regression guard for #152 — by-id mutations must target the mailbox the id
+ * was listed from.
+ *
+ * A Mail.app numeric message id is unique only *within a mailbox*, and a label
+ * store (Gmail, iCloud) exposes ONE message in several mailboxes under the SAME
+ * id: on a real account, id 75816 is reported by "Important", "All Mail" AND
+ * "INBOX" for the same mail. The old implementation walked every account's every
+ * mailbox and applied the operation to the FIRST match; `mailboxes of account`
+ * yields INBOX late, so a batch of ids listed from INBOX was reliably applied to
+ * the "Important" copies instead — every id reported `ok` while the INBOX
+ * messages stayed put and other copies were moved/deleted.
+ *
+ * These tests assert the generated AppleScript is mailbox-scoped, and that the
+ * unscoped first-match-wins walk is gone. executeAppleScript is fully mocked, so
+ * no running Mail.app is needed.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const FIELD_SEP = "\x1f";
+const RECORD_SEP = "\x1e";
+const DIAG_MARKER = "\x1dDIAG\x1d";
+const DIAG_FIELD_SEP = "\x1dF\x1d";
+
+const h = vi.hoisted(() => ({ calls: [] as string[] }));
+
+/** A list-messages payload: two ids, six fields each (mailbox = the one asked for). */
+function listPayload(ids: string[]): string {
+  const rows = ids
+    .map((id) =>
+      [
+        id,
+        "Subject",
+        "sender@example.com",
+        "Monday, January 1, 2026 at 0:00:00",
+        "false",
+        "false",
+      ].join(FIELD_SEP)
+    )
+    .join(RECORD_SEP);
+  return `${rows}${DIAG_MARKER}timedOut=false${DIAG_FIELD_SEP}skipped=${DIAG_FIELD_SEP}notSearched=`;
+}
+
+vi.mock("@/utils/applescript.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/applescript.js")>();
+  return {
+    ...actual,
+    executeAppleScript: (script: string) => {
+      h.calls.push(script);
+      // The list script is the only one that builds `outputText`; everything
+      // else (mutations) just needs a benign success.
+      const output = script.includes("outputText") ? listPayload(["75816", "75791"]) : "ok";
+      return { success: true, output, error: undefined as string | undefined };
+    },
+  };
+});
+
+import { AppleMailManager } from "@/services/appleMailManager.js";
+
+const lastScript = () => h.calls[h.calls.length - 1] ?? "";
+
+describe("#152 — by-id mutations are scoped to the source mailbox", () => {
+  let mgr: AppleMailManager;
+
+  beforeEach(() => {
+    h.calls.length = 0;
+    mgr = new AppleMailManager();
+    // Seed the id→location index the way real usage does: list the mailbox
+    // first, which is exactly the reporter's flow (list INBOX, then batch-op).
+    mgr.listMessages("INBOX", "me@example.com", 50);
+  });
+
+  it("batch delete opens the listed mailbox instead of walking every mailbox", () => {
+    mgr.batchDeleteMessages(["75816", "75791"]);
+    const s = lastScript();
+
+    // Scoped: resolves one specific account+mailbox into _tmb, then operates there.
+    expect(s).toContain("set _tmb to missing value");
+    expect(s).toContain('"INBOX"');
+    expect(s).toContain('"me@example.com"');
+    expect(s).toContain("messages of _tmb whose id is");
+    expect(s).toContain("delete _msg");
+
+    // The pre-fix bug: applying the op to the first hit found while iterating
+    // every mailbox of every account. That shape must not reappear.
+    expect(s).not.toContain("set _m to (messages of mb whose id is _theId)");
+  });
+
+  it("batch move scopes the SOURCE lookup while still resolving the destination", () => {
+    mgr.batchMoveMessages(["75816"], "Archive", "me@example.com");
+    const s = lastScript();
+
+    expect(s).toContain("set _tmb to missing value");
+    expect(s).toContain("messages of _tmb whose id is");
+    expect(s).toContain("move _msg to destMailbox");
+    // Destination resolution (the pre-existing, correct half) is untouched.
+    expect(s).toContain("set destMailbox to item 1 of destMatches");
+  });
+
+  it("single delete is scoped the same way as the batch path", () => {
+    mgr.deleteMessage("75816");
+    const s = lastScript();
+
+    expect(s).toContain("set _tmb to missing value");
+    expect(s).toContain("messages of _tmb whose id is 75816");
+    expect(s).toContain("delete msg");
+    // Old shape: unscoped `repeat with mb in mailboxes of acct` around the op.
+    expect(s).not.toContain("messages of mb whose id is 75816");
+  });
+
+  it("single move is scoped to the mailbox the id was listed from", () => {
+    mgr.moveMessage("75791", "Archive", "me@example.com");
+    const s = lastScript();
+
+    expect(s).toContain("set _tmb to missing value");
+    expect(s).toContain("messages of _tmb whose id is 75791");
+    expect(s).not.toContain("messages of mb whose id is 75791");
+  });
+
+  it("an id with no recorded mailbox is refused when ambiguous, never guessed", () => {
+    // 999 was never listed, so there is no source mailbox to scope to.
+    mgr.batchDeleteMessages(["999"]);
+    const s = lastScript();
+
+    // It counts every mailbox holding the id...
+    expect(s).toContain("set item _k of _uhit to ((item _k of _uhit) + 1)");
+    // ...and refuses rather than acting when more than one does.
+    expect(s).toContain("is present in more than one mailbox");
+    // The op is still reachable for the unambiguous single-hit case.
+    expect(s).toContain("delete _msg");
+  });
+
+  it("single-op with an unrecorded id also refuses ambiguity instead of first-match", () => {
+    mgr.deleteMessage("999");
+    const s = lastScript();
+
+    expect(s).toContain("if (count of _hits) > 1 then");
+    expect(s).toContain("is present in more than one mailbox");
+  });
+
+  it("mixes located and unlocated ids in one batch without losing either", () => {
+    mgr.batchMarkAsRead(["75816", "999"]);
+    const s = lastScript();
+
+    // Located id → scoped block; unlocated id → ambiguity-checked block.
+    expect(s).toContain("set _tmb to missing value");
+    expect(s).toContain("is present in more than one mailbox");
+    // Positions are what map results back to input order — both must appear.
+    expect(s).toContain("set _gpos to {1}");
+    expect(s).toContain("set _upos to {2}");
+  });
+});

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -120,6 +120,15 @@ const CONTENT_MARKER = "\x1dCONTENT\x1d"; // subject/plain-text boundary
 const MSGID_MARKER = "\x1dMSGID\x1d"; // subject/RFC-Message-ID boundary (get-message content)
 const HTML_MARKER = "\x1dHTML\x1d"; // plain-text/source boundary
 const BATCH_FATAL = "\x1dFATAL\x1d"; // prefix for a whole-batch failure (e.g. bad destination)
+/**
+ * Leading text of the error returned when a bare numeric id can't be pinned to
+ * one mailbox. Mail.app ids are per-mailbox and a label store repeats one id
+ * across INBOX / "Important" / "All Mail", so a mutation with no recorded
+ * source mailbox has no safe target to pick (#152).
+ */
+const AMBIGUOUS_ID_PREFIX = "Message id ";
+/** Same refusal, phrased for the batch path where the id isn't interpolable. */
+const AMBIGUOUS_ID_BATCH = "This message id is present in more than one mailbox ";
 
 /**
  * Normalize an RFC 5322 Message-ID for backend-independent matching: trim and
@@ -767,6 +776,34 @@ export class AppleMailManager {
       const oldest = this.idLocationIndex.keys().next().value;
       if (oldest !== undefined) this.idLocationIndex.delete(oldest);
     }
+  }
+
+  /** Where a message id was last listed/searched from, if we've seen it. */
+  private locationFor(id: string): { account: string; mailbox: string } | undefined {
+    return this.idLocationIndex.get(String(id));
+  }
+
+  /**
+   * AppleScript fragment resolving `account` + `mailbox` into `_tmb`, leaving
+   * `_tmb` as `missing value` when it can't be pinned down. Exact-name match
+   * only, and a name matching more than one mailbox resolves to nothing rather
+   * than guessing — the same rule the move destination already applies.
+   */
+  private resolveMailboxFragment(account: string, mailbox: string): string {
+    const resolved = this.resolveMailbox(mailbox, account);
+    return `
+        set _tmb to missing value
+        set _acctM to {}
+        repeat with _a in accounts
+          if (name of _a) is "${escapeForAppleScript(account)}" then set end of _acctM to _a
+        end repeat
+        if (count of _acctM) is 1 then
+          set _mbM to {}
+          repeat with _m in (mailboxes of (item 1 of _acctM))
+            if (name of _m) is "${escapeForAppleScript(resolved)}" then set end of _mbM to _m
+          end repeat
+          if (count of _mbM) is 1 then set _tmb to item 1 of _mbM
+        end if`;
   }
 
   /**
@@ -2263,24 +2300,65 @@ export class AppleMailManager {
   }
 
   /**
-   * Helper to find and operate on a message by ID.
+   * Helper to find and operate on a message by ID, scoped to the mailbox the id
+   * was listed from.
+   *
+   * Mail.app numeric ids are per-mailbox, and on a label store (Gmail, iCloud)
+   * ONE message is present in several mailboxes under the SAME id — INBOX,
+   * "Important" and "All Mail" all report id 75816 for the same mail. This used
+   * to walk every account's every mailbox and mutate the FIRST hit; because
+   * `mailboxes of account` yields INBOX late, an id listed from INBOX was
+   * reliably mutated in "Important" instead, so the op reported success while
+   * the INBOX copy stayed put and a different copy was moved/deleted (#152).
+   *
+   * Which mailbox a mutation lands in is semantic — deleting the INBOX copy and
+   * deleting the "All Mail" copy are different operations — so scope to the
+   * mailbox the id actually came from (`idLocationIndex`, populated by every
+   * list/search) and never guess.
    */
   private findMessageScript(id: string, operation: string): string {
+    const loc = this.locationFor(id);
+    if (loc) {
+      return buildAppLevelScript(`
+      try
+        ${this.resolveMailboxFragment(loc.account, loc.mailbox)}
+        if _tmb is missing value then return "error:Message not found"
+        set matchingMsgs to (messages of _tmb whose id is ${Number(id)})
+        if (count of matchingMsgs) > 0 then
+          set msg to item 1 of matchingMsgs
+          ${operation}
+          return "ok"
+        end if
+        return "error:Message not found"
+      on error errMsg
+        return "error:" & errMsg
+      end try
+    `);
+    }
+
+    // No recorded location (id supplied out-of-band, or evicted from the
+    // index). Collect EVERY mailbox holding this id and act only when it is
+    // unambiguous — refusing beats mutating an arbitrary copy.
     return buildAppLevelScript(`
       try
+        set _hits to {}
+        set _names to ""
         repeat with acct in accounts
           repeat with mb in mailboxes of acct
             try
               set matchingMsgs to (messages of mb whose id is ${Number(id)})
               if (count of matchingMsgs) > 0 then
-                set msg to item 1 of matchingMsgs
-                ${operation}
-                return "ok"
+                set end of _hits to (item 1 of matchingMsgs)
+                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
               end if
             end try
           end repeat
         end repeat
-        return "error:Message not found"
+        if (count of _hits) is 0 then return "error:Message not found"
+        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the operation targets the right copy"
+        set msg to item 1 of _hits
+        ${operation}
+        return "ok"
       on error errMsg
         return "error:" & errMsg
       end try
@@ -2503,6 +2581,37 @@ export class AppleMailManager {
     const safeMailbox = escapeForAppleScript(targetMailbox);
     const safeAccount = escapeForAppleScript(targetAccount);
 
+    // Locate the SOURCE copy the same way every other by-id mutation does:
+    // scoped to the mailbox the id was listed from, because one Mail.app id
+    // names a different message in every mailbox that holds it (#152).
+    const loc = this.locationFor(id);
+    const findAndMove = loc
+      ? `
+        ${this.resolveMailboxFragment(loc.account, loc.mailbox)}
+        if _tmb is missing value then return "error:Message not found"
+        set matchingMsgs to (messages of _tmb whose id is ${Number(id)})
+        if (count of matchingMsgs) is 0 then return "error:Message not found"
+        move (item 1 of matchingMsgs) to destMailbox
+        return "ok"`
+      : `
+        set _hits to {}
+        set _names to ""
+        repeat with acct in accounts
+          repeat with mb in (mailboxes of acct)
+            try
+              set matchingMsgs to (messages of mb whose id is ${Number(id)})
+              if (count of matchingMsgs) > 0 then
+                set end of _hits to (item 1 of matchingMsgs)
+                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
+              end if
+            end try
+          end repeat
+        end repeat
+        if (count of _hits) is 0 then return "error:Message not found"
+        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the move targets the right copy"
+        move (item 1 of _hits) to destMailbox
+        return "ok"`;
+
     const script = buildAppLevelScript(`
       try
         -- \`mailboxes of account\` is already flat: it includes nested mailboxes
@@ -2518,21 +2627,7 @@ export class AppleMailManager {
         if (count of destMatches) is 0 then return "error:Destination mailbox \\"" & destName & "\\" not found in account \\"${safeAccount}\\""
         if (count of destMatches) > 1 then return "error:Destination mailbox \\"" & destName & "\\" is ambiguous (" & (count of destMatches) & " matches) in account \\"${safeAccount}\\"; disambiguate or move by full path"
         set destMailbox to item 1 of destMatches
-
-        -- Find the message by id. The flat mailbox list already covers nested
-        -- mailboxes, so this reaches messages in subfolders without recursing.
-        repeat with acct in accounts
-          repeat with mb in (mailboxes of acct)
-            try
-              set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                move (item 1 of matchingMsgs) to destMailbox
-                return "ok"
-              end if
-            end try
-          end repeat
-        end repeat
-        return "error:Message not found"
+        ${findAndMove}
       on error errMsg
         return "error:" & errMsg
       end try
@@ -2571,15 +2666,26 @@ export class AppleMailManager {
    * Previously each batch method looped and called the per-id method, so a
    * 100-id batch spawned 100 osascript processes — each one re-resolving
    * accounts and walking the whole account→mailbox tree — all serialized
-   * through the gate (issue #31). This walks the tree exactly once: for each
-   * mailbox it probes the still-pending IDs with `whose id is` (indexed, so
-   * effectively free) and applies `operation` to any match, tracking found IDs
-   * so it can stop early once all are accounted for. Per-id outcomes come back
-   * as control-char-delimited `id<FS>status` records (status: `ok`,
-   * `notfound`, or `error:<msg>`), and results are returned in input order.
+   * through the gate (issue #31). Still one osascript invocation, but the ids
+   * are now grouped by the mailbox they were listed from and each group opens
+   * exactly that one mailbox. Per-id outcomes come back as control-char
+   * delimited `position<FS>status` records (status: `ok`, `notfound`, or
+   * `error:<msg>`), and results are returned in input order.
    *
-   * `setup` runs once before the walk (used by move to resolve the destination);
-   * it may bail the whole batch by returning a `BATCH_FATAL`-prefixed string.
+   * Scoping is a CORRECTNESS requirement, not an optimization (#152). A Mail.app
+   * numeric id is unique only within a mailbox, and a label store (Gmail,
+   * iCloud) exposes one message in several mailboxes under the same id — INBOX,
+   * "Important" and "All Mail" all report id 75816 for the same mail. The old
+   * tree walk applied `operation` to the FIRST mailbox that matched, and
+   * `mailboxes of account` yields INBOX late, so a batch of ids listed from
+   * INBOX was reliably applied to the "Important" copies instead: every id
+   * reported `ok` while the INBOX messages stayed put and other copies were
+   * moved/deleted. Grouping by recorded source mailbox makes the op land on the
+   * copy the caller actually listed; ids with no recorded mailbox are refused
+   * when ambiguous rather than applied to an arbitrary copy.
+   *
+   * `setup` runs once up front (used by move to resolve the destination); it may
+   * bail the whole batch by returning a `BATCH_FATAL`-prefixed string.
    */
   private runBatchOperation(ids: string[], operation: string, setup = ""): BatchOperationResult[] {
     // Keep the numeric IDs paired with their original string form and 1-based
@@ -2597,39 +2703,115 @@ export class AppleMailManager {
       return ids.map((id) => ({ id, success: false, error: "Invalid message ID" }));
     }
 
+    // Group the ids by the mailbox they were listed from. Each group opens that
+    // one mailbox and applies the op only there; ids we've never seen listed
+    // fall into `unlocated` and are resolved with an ambiguity check.
+    const groups = new Map<
+      string,
+      { account: string; mailbox: string; items: { num: number; pos: number }[] }
+    >();
+    const unlocated: { num: number; pos: number }[] = [];
+    valid.forEach((v, i) => {
+      const pos = i + 1;
+      const loc = this.locationFor(v.id);
+      if (!loc) {
+        unlocated.push({ num: v.num, pos });
+        return;
+      }
+      const key = `${loc.account} ${loc.mailbox}`;
+      const g = groups.get(key) ?? { account: loc.account, mailbox: loc.mailbox, items: [] };
+      g.items.push({ num: v.num, pos });
+      groups.set(key, g);
+    });
+
+    const asList = (nums: number[]): string => `{${nums.join(", ")}}`;
+
+    // One block per source mailbox: resolve it once, then apply the op to each
+    // of that mailbox's ids.
+    const scopedBlocks = [...groups.values()]
+      .map(
+        (g) => `
+        ${this.resolveMailboxFragment(g.account, g.mailbox)}
+        set _gids to ${asList(g.items.map((it) => it.num))}
+        set _gpos to ${asList(g.items.map((it) => it.pos))}
+        if _tmb is missing value then
+          repeat with _k from 1 to (count of _gpos)
+            set _out to _out & ((item _k of _gpos) as string) & "${FIELD_SEP}error:source mailbox \\"${escapeForAppleScript(g.mailbox)}\\" not found in account \\"${escapeForAppleScript(g.account)}\\"${RECORD_SEP}"
+          end repeat
+        else
+          repeat with _k from 1 to (count of _gids)
+            set _idx to item _k of _gpos
+            try
+              set _m to (messages of _tmb whose id is (item _k of _gids))
+              if (count of _m) > 0 then
+                set _msg to item 1 of _m
+                ${operation}
+                set _out to _out & (_idx as string) & "${FIELD_SEP}ok${RECORD_SEP}"
+              else
+                set _out to _out & (_idx as string) & "${FIELD_SEP}notfound${RECORD_SEP}"
+              end if
+            on error _e
+              set _out to _out & (_idx as string) & "${FIELD_SEP}error:" & _e & "${RECORD_SEP}"
+            end try
+          end repeat
+        end if`
+      )
+      .join("\n");
+
+    // Ids with no recorded source mailbox: count every mailbox holding each id
+    // and act only where exactly one does. Anything ambiguous is refused with
+    // the candidates named, never applied to whichever copy sorts first.
+    const unlocatedBlock = unlocated.length
+      ? `
+        set _uids to ${asList(unlocated.map((it) => it.num))}
+        set _upos to ${asList(unlocated.map((it) => it.pos))}
+        set _ucount to count of _uids
+        set _uhit to {}
+        set _umsg to {}
+        set _unames to {}
+        repeat with _k from 1 to _ucount
+          set end of _uhit to 0
+          set end of _umsg to missing value
+          set end of _unames to ""
+        end repeat
+        repeat with acct in accounts
+          repeat with mb in (mailboxes of acct)
+            repeat with _k from 1 to _ucount
+              try
+                set _m to (messages of mb whose id is (item _k of _uids))
+                if (count of _m) > 0 then
+                  set item _k of _uhit to ((item _k of _uhit) + 1)
+                  if (item _k of _uhit) is 1 then set item _k of _umsg to (item 1 of _m)
+                  set item _k of _unames to ((item _k of _unames) & (name of acct) & "/" & (name of mb) & ", ")
+                end if
+              end try
+            end repeat
+          end repeat
+        end repeat
+        repeat with _k from 1 to _ucount
+          set _idx to item _k of _upos
+          if (item _k of _uhit) is 0 then
+            set _out to _out & (_idx as string) & "${FIELD_SEP}notfound${RECORD_SEP}"
+          else if (item _k of _uhit) > 1 then
+            set _out to _out & (_idx as string) & "${FIELD_SEP}error:${AMBIGUOUS_ID_BATCH}(" & (item _k of _unames) & "); list or search that mailbox first so the operation targets the right copy${RECORD_SEP}"
+          else
+            try
+              set _msg to item _k of _umsg
+              ${operation}
+              set _out to _out & (_idx as string) & "${FIELD_SEP}ok${RECORD_SEP}"
+            on error _e
+              set _out to _out & (_idx as string) & "${FIELD_SEP}error:" & _e & "${RECORD_SEP}"
+            end try
+          end if
+        end repeat`
+      : "";
+
     const script = buildAppLevelScript(`
       try
         ${setup}
         set _out to ""
-        set _done to {}
-        set _ids to {${valid.map((v) => v.num).join(", ")}}
-        set _total to count of _ids
-        repeat with acct in accounts
-          if (count of _done) is _total then exit repeat
-          repeat with mb in (mailboxes of acct)
-            if (count of _done) is _total then exit repeat
-            repeat with _idx from 1 to _total
-              if _idx is not in _done then
-                set _theId to item _idx of _ids
-                try
-                  set _m to (messages of mb whose id is _theId)
-                  if (count of _m) > 0 then
-                    set _msg to item 1 of _m
-                    ${operation}
-                    set end of _done to _idx
-                    set _out to _out & (_idx as string) & "${FIELD_SEP}ok${RECORD_SEP}"
-                  end if
-                on error _e
-                  set end of _done to _idx
-                  set _out to _out & (_idx as string) & "${FIELD_SEP}error:" & _e & "${RECORD_SEP}"
-                end try
-              end if
-            end repeat
-          end repeat
-        end repeat
-        repeat with _idx from 1 to _total
-          if _idx is not in _done then set _out to _out & (_idx as string) & "${FIELD_SEP}notfound${RECORD_SEP}"
-        end repeat
+        ${scopedBlocks}
+        ${unlocatedBlock}
         return _out
       on error errMsg
         return "${BATCH_FATAL}" & errMsg


### PR DESCRIPTION
Fixes #152.

## The bug

A Mail.app numeric message id is unique only **within a mailbox**, and a label store (Gmail, iCloud) exposes one message in several mailboxes under the **same** id. Verified against a real account:

```
id 75815 lives in: rob@superiortech.io/All Mail; rob@superiortech.io/Sent Mail; rob@superiortech.io/INBOX
```

Every by-id mutation — `move-message`, `delete-message`, `batch-move-messages`, `batch-delete-messages`, and the batch read/flag ops — walked every account's every mailbox and applied the operation to the **first** match. `mailboxes of account` yields `INBOX` late, so an id listed from INBOX was reliably operated on somewhere else. Same probe, old resolution vs new:

```
OLD picks: rob@superiortech.io / All Mail     <- wrong copy
NEW picks: rob@superiortech.io / INBOX        <- the mailbox it was listed from
```

That is exactly what @scottstern0325 reported: `batch-delete-messages` returned `success:24` while the intended messages were still in INBOX and other copies had been deleted. The `success` count was the number of ids passed, not the number of messages affected, so it couldn't be used to verify the result either.

## The fix

Mutations now scope to the mailbox the id was listed from, reusing `idLocationIndex` — the id→(account, mailbox) map every `list-messages`/`search-messages` already populates, and which the **read** paths already consult for this exact reason. The mutation paths were simply never taught to use it.

Ids with no recorded source mailbox are resolved only when exactly one mailbox holds them; an ambiguous id now **fails with the candidates named** rather than being applied to whichever copy sorts first. Silently picking one is what made the original bug invisible.

Side benefit: the batch path no longer walks the whole account→mailbox tree — it opens only the mailboxes the ids actually came from.

`imap:` ids were never affected (they already encode account + mailbox path + UID); this was specific to the bare-numeric AppleScript ids returned when no IMAP account is configured, which is the reporter's setup.

## Verification

- New guard `src/services/appleMailManager.batchScope.test.ts` (7 tests). **Confirmed it fails on the pre-fix code** — all 7 fail against `origin/main`'s `appleMailManager.ts` and pass against the fix, so it can actually catch the bug it targets.
- Full suite: 518 tests / 37 files pass. typecheck, lint (0 errors), `format:check` clean.
- Real-data end-to-end through the built bundle with IMAP disabled (forcing the numeric-id path): `list-messages INBOX` → numeric ids → `batch-flag-messages` succeeded on a listed id, `batch-unflag-messages` restored it, and a never-listed id `999` failed instead of silently hitting an arbitrary message. Verified afterwards that no flag residue was left in any of the three mailboxes holding that id.

## Docs

CHANGELOG under a real `## [2.10.15]` heading; `CLAUDE.md` message-IDs section gains the id↔mailbox binding rule (agent-facing); README gains a Batch Operations preamble and a troubleshooting entry for the new ambiguity refusal.