### PR TITLE
fix: refuse ambiguous message id lookups

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.24",
+      "version": "2.10.25",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.24",
+      "version": "2.10.25",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.24",
+  "version": "2.10.25",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.24",
+  "version": "2.10.25",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.24",
+      "version": "2.10.25",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.24",
+  "version": "2.10.25",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [2.10.25] - 2026-08-14
+
+### Fixed
+
+- **Numeric message reads now refuse ambiguous ids instead of choosing an arbitrary copy.**
+  The manager uses the caller's account/mailbox hint or remembered location first,
+  then scans all mailboxes only when needed. A full scan with zero matches returns
+  not-found; multiple matches return the same actionable ambiguity error as the
+  batch mutation path, and the tool layer surfaces that diagnostic to the caller.
+
 ## [2.10.24] - 2026-08-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
   not-found; multiple matches return the same actionable ambiguity error as the
   batch mutation path, and the tool layer surfaces that diagnostic to the caller.
 
+- **A lookup failure is no longer signalled by a bare `error:` text prefix.** The success
+  payload of the same read script leads with the message *subject*, which is whatever the
+  sender wrote — so any message whose subject began with `error:` was reported as a failed
+  lookup and became unreadable through `get-message`, with the remainder of its own payload
+  surfaced as the error text. The failure channel is now the GS-wrapped `\x1dERR\x1d`
+  marker, matching the existing `CONTENT`/`MSGID`/`HTML` delimiters, which sender-supplied
+  text cannot forge.
+
 ## [2.10.24] - 2026-08-14
 
 ### Changed

--- a/build/index.js
+++ b/build/index.js
@@ -78300,6 +78300,7 @@ var DIAG_ITEM_SEP = "M";
 var CONTENT_MARKER = "CONTENT";
 var MSGID_MARKER = "MSGID";
 var HTML_MARKER = "HTML";
+var LOOKUP_ERROR_MARKER = "ERR";
 var BATCH_FATAL = "FATAL";
 var RECON_TAG = "RECON";
 var SNAP_TAG = "SNAP";
@@ -79746,8 +79747,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             end try
           end repeat
         end repeat
-        if (count of _hits) is 0 then return "error:Message not found"
-        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
+        if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
+        if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
         if (count of _hits) is 1 then
           set msg to item 1 of _hits
           ${innerFetch}
@@ -79773,8 +79774,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       if (!result.success) console.error(`Failed to get message content: ${result.error}`);
       return null;
     }
-    if (result.output.startsWith("error:")) {
-      this.lastMessageLookupError = result.output.slice("error:".length).trim();
+    if (result.output.startsWith(LOOKUP_ERROR_MARKER)) {
+      this.lastMessageLookupError = result.output.slice(LOOKUP_ERROR_MARKER.length).trim();
       return null;
     }
     const htmlSplit = result.output.split(HTML_MARKER);
@@ -79814,11 +79815,11 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         "return source of msg"
       );
       const scoped = executeAppleScript(scopedScript, { timeoutMs: 12e4 });
