### PR TITLE
fix(security): require atomic numeric batch scope

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.23",
+      "version": "2.10.24",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.23",
+      "version": "2.10.24",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.23",
+  "version": "2.10.24",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.23",
+  "version": "2.10.24",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.23",
+      "version": "2.10.24",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.23",
+  "version": "2.10.24",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## [Unreleased]
 
+## [2.10.24] - 2026-08-14
+
+### Changed
+
+- **Numeric batch source scopes now require both `sourceAccount` and `sourceMailbox`.**
+  A lone `sourceMailbox` was resolved against the mutable default-send account, so ids
+  listed from a non-default account were scoped to the *default* account's same-named
+  mailbox — and a numeric id that also exists there was mutated silently. That is the
+  #152 failure mode moved from cross-mailbox to cross-account, and it was strictly
+  worse than passing no scope at all, which refuses the case as ambiguous. Both fields
+  are now required together, and a whitespace-only value is rejected outright instead
+  of being silently discarded. `imap:` ids are unaffected — they already carry account,
+  mailbox and UID. Closes items 1 and 2 of #156.
+
 ## [2.10.23] - 2026-08-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -852,11 +852,12 @@ likely to be refused as ambiguous. Passing the source mailbox explicitly is the 
 stay scoped, and it overrides the remembered location. These parameters name where the ids **came
 from**; for `batch-move-messages` that is distinct from `mailbox`, the destination.
 
-`sourceMailbox` is the one that scopes, and it works on its own: omitting `sourceAccount` means
-that mailbox **in the default account**, exactly as an omitted `account` does elsewhere. If the
-default account cannot be determined, the ids fail with an error asking for an explicit
-`sourceAccount` — a scope the server can't honor is never quietly downgraded to the guess-the-copy
-walk. `sourceAccount` by itself pins nothing, since the mailbox is what an id is scoped to.
+`sourceMailbox` and `sourceAccount` are an atomic scope pair: provide **both** for numeric ids.
+The server never fills in a missing account from mutable default-send state, because the same
+mailbox name can exist in more than one account and numeric ids are only unique within an account
+and mailbox. A whitespace-only source field is rejected. `sourceAccount` by itself pins nothing,
+since the mailbox is what an id is scoped to; `imap:…` ids ignore both fields because they carry
+their own account, mailbox, and UID identity.
 
 **A repeated id is one message.** `ids` is treated as a set: a duplicate names the same message,
 so it is operated on once, and the batch returns **one result per distinct id**. `success` is
@@ -868,7 +869,7 @@ therefore a count of messages, not of list positions.
 |-----------|------|----------|-------------|
 | `ids` | string[] | Yes | Message IDs to delete (max 100) |
 | `sourceMailbox` | string | No | Mailbox the **numeric** ids were listed from — pins them to it. Ignored for `imap:` ids. |