-      if (scoped.success && scoped.output.trim() && !scoped.output.startsWith("error:")) {
+      if (scoped.success && scoped.output.trim() && !scoped.output.startsWith(LOOKUP_ERROR_MARKER)) {
         return scoped.output;
       }
-      if (scoped.success && scoped.output.startsWith("error:")) {
-        this.lastMessageLookupError = scoped.output.slice("error:".length).trim();
+      if (scoped.success && scoped.output.startsWith(LOOKUP_ERROR_MARKER)) {
+        this.lastMessageLookupError = scoped.output.slice(LOOKUP_ERROR_MARKER.length).trim();
       }
     }
     const script = buildAppLevelScript(`
@@ -79836,8 +79837,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             end try
           end repeat
         end repeat
-        if (count of _hits) is 0 then return "error:Message not found"
-        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
+        if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
+        if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
         if (count of _hits) is 1 then
           set msg to item 1 of _hits
           return source of msg
@@ -79851,8 +79852,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     if (!result.success || !result.output.trim()) {
       return null;
     }
-    if (result.output.startsWith("error:")) {
-      this.lastMessageLookupError = result.output.slice("error:".length).trim();
+    if (result.output.startsWith(LOOKUP_ERROR_MARKER)) {
+      this.lastMessageLookupError = result.output.slice(LOOKUP_ERROR_MARKER.length).trim();
       return null;
     }
     return result.output;

--- a/build/index.js
+++ b/build/index.js
@@ -79724,17 +79724,19 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     }
     const script = buildAppLevelScript(`
       try
+        set _hits to {}
         repeat with acct in accounts
           repeat with mb in mailboxes of acct
             try
               set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set msg to item 1 of matchingMsgs
-                ${innerFetch}
-              end if
+              if (count of matchingMsgs) > 0 then set end of _hits to item 1 of matchingMsgs
             end try
           end repeat
         end repeat
+        if (count of _hits) is 1 then
+          set msg to item 1 of _hits
+          ${innerFetch}
+        end if
         return ""
       on error errMsg
         return ""
@@ -79796,17 +79798,19 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     }
     const script = buildAppLevelScript(`
       try
+        set _hits to {}
         repeat with acct in accounts
           repeat with mb in mailboxes of acct
             try
               set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set msg to item 1 of matchingMsgs
-                return source of msg
-              end if
+              if (count of matchingMsgs) > 0 then set end of _hits to item 1 of matchingMsgs
             end try
           end repeat
         end repeat
+        if (count of _hits) is 1 then
+          set msg to item 1 of _hits
+          return source of msg
+        end if
         return ""
       on error errMsg
         return ""
@@ -80256,27 +80260,13 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     const safeBody = escapeForAppleScriptBody(body);
     const replyAllClause = replyAll ? " with reply to all" : "";
     const sendAction = send ? "send theReply" : "";
-    const script = buildAppLevelScript(`
-      try
-        repeat with acct in accounts
-          repeat with mb in mailboxes of acct
-            try
-              set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set msg to item 1 of matchingMsgs
-                set theReply to reply msg without opening window${replyAllClause}
-                set content of theReply to "${safeBody}"
-                ${sendAction}
-                return "ok"
-              end if
-            end try
-          end repeat
-        end repeat
-        return "error:Message not found"
-      on error errMsg
-        return "error:" & errMsg
-      end try
-    `);
+    const script = this.findMessageScript(
+      id,
+      `
+          set theReply to reply msg without opening window${replyAllClause}
+          set content of theReply to "${safeBody}"
+          ${sendAction}`
+    );
     const result = executeAppleScript(script, { timeoutMs: 6e4 });
     if (!result.success || result.output.startsWith("error:")) {
       console.error(`Failed to reply to message: ${result.error || result.output}`);
@@ -80301,28 +80291,14 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       recipientCommands += `make new to recipient at end of to recipients of theForward with properties {address:"${escapeForAppleScript(addr)}"}
 `;
     }
-    const script = buildAppLevelScript(`
-      try
-        repeat with acct in accounts
-          repeat with mb in mailboxes of acct
-            try
-              set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set msg to item 1 of matchingMsgs
-                set theForward to forward msg without opening window
-                ${recipientCommands}
-                ${safeBody ? `set content of theForward to "${safeBody}"` : ""}
-                ${sendAction}
-                return "ok"
-              end if
-            end try
-          end repeat
-        end repeat
-        return "error:Message not found"
-      on error errMsg
-        return "error:" & errMsg
-      end try
-    `);
+    const script = this.findMessageScript(
+      id,
+      `
+          set theForward to forward msg without opening window
+          ${recipientCommands}
+          ${safeBody ? `set content of theForward to "${safeBody}"` : ""}
+          ${sendAction}`
+    );
     const result = executeAppleScript(script, { timeoutMs: 6e4 });
     if (!result.success || result.output.startsWith("error:")) {
       console.error(`Failed to forward message: ${result.error || result.output}`);

--- a/build/index.js
+++ b/build/index.js
@@ -78653,6 +78653,8 @@ var AppleMailManager = class {
    * misses and falls back to the full scan, so it can never wedge a lookup.
    */
   idLocationIndex = /* @__PURE__ */ new Map();
+  /** Error from the most recent numeric message read, if it was refused. */
+  lastMessageLookupError;
   /** Cap on the id→location index so a long-lived process can't grow unbounded. */
   ID_LOCATION_MAX = 5e3;
   /** Record (or refresh) where a message id lives, evicting oldest when full. */
@@ -78680,6 +78682,12 @@ var AppleMailManager = class {
    */
   noteMessageLocation(id, account, mailbox) {
     this.rememberLocation(id, account, mailbox);
+  }
+  /** Consume the most recent read refusal so the tool layer can preserve it. */
+  consumeLastMessageLookupError() {
+    const error2 = this.lastMessageLookupError;
+    this.lastMessageLookupError = void 0;
+    return error2;
   }
   /**
    * AppleScript fragment resolving `account` + `mailbox` into `_tmb`, leaving
@@ -79699,6 +79707,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
    *   returned the entire raw MIME blob mislabeled as HTML (#32).
    */
   getMessageContent(id, includeHtml = false, hint) {
+    this.lastMessageLookupError = void 0;
     const sourceFetch = includeHtml ? `set htmlSource to ""
                 try
                   set htmlSource to source of msg
@@ -79725,14 +79734,20 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     const script = buildAppLevelScript(`
       try
         set _hits to {}
+        set _names to ""
         repeat with acct in accounts
           repeat with mb in mailboxes of acct
             try
               set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then set end of _hits to item 1 of matchingMsgs
+              if (count of matchingMsgs) > 0 then
+                set end of _hits to item 1 of matchingMsgs
+                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
+              end if
             end try
           end repeat
         end repeat
+        if (count of _hits) is 0 then return "error:Message not found"
+        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
         if (count of _hits) is 1 then
           set msg to item 1 of _hits
           ${innerFetch}
@@ -79756,6 +79771,10 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
   parseMessageContent(id, result, includeHtml) {
     if (!result.success || !result.output.trim()) {
       if (!result.success) console.error(`Failed to get message content: ${result.error}`);
+      return null;
+    }
+    if (result.output.startsWith("error:")) {
+      this.lastMessageLookupError = result.output.slice("error:".length).trim();
       return null;
     }
     const htmlSplit = result.output.split(HTML_MARKER);
@@ -79785,6 +79804,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
    * a 20MB attachment can take several seconds over Exchange/IMAP.
    */
   getRawSource(id, hint) {
+    this.lastMessageLookupError = void 0;
     const loc = hint?.account && hint?.mailbox ? { account: hint.account, mailbox: hint.mailbox } : this.idLocationIndex.get(id.toString());
     if (loc) {
       const scopedScript = this.scopedByIdScript(
@@ -79794,19 +79814,30 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         "return source of msg"
       );
       const scoped = executeAppleScript(scopedScript, { timeoutMs: 12e4 });
-      if (scoped.success && scoped.output.trim()) return scoped.output;
+      if (scoped.success && scoped.output.trim() && !scoped.output.startsWith("error:")) {
+        return scoped.output;
+      }
+      if (scoped.success && scoped.output.startsWith("error:")) {
+        this.lastMessageLookupError = scoped.output.slice("error:".length).trim();
+      }
     }
     const script = buildAppLevelScript(`
       try
         set _hits to {}
+        set _names to ""
         repeat with acct in accounts
           repeat with mb in mailboxes of acct
             try
               set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then set end of _hits to item 1 of matchingMsgs
+              if (count of matchingMsgs) > 0 then
+                set end of _hits to item 1 of matchingMsgs
+                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
+              end if
             end try
           end repeat
         end repeat
+        if (count of _hits) is 0 then return "error:Message not found"
+        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
         if (count of _hits) is 1 then
           set msg to item 1 of _hits
           return source of msg
@@ -79818,6 +79849,10 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     `);
     const result = executeAppleScript(script, { timeoutMs: 12e4 });
     if (!result.success || !result.output.trim()) {
+      return null;
+    }
+    if (result.output.startsWith("error:")) {
+      this.lastMessageLookupError = result.output.slice("error:".length).trim();
       return null;
     }
     return result.output;
@@ -84711,7 +84746,10 @@ Do not use when: you don't yet have an id (use search-messages or list-messages 
           account,
           mailbox
         });
-        if (!content) return errorResponse(`Message with ID "${id}" not found`);
+        if (!content) {
+          const lookupError = mailManager.consumeLastMessageLookupError();
+          return errorResponse(lookupError ?? `Message with ID "${id}" not found`);
+        }
         const isHtml = preferHtml === true && !!content.htmlContent;
         const body = isHtml ? content.htmlContent : content.plainText;
         return successResponse(`Subject: ${content.subject}

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.24",
+  "version": "2.10.25",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.10.24"
+        "apple-mail-mcp@2.10.25"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.24",
+  "version": "2.10.25",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -661,7 +661,10 @@ registerTool(
             account,
             mailbox,
           });
-          if (!content) return errorResponse(`Message with ID "${id}" not found`);
+          if (!content) {
+            const lookupError = mailManager.consumeLastMessageLookupError();
+            return errorResponse(lookupError ?? `Message with ID "${id}" not found`);
+          }
           const isHtml = preferHtml === true && !!content.htmlContent;
           const body = isHtml ? content.htmlContent! : content.plainText;
           return successResponse(`Subject: ${content.subject}\n\n${body}`, {

--- a/src/services/appleMailManager.messageIdentity.test.ts
+++ b/src/services/appleMailManager.messageIdentity.test.ts
@@ -58,18 +58,31 @@ describe("by-id message identity", () => {
   });
 
   it("does not read an arbitrary first match when an id has no recorded location", () => {
+    h.output =
+      "error:Message id 42 is present in more than one mailbox (Work/INBOX, Work/All Mail); list or search that mailbox first so the read targets the right copy";
     expect(mgr.getRawSource("42")).toBeNull();
     let script = lastScript();
     expect(script).toContain("set _hits to {}");
+    expect(script).toContain('set _names to ""');
+    expect(script).toContain("if (count of _hits) > 1 then");
     expect(script).toContain("if (count of _hits) is 1 then");
     expect(script.indexOf("return source of msg")).toBeGreaterThan(
       script.indexOf("if (count of _hits) is 1 then")
     );
+    expect(mgr.consumeLastMessageLookupError()).toMatch(
+      /^Message id 42 is present in more than one mailbox/
+    );
 
     h.calls.length = 0;
+    h.output =
+      "error:Message id 42 is present in more than one mailbox (Work/INBOX, Work/All Mail); list or search that mailbox first so the read targets the right copy";
     expect(mgr.getMessageContent("42")).toBeNull();
     script = lastScript();
     expect(script).toContain("set _hits to {}");
+    expect(script).toContain("if (count of _hits) > 1 then");
     expect(script).toContain("if (count of _hits) is 1 then");
+    expect(mgr.consumeLastMessageLookupError()).toMatch(
+      /^Message id 42 is present in more than one mailbox/
+    );
   });
 });

--- a/src/services/appleMailManager.messageIdentity.test.ts
+++ b/src/services/appleMailManager.messageIdentity.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression guards for by-id message identity.
+ *
+ * A numeric Mail.app id can appear in more than one mailbox (for example, a
+ * Gmail label and All Mail). Message reads and reply/forward mutations must
+ * use the same location-aware resolver as the other by-id mutations instead
+ * of silently taking the first mailbox encountered.
+ *
+ * executeAppleScript is mocked, so these tests inspect generated AppleScript
+ * without requiring a running Mail.app instance.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const h = vi.hoisted(() => ({ calls: [] as string[], output: "" }));
+
+vi.mock("@/utils/applescript.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/applescript.js")>();
+  return {
+    ...actual,
+    executeAppleScript: (script: string) => {
+      h.calls.push(script);
+      return { success: true, output: h.output, error: undefined as string | undefined };
+    },
+  };
+});
+
+import { AppleMailManager } from "@/services/appleMailManager.js";
+
+const lastScript = () => h.calls[h.calls.length - 1] ?? "";
+
+describe("by-id message identity", () => {
+  let mgr: AppleMailManager;
+
+  beforeEach(() => {
+    h.calls.length = 0;
+    h.output = "";
+    mgr = new AppleMailManager();
+  });
+
+  it("uses the recorded mailbox resolver for replies and forwards", () => {
+    h.output = "ok";
+    mgr.noteMessageLocation("42", "work@example.com", "INBOX");
+
+    expect(mgr.replyToMessage("42", "Reply body", false, false)).toBe(true);
+    let script = lastScript();
+    expect(script).toContain('if (name of _a) is "work@example.com"');
+    expect(script).toContain('if (name of _m) is "INBOX"');
+    expect(script).toContain("messages of _tmb whose id is 42");
+    expect(script).toContain("reply msg without opening window");
+    expect(script).not.toContain("messages of mb whose id is 42");
+
+    h.calls.length = 0;
+    expect(mgr.forwardMessage("42", ["recipient@example.com"], undefined, false)).toBe(true);
+    script = lastScript();
+    expect(script).toContain("messages of _tmb whose id is 42");
+    expect(script).toContain("forward msg without opening window");
+    expect(script).not.toContain("messages of mb whose id is 42");
+  });
+
+  it("does not read an arbitrary first match when an id has no recorded location", () => {
+    expect(mgr.getRawSource("42")).toBeNull();
+    let script = lastScript();
+    expect(script).toContain("set _hits to {}");
+    expect(script).toContain("if (count of _hits) is 1 then");
+    expect(script.indexOf("return source of msg")).toBeGreaterThan(
+      script.indexOf("if (count of _hits) is 1 then")
+    );
+
+    h.calls.length = 0;
+    expect(mgr.getMessageContent("42")).toBeNull();
+    script = lastScript();
+    expect(script).toContain("set _hits to {}");
+    expect(script).toContain("if (count of _hits) is 1 then");
+  });
+});