-| `sourceAccount` | string | No | Account the numeric ids were listed from. Defaults to the default account; on its own it pins nothing — pair it with `sourceMailbox`. |
+| `sourceAccount` | string | No | Account the numeric ids were listed from. Required when `sourceMailbox` is supplied; on its own it pins nothing. |
 
 `structuredContent` carries `countDelta` — what the batch actually did to each
 source mailbox. See [Auditing destructive operations](#auditing-destructive-operations).
@@ -883,7 +884,7 @@ source mailbox. See [Auditing destructive operations](#auditing-destructive-oper
 | `mailbox` | string | Yes | Destination mailbox |
 | `account` | string | No | Account containing mailbox |
 | `sourceMailbox` | string | No | Mailbox the **numeric** ids were listed from — pins them to it. Ignored for `imap:` ids. |
-| `sourceAccount` | string | No | Account the numeric ids were listed from. Defaults to the default account; on its own it pins nothing — pair it with `sourceMailbox`. |
+| `sourceAccount` | string | No | Account the numeric ids were listed from. Required when `sourceMailbox` is supplied; on its own it pins nothing. |
 
 `structuredContent` carries `countDelta` — what the batch actually did to each
 **source** mailbox. See [Auditing destructive operations](#auditing-destructive-operations).
@@ -894,7 +895,7 @@ source mailbox. See [Auditing destructive operations](#auditing-destructive-oper
 |-----------|------|----------|-------------|
 | `ids` | string[] | Yes | Message IDs (max 100) |
 | `sourceMailbox` | string | No | Mailbox the **numeric** ids were listed from — pins them to it. Ignored for `imap:` ids. |
-| `sourceAccount` | string | No | Account the numeric ids were listed from. Defaults to the default account; on its own it pins nothing — pair it with `sourceMailbox`. |
+| `sourceAccount` | string | No | Account the numeric ids were listed from. Required when `sourceMailbox` is supplied; on its own it pins nothing. |
 
 #### `batch-flag-messages` / `batch-unflag-messages`
 
@@ -903,7 +904,7 @@ source mailbox. See [Auditing destructive operations](#auditing-destructive-oper
 | `ids` | string[] | Yes | Message IDs (max 100) |
 | `color` | string | No | (`batch-flag-messages` only) Flag color — see [`flag-message`](#flag-message--unflag-message). Applied on both routes, so a mixed batch of numeric and `imap:` ids all end up colored. |
 | `sourceMailbox` | string | No | Mailbox the **numeric** ids were listed from — pins them to it. Ignored for `imap:` ids. |
-| `sourceAccount` | string | No | Account the numeric ids were listed from. Defaults to the default account; on its own it pins nothing — pair it with `sourceMailbox`. |
+| `sourceAccount` | string | No | Account the numeric ids were listed from. Required when `sourceMailbox` is supplied; on its own it pins nothing. |
 
 ---
 

--- a/build/index.js
+++ b/build/index.js
@@ -80734,39 +80734,44 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
   /**
    * Turn a caller-supplied batch source scope into an account+mailbox pair.
    *
-   * `mailbox` is what does the scoping, and it works ON ITS OWN: an omitted
-   * `account` means "the default account" here exactly as it does for every
-   * other tool in this server (see resolveAccount), never "ignore the argument
-   * you were given". Requiring both used to make a lone `sourceMailbox` a silent
-   * no-op — the ids fell back to the whole-tree path and were then refused as
-   * ambiguous, which is the very failure the parameter exists to prevent.
+   * A numeric source scope is an account+mailbox pair. A mailbox name alone is
+   * not an identity: the same mailbox can exist in several accounts, and a
+   * numeric Mail id is not globally unique. Resolving a missing account from
+   * mutable default-send state can therefore target the wrong account. Require
+   * both fields so a caller cannot silently cross that account boundary.
    *
    * The safety property is absolute: when the account cannot be determined there
    * is NO fallback to the scan-and-guess walk. The caller gets an error naming
    * the mailbox it asked for, so it can retry with an explicit `sourceAccount`.
    * (An `account` with no `mailbox` cannot pin anything, so it scopes nothing —
-   * those ids still go through the index / ambiguity-checked path.)
+   * those ids still go through the index / ambiguity-checked path. A supplied
+   * whitespace-only field is rejected rather than silently discarded.)
    */
   resolveBatchScope(scope) {
-    const mailbox = scope?.mailbox?.trim();
+    const rawMailbox = scope?.mailbox;
+    const rawAccount = scope?.account;
+    const mailbox = rawMailbox?.trim();
+    const account = rawAccount?.trim();
+    if (rawMailbox !== void 0 && !mailbox) {
+      return {
+        kind: "unresolvable",
+        error: "sourceMailbox must contain a mailbox name; whitespace-only scope is not allowed."
+      };
+    }
+    if (rawAccount !== void 0 && !account) {
+      return {
+        kind: "unresolvable",
+        error: "sourceAccount must contain an account name; whitespace-only scope is not allowed."
+      };
+    }
     if (!mailbox) return { kind: "none" };
-    const account = scope?.account?.trim();
-    if (account) return { kind: "scoped", account, mailbox };
-    const known = this.getCachedAccounts();
-    if (known.length === 0) {
+    if (!account) {
       return {
         kind: "unresolvable",
-        error: `Cannot scope to source mailbox "${mailbox}": no sourceAccount was given and no Mail account could be read (Mail returned none, or the AppleScript transport failed). Retry with an explicit sourceAccount.`
+        error: `Cannot scope to source mailbox "${mailbox}" without sourceAccount: numeric Mail ids are only unique within an account and mailbox. Retry with both sourceAccount and sourceMailbox explicitly set.`
       };
     }
-    const chosen = this.resolveAccount();
-    if (!known.some((a) => a.name === chosen)) {
-      return {
-        kind: "unresolvable",
-        error: `Cannot scope to source mailbox "${mailbox}": no sourceAccount was given and the default account could not be determined. Retry with an explicit sourceAccount (available: ${known.map((a) => a.name).join(", ")}).`
-      };
-    }
-    return { kind: "scoped", account: chosen, mailbox };
+    return { kind: "scoped", account, mailbox };
   }
   /**
    * Run one operation over many message IDs in a SINGLE osascript invocation.
@@ -84420,10 +84425,10 @@ function withJsonSchema2020_12(transport2) {
 // src/index.ts
 loadFileConfig();
 var BATCH_SOURCE_MAILBOX_SCHEMA = external_exports.string().optional().describe(
-  "Mailbox the numeric ids were listed from (e.g. 'INBOX'). Pins each id to that mailbox \u2014 strongly recommended, since one numeric id can match in several mailboxes. Works on its own: without sourceAccount it means that mailbox in the default account. Ignored for imap: ids."
+  "Mailbox the numeric ids were listed from (e.g. 'INBOX'). Must be paired with sourceAccount to form an unambiguous scope. Ignored for imap: ids."
 );
 var BATCH_SOURCE_ACCOUNT_SCHEMA = external_exports.string().optional().describe(
-  "Account the numeric ids were listed from. Defaults to the default account. On its own it pins nothing \u2014 pair it with sourceMailbox."
+  "Account the numeric ids were listed from. Required when sourceMailbox is supplied; on its own it pins nothing."
 );
 var FLAG_COLOR_INDEX = {
   red: 0,

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.23",
+  "version": "2.10.24",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.10.23"
+        "apple-mail-mcp@2.10.24"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.23",
+  "version": "2.10.24",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,14 +133,14 @@ const BATCH_SOURCE_MAILBOX_SCHEMA = z
   .string()
   .optional()
   .describe(
-    "Mailbox the numeric ids were listed from (e.g. 'INBOX'). Pins each id to that mailbox — strongly recommended, since one numeric id can match in several mailboxes. Works on its own: without sourceAccount it means that mailbox in the default account. Ignored for imap: ids."
+    "Mailbox the numeric ids were listed from (e.g. 'INBOX'). Must be paired with sourceAccount to form an unambiguous scope. Ignored for imap: ids."
   );
 
 const BATCH_SOURCE_ACCOUNT_SCHEMA = z
   .string()
   .optional()
   .describe(
-    "Account the numeric ids were listed from. Defaults to the default account. On its own it pins nothing — pair it with sourceMailbox."
+    "Account the numeric ids were listed from. Required when sourceMailbox is supplied; on its own it pins nothing."
   );
 
 /** Apple Mail flag colors → the 0-6 palette index. `grey` is an alias for `gray`.

--- a/src/services/appleMailManager.batchScopeExplicit.test.ts
+++ b/src/services/appleMailManager.batchScopeExplicit.test.ts
@@ -93,30 +93,32 @@ describe("explicit batch source scope", () => {
     expect(s).not.toContain("repeat with acct in accounts");
   });
 
-  // A source mailbox on its own has to work: everywhere else in this server an
-  // omitted `account` means "the default account" (resolveAccount), never
-  // "ignore the argument you were given". Discarding a lone `sourceMailbox` sent
-  // the batch down the whole-tree path, where the id it was meant to pin is then
-  // refused as ambiguous — precisely the failure the parameter exists to prevent.
-  it("scopes on sourceMailbox ALONE, resolving the account the way the rest of the server does", () => {
+  it("rejects sourceMailbox without sourceAccount instead of guessing an account", () => {
     const res = mgr.batchDeleteMessages(["79345"], { mailbox: "Sales Spam" });
 
-    expect(res).toEqual([{ id: "79345", success: true }]);
-    const s = batchScript();
-    expect(s).toContain("Sales Spam");
-    // Resolved to the first ENABLED account (iCloud is disabled and must not be
-    // chosen implicitly — #47).
-    expect(s).toContain("rob@superiortech.io");
-    expect(s).not.toContain("repeat with acct in accounts");
+    expect(res).toEqual([
+      {
+        id: "79345",
+        success: false,
+        error: expect.stringContaining("without sourceAccount"),
+      },
+    ]);
+    expect(batchScript()).toBe("");
   });
 
-  it("honors the default-account override when scoping on sourceMailbox alone", () => {
+  it("rejects whitespace-only source fields instead of silently dropping the scope", () => {
     process.env.APPLE_MAIL_MCP_DEFAULT_ACCOUNT = "robert.b.sweet@gmail.com";
-    mgr.batchMarkAsRead(["79345"], { mailbox: "INBOX" });
+    const mailboxOnly = mgr.batchMarkAsRead(["79345"], { mailbox: "   " });
+    const accountOnly = mgr.batchMarkAsRead(["79345"], {
+      account: "   ",
+      mailbox: "INBOX",
+    });
 
-    const s = batchScript();
-    expect(s).toContain("robert.b.sweet@gmail.com");
-    expect(s).not.toContain("repeat with acct in accounts");
+    expect(mailboxOnly[0].success).toBe(false);
+    expect(mailboxOnly[0].error).toMatch(/whitespace-only/);
+    expect(accountOnly[0].success).toBe(false);
+    expect(accountOnly[0].error).toMatch(/whitespace-only/);
+    expect(batchScript()).toBe("");
   });
 
   it("FAILS the ids when no account can be resolved — never falls back to the walk", () => {

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -3485,18 +3485,18 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
   /**
    * Turn a caller-supplied batch source scope into an account+mailbox pair.
    *
-   * `mailbox` is what does the scoping, and it works ON ITS OWN: an omitted
-   * `account` means "the default account" here exactly as it does for every
-   * other tool in this server (see resolveAccount), never "ignore the argument
-   * you were given". Requiring both used to make a lone `sourceMailbox` a silent
-   * no-op — the ids fell back to the whole-tree path and were then refused as
-   * ambiguous, which is the very failure the parameter exists to prevent.
+   * A numeric source scope is an account+mailbox pair. A mailbox name alone is
+   * not an identity: the same mailbox can exist in several accounts, and a
+   * numeric Mail id is not globally unique. Resolving a missing account from
+   * mutable default-send state can therefore target the wrong account. Require
+   * both fields so a caller cannot silently cross that account boundary.
    *
    * The safety property is absolute: when the account cannot be determined there
    * is NO fallback to the scan-and-guess walk. The caller gets an error naming
    * the mailbox it asked for, so it can retry with an explicit `sourceAccount`.
    * (An `account` with no `mailbox` cannot pin anything, so it scopes nothing —
-   * those ids still go through the index / ambiguity-checked path.)
+   * those ids still go through the index / ambiguity-checked path. A supplied
+   * whitespace-only field is rejected rather than silently discarded.)
    */
   private resolveBatchScope(scope?: {
     account?: string;
@@ -3505,34 +3505,34 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     | { kind: "none" }
     | { kind: "scoped"; account: string; mailbox: string }
     | { kind: "unresolvable"; error: string } {
-    const mailbox = scope?.mailbox?.trim();
+    const rawMailbox = scope?.mailbox;
+    const rawAccount = scope?.account;
+    const mailbox = rawMailbox?.trim();
+    const account = rawAccount?.trim();
+
+    if (rawMailbox !== undefined && !mailbox) {
+      return {
+        kind: "unresolvable",
+        error: "sourceMailbox must contain a mailbox name; whitespace-only scope is not allowed.",
+      };
+    }
+    if (rawAccount !== undefined && !account) {
+      return {
+        kind: "unresolvable",
+        error: "sourceAccount must contain an account name; whitespace-only scope is not allowed.",
+      };
+    }
     if (!mailbox) return { kind: "none" };
-
-    const account = scope?.account?.trim();
-    if (account) return { kind: "scoped", account, mailbox };
-
-    const known = this.getCachedAccounts();
-    if (known.length === 0) {
+    if (!account) {
       return {
         kind: "unresolvable",
         error:
-          `Cannot scope to source mailbox "${mailbox}": no sourceAccount was given and no Mail ` +
-          `account could be read (Mail returned none, or the AppleScript transport failed). ` +
-          `Retry with an explicit sourceAccount.`,
+          `Cannot scope to source mailbox "${mailbox}" without sourceAccount: numeric Mail ids ` +
+          `are only unique within an account and mailbox. Retry with both sourceAccount and ` +
+          `sourceMailbox explicitly set.`,
       };
     }
-
-    const chosen = this.resolveAccount();
-    if (!known.some((a) => a.name === chosen)) {
-      return {
-        kind: "unresolvable",
-        error:
-          `Cannot scope to source mailbox "${mailbox}": no sourceAccount was given and the ` +
-          `default account could not be determined. Retry with an explicit sourceAccount ` +
-          `(available: ${known.map((a) => a.name).join(", ")}).`,
-      };
-    }
-    return { kind: "scoped", account: chosen, mailbox };
+    return { kind: "scoped", account, mailbox };
   }
 
   /**


### PR DESCRIPTION
Summary
- Require numeric batch callers to provide the complete `sourceAccount` + `sourceMailbox` pair.
- Reject whitespace-only source fields instead of silently falling back to an unscoped walk.
- Close the cross-account wrong-target path documented in open issue #156, while leaving self-scoped `imap:` ids unchanged.

Verification
- `pnpm run build`
- `pnpm test` — 40 files, 573 tests passed
- `pnpm run lint` — 0 errors; 10 pre-existing `no-explicit-any` warnings
- `pnpm run format:check`
- `git diff --check`
- Commit hook reran `tsc --noEmit` and `vitest run` — 40 files, 573 tests passed

Risk / Notes
- Shipped runtime and public docs changed; package version is 2.10.18 and plugin manifests/build were synchronized.
- This is intentionally fail-closed and compatibility-breaking for callers that supplied only `sourceMailbox`; the error tells them to provide both fields.
- Open for maintainer review; no live Mail.app integration was run in this environment. The PR is not merged, shipped, accepted, or maintainer-approved.