--- a/src/services/appleMailManager.messageIdentity.test.ts
+++ b/src/services/appleMailManager.messageIdentity.test.ts
@@ -85,7 +85,7 @@ describe("by-id message identity", () => {
 
   it("does not read an arbitrary first match when an id has no recorded location", () => {
     h.output =
-      "error:Message id 42 is present in more than one mailbox (Work/INBOX, Work/All Mail); list or search that mailbox first so the read targets the right copy";
+      "\x1dERR\x1dMessage id 42 is present in more than one mailbox (Work/INBOX, Work/All Mail); list or search that mailbox first so the read targets the right copy";
     expect(mgr.getRawSource("42")).toBeNull();
     let script = lastScript();
     expect(script).toContain("set _hits to {}");
@@ -101,7 +101,7 @@ describe("by-id message identity", () => {
 
     h.calls.length = 0;
     h.output =
-      "error:Message id 42 is present in more than one mailbox (Work/INBOX, Work/All Mail); list or search that mailbox first so the read targets the right copy";
+      "\x1dERR\x1dMessage id 42 is present in more than one mailbox (Work/INBOX, Work/All Mail); list or search that mailbox first so the read targets the right copy";
     expect(mgr.getMessageContent("42")).toBeNull();
     script = lastScript();
     expect(script).toContain("set _hits to {}");
@@ -110,5 +110,33 @@ describe("by-id message identity", () => {
     expect(mgr.consumeLastMessageLookupError()).toMatch(
       /^Message id 42 is present in more than one mailbox/
     );
+  });
+  it("does not mistake a sender-controlled subject for a lookup failure", () => {
+    // The success payload of the read script leads with `subject`, which is
+    // whatever the sender wrote. A bare `error:` text prefix as the failure
+    // signal therefore collides with legitimate mail: any message whose subject
+    // starts with `error:` became permanently unreadable via get-message, and
+    // the remainder of its own payload was reported as the lookup error.
+    mgr.noteMessageLocation("42", "work@example.com", "INBOX");
+    h.output =
+      "error:Message not found\x1dMSGID\x1d<hostile@example.com>\x1dCONTENT\x1dbody text\x1dHTML\x1d";
+
+    expect(mgr.getMessageContent("42")).toMatchObject({
+      id: "42",
+      subject: "error:Message not found",
+      plainText: "body text",
+      rfcMessageId: "hostile@example.com",
+    });
+    expect(mgr.consumeLastMessageLookupError()).toBeUndefined();
+  });
+
+  it("does not mistake raw source that opens with error: for a lookup failure", () => {
+    mgr.noteMessageLocation("42", "work@example.com", "INBOX");
+    h.output = "error:Message not found\r\nFrom: sender@example.com\r\n\r\nbody";
+
+    expect(mgr.getRawSource("42")).toBe(
+      "error:Message not found\r\nFrom: sender@example.com\r\n\r\nbody"
+    );
+    expect(mgr.consumeLastMessageLookupError()).toBeUndefined();
   });
 });

--- a/src/services/appleMailManager.messageIdentity.test.ts
+++ b/src/services/appleMailManager.messageIdentity.test.ts
@@ -57,6 +57,32 @@ describe("by-id message identity", () => {
     expect(script).not.toContain("messages of mb whose id is 42");
   });
 
+  it("uses the recorded mailbox resolver for message reads", () => {
+    mgr.noteMessageLocation("42", "work@example.com", "INBOX");
+
+    h.output = "Subject\x1dMSGID\x1d<id@example.com>\x1dCONTENT\x1dbody\x1dHTML\x1d";
+    expect(mgr.getMessageContent("42")).toMatchObject({
+      id: "42",
+      subject: "Subject",
+      plainText: "body",
+      rfcMessageId: "id@example.com",
+    });
+    let script = lastScript();
+    expect(script).toContain('first account whose name is "work@example.com"');
+    expect(script).toContain('if (name of mb) is "INBOX" then');
+    expect(script).toContain("messages of targetMb whose id is 42");
+    expect(script).not.toContain("messages of mb whose id is 42");
+
+    h.calls.length = 0;
+    h.output = "raw MIME source";
+    expect(mgr.getRawSource("42")).toBe("raw MIME source");
+    script = lastScript();
+    expect(script).toContain('first account whose name is "work@example.com"');
+    expect(script).toContain('if (name of mb) is "INBOX" then');
+    expect(script).toContain("messages of targetMb whose id is 42");
+    expect(script).not.toContain("messages of mb whose id is 42");
+  });
+
   it("does not read an arbitrary first match when an id has no recorded location", () => {
     h.output =
       "error:Message id 42 is present in more than one mailbox (Work/INBOX, Work/All Mail); list or search that mailbox first so the read targets the right copy";

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -2253,17 +2253,19 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
 
     const script = buildAppLevelScript(`
       try
+        set _hits to {}
         repeat with acct in accounts
           repeat with mb in mailboxes of acct
             try
               set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set msg to item 1 of matchingMsgs
-                ${innerFetch}
-              end if
+              if (count of matchingMsgs) > 0 then set end of _hits to item 1 of matchingMsgs
             end try
           end repeat
         end repeat
+        if (count of _hits) is 1 then
+          set msg to item 1 of _hits
+          ${innerFetch}
+        end if
         return ""
       on error errMsg
         return ""
@@ -2352,17 +2354,19 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
 
     const script = buildAppLevelScript(`
       try
+        set _hits to {}
         repeat with acct in accounts
           repeat with mb in mailboxes of acct
             try
               set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set msg to item 1 of matchingMsgs
-                return source of msg
-              end if
+              if (count of matchingMsgs) > 0 then set end of _hits to item 1 of matchingMsgs
             end try
           end repeat
         end repeat
+        if (count of _hits) is 1 then
+          set msg to item 1 of _hits
+          return source of msg
+        end if
         return ""
       on error errMsg
         return ""
@@ -2917,27 +2921,13 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     const replyAllClause = replyAll ? " with reply to all" : "";
     const sendAction = send ? "send theReply" : "";
 
-    const script = buildAppLevelScript(`
-      try
-        repeat with acct in accounts
-          repeat with mb in mailboxes of acct
-            try
-              set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set msg to item 1 of matchingMsgs
-                set theReply to reply msg without opening window${replyAllClause}
-                set content of theReply to "${safeBody}"
-                ${sendAction}
-                return "ok"
-              end if
-            end try
-          end repeat
-        end repeat
-        return "error:Message not found"
-      on error errMsg
-        return "error:" & errMsg
-      end try
-    `);
+    const script = this.findMessageScript(
+      id,
+      `
+          set theReply to reply msg without opening window${replyAllClause}
+          set content of theReply to "${safeBody}"
+          ${sendAction}`
+    );
 
     const result = executeAppleScript(script, { timeoutMs: 60000 });
 
@@ -2968,28 +2958,14 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       recipientCommands += `make new to recipient at end of to recipients of theForward with properties {address:"${escapeForAppleScript(addr)}"}\n`;
     }
 
-    const script = buildAppLevelScript(`
-      try
-        repeat with acct in accounts
-          repeat with mb in mailboxes of acct
-            try
-              set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set msg to item 1 of matchingMsgs
-                set theForward to forward msg without opening window
-                ${recipientCommands}
-                ${safeBody ? `set content of theForward to "${safeBody}"` : ""}
-                ${sendAction}
-                return "ok"
-              end if
-            end try
-          end repeat
-        end repeat
-        return "error:Message not found"
-      on error errMsg
-        return "error:" & errMsg
-      end try
-    `);
+    const script = this.findMessageScript(
+      id,
+      `
+          set theForward to forward msg without opening window
+          ${recipientCommands}
+          ${safeBody ? `set content of theForward to "${safeBody}"` : ""}
+          ${sendAction}`
+    );
 
     const result = executeAppleScript(script, { timeoutMs: 60000 });
 

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -133,6 +133,7 @@ const DIAG_ITEM_SEP = "\x1dM\x1d"; // between diagnostics list items
 const CONTENT_MARKER = "\x1dCONTENT\x1d"; // subject/plain-text boundary
 const MSGID_MARKER = "\x1dMSGID\x1d"; // subject/RFC-Message-ID boundary (get-message content)
 const HTML_MARKER = "\x1dHTML\x1d"; // plain-text/source boundary
+const LOOKUP_ERROR_MARKER = "\x1dERR\x1d"; // GS-wrapped — by-id lookup failure; must not be a bare text prefix because the success payload of the same script leads with the sender-controlled subject
 const BATCH_FATAL = "\x1dFATAL\x1d"; // prefix for a whole-batch failure (e.g. bad destination)
 /**
  * Forensic record tags (#155). These ride in the SAME delimited stream as the
@@ -2277,8 +2278,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             end try
           end repeat
         end repeat
-        if (count of _hits) is 0 then return "error:Message not found"
-        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
+        if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
+        if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
         if (count of _hits) is 1 then
           set msg to item 1 of _hits
           ${innerFetch}
@@ -2311,8 +2312,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       return null;
     }
 
-    if (result.output.startsWith("error:")) {
-      this.lastMessageLookupError = result.output.slice("error:".length).trim();
+    if (result.output.startsWith(LOOKUP_ERROR_MARKER)) {
+      this.lastMessageLookupError = result.output.slice(LOOKUP_ERROR_MARKER.length).trim();
       return null;
     }
 
@@ -2371,11 +2372,15 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         "return source of msg"
       );
       const scoped = executeAppleScript(scopedScript, { timeoutMs: 120000 });
-      if (scoped.success && scoped.output.trim() && !scoped.output.startsWith("error:")) {
+      if (
+        scoped.success &&
+        scoped.output.trim() &&
+        !scoped.output.startsWith(LOOKUP_ERROR_MARKER)
+      ) {
         return scoped.output;
       }
-      if (scoped.success && scoped.output.startsWith("error:")) {
-        this.lastMessageLookupError = scoped.output.slice("error:".length).trim();
+      if (scoped.success && scoped.output.startsWith(LOOKUP_ERROR_MARKER)) {
+        this.lastMessageLookupError = scoped.output.slice(LOOKUP_ERROR_MARKER.length).trim();
       }
       // Miss (stale index) → fall through to the full scan.
     }
@@ -2395,8 +2400,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             end try
           end repeat
         end repeat
-        if (count of _hits) is 0 then return "error:Message not found"
-        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
+        if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
+        if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
         if (count of _hits) is 1 then
           set msg to item 1 of _hits
           return source of msg
@@ -2412,8 +2417,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     if (!result.success || !result.output.trim()) {
       return null;
     }
-    if (result.output.startsWith("error:")) {
-      this.lastMessageLookupError = result.output.slice("error:".length).trim();
+    if (result.output.startsWith(LOOKUP_ERROR_MARKER)) {
+      this.lastMessageLookupError = result.output.slice(LOOKUP_ERROR_MARKER.length).trim();
       return null;
     }
 

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -902,6 +902,9 @@ export class AppleMailManager {
    */
   private idLocationIndex = new Map<string, { account: string; mailbox: string }>();
 
+  /** Error from the most recent numeric message read, if it was refused. */
+  private lastMessageLookupError: string | undefined;
+
   /** Cap on the id→location index so a long-lived process can't grow unbounded. */
   private readonly ID_LOCATION_MAX = 5000;
 
@@ -933,6 +936,13 @@ export class AppleMailManager {
    */
   noteMessageLocation(id: string, account: string, mailbox: string): void {
     this.rememberLocation(id, account, mailbox);
+  }
+
+  /** Consume the most recent read refusal so the tool layer can preserve it. */
+  consumeLastMessageLookupError(): string | undefined {
+    const error = this.lastMessageLookupError;
+    this.lastMessageLookupError = undefined;
+    return error;
   }
 
   /**
@@ -2209,6 +2219,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     includeHtml = false,
     hint?: { account?: string; mailbox?: string }
   ): MessageContent | null {
+    this.lastMessageLookupError = undefined;
     // Only `source of msg` is fetched when HTML is requested. `content of msg`
     // is the plain-text body and is always cheap.
     const sourceFetch = includeHtml
@@ -2254,14 +2265,20 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     const script = buildAppLevelScript(`
       try
         set _hits to {}
+        set _names to ""
         repeat with acct in accounts
           repeat with mb in mailboxes of acct
             try
               set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then set end of _hits to item 1 of matchingMsgs
+              if (count of matchingMsgs) > 0 then
+                set end of _hits to item 1 of matchingMsgs
+                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
+              end if
             end try
           end repeat
         end repeat
+        if (count of _hits) is 0 then return "error:Message not found"
+        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
         if (count of _hits) is 1 then
           set msg to item 1 of _hits
           ${innerFetch}
@@ -2291,6 +2308,11 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
   ): MessageContent | null {
     if (!result.success || !result.output.trim()) {
       if (!result.success) console.error(`Failed to get message content: ${result.error}`);
+      return null;
+    }
+
+    if (result.output.startsWith("error:")) {
+      this.lastMessageLookupError = result.output.slice("error:".length).trim();
       return null;
     }
 
@@ -2332,6 +2354,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
    * a 20MB attachment can take several seconds over Exchange/IMAP.
    */
   getRawSource(id: string, hint?: { account?: string; mailbox?: string }): string | null {
+    this.lastMessageLookupError = undefined;
     // Fast path: fetch from the known mailbox directly (same rationale as
     // getMessageContent — the unscoped scan below times out for a message in a
     // late-iterated large folder like "Sent Items"). See idLocationIndex.
@@ -2348,21 +2371,32 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         "return source of msg"
       );
       const scoped = executeAppleScript(scopedScript, { timeoutMs: 120000 });
-      if (scoped.success && scoped.output.trim()) return scoped.output;
+      if (scoped.success && scoped.output.trim() && !scoped.output.startsWith("error:")) {
+        return scoped.output;
+      }
+      if (scoped.success && scoped.output.startsWith("error:")) {
+        this.lastMessageLookupError = scoped.output.slice("error:".length).trim();
+      }
       // Miss (stale index) → fall through to the full scan.
     }
 
     const script = buildAppLevelScript(`
       try
         set _hits to {}
+        set _names to ""
         repeat with acct in accounts
           repeat with mb in mailboxes of acct
             try
               set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then set end of _hits to item 1 of matchingMsgs
+              if (count of matchingMsgs) > 0 then
+                set end of _hits to item 1 of matchingMsgs
+                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
+              end if
             end try
           end repeat
         end repeat
+        if (count of _hits) is 0 then return "error:Message not found"
+        if (count of _hits) > 1 then return "error:${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
         if (count of _hits) is 1 then
           set msg to item 1 of _hits
           return source of msg
@@ -2376,6 +2410,10 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     const result = executeAppleScript(script, { timeoutMs: 120000 });
 
     if (!result.success || !result.output.trim()) {
+      return null;
+    }
+    if (result.output.startsWith("error:")) {
+      this.lastMessageLookupError = result.output.slice("error:".length).trim();
       return null;
     }
 


### PR DESCRIPTION
Summary
- Route reply and forward operations through the existing account-and-mailbox resolver so a numeric Mail.app ID cannot mutate the first mailbox encountered.
- Make unlocated content and raw-source reads proceed only when exactly one mailbox contains the ID.
- Add deterministic AppleScript-shape regression coverage and release the change as 2.10.19 with the rebuilt bundle and synchronized plugin manifests.

Verification
- `pnpm run build`
- `pnpm test` — 41 files, 575 tests passed
- `pnpm run lint` — 0 errors; 10 existing `no-explicit-any` warnings
- `pnpm run format:check`
- `git diff --check`
- Commit hook: `tsc --noEmit` and `vitest run` — 41 files, 575 tests passed
- Apple Mail integration tests: Not run; this PR has deterministic mocked AppleScript coverage only.

Risk / Notes
- This is a behavior-hardening change for shipped runtime code and updates `CHANGELOG.md`, `package.json`, committed `build/index.js`, and plugin manifests.
- An ID with multiple mailbox matches now returns no read result or mutation rather than guessing; callers should list/search the intended mailbox first.
- Open for maintainer review; no live Mail.app state was changed. The PR is not merged, shipped, accepted, or maintainer-approved.