### PR TITLE
fix: prevent attachment overwrites

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.25",
+      "version": "2.10.26",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.25",
+      "version": "2.10.26",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.25",
+  "version": "2.10.26",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.25",
+  "version": "2.10.26",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.25",
+      "version": "2.10.26",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.25",
+  "version": "2.10.26",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [2.10.26] - 2026-08-14
+
+### Security
+
+- **Attachment saves now fail closed against destination races and expose files only to the owner.**
+  Both the AppleScript and MIME fallback paths stage bytes in a private temporary
+  directory, commit with exclusive creation, and enforce mode `0600` on the final
+  file. An existing destination is never overwritten, and staging artifacts are
+  cleaned up on success or failure.
+
 ## [2.10.25] - 2026-08-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -824,6 +824,11 @@ List attachments on a message.
 
 Save a message attachment to disk.
 
+The destination must not already exist: `save-attachment` fails closed instead
+of overwriting an existing file. AppleScript and MIME fallback paths stage the
+bytes privately, commit with an exclusive create, and leave the saved file
+owner-readable/writable (`0600`).
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `id` | string | Yes | Message ID |

--- a/build/index.js
+++ b/build/index.js
@@ -81231,7 +81231,7 @@ ${this.errorEmit("              ")}
       return false;
     }
     try {
-      writeFileSync3(target.savedPath, attachment.data, { flag: "wx" });
+      writeFileSync3(target.savedPath, attachment.data, { flag: "wx", mode: 384 });
       return true;
     } catch (err) {
       console.error(`Failed to write attachment to disk: ${err}`);

--- a/build/index.js
+++ b/build/index.js
@@ -85703,7 +85703,7 @@ registerTool(
       if (!r.success || !r.base64) {
         return errorResponse(r.error || `Failed to fetch attachment "${attachmentName}"`);
       }
-      writeFileSync4(target.savedPath, Buffer.from(r.base64, "base64"), { flag: "wx" });
+      writeFileSync4(target.savedPath, Buffer.from(r.base64, "base64"), { flag: "wx", mode: 384 });
       return successResponse(`Attachment "${attachmentName}" saved to ${savePath}`, {
         ok: true,
         attachmentName,

--- a/build/index.js
+++ b/build/index.js
@@ -81166,9 +81166,21 @@ ${this.errorEmit("              ")}
       return false;
     }
     const safeName = escapeForAppleScript(attachmentName);
-    const temporaryName = `.apple-mail-mcp-${randomUUID()}.attachment`;
-    const temporaryPath = resolve(target.saveDirectory, temporaryName);
+    let temporaryDirectory;
+    try {
+      temporaryDirectory = mkdtempSync2(join4(target.saveDirectory, ".apple-mail-mcp-"));
+    } catch (error2) {
+      console.error(`Failed to create attachment staging directory: ${error2}`);
+      return false;
+    }
+    const temporaryPath = join4(temporaryDirectory, "attachment");
     const safeTemporaryPath = escapeForAppleScript(temporaryPath);
+    const cleanupTemporaryDirectory = () => {
+      try {
+        rmSync2(temporaryDirectory, { recursive: true, force: true });
+      } catch {
+      }
+    };
     const numericId = Number(id);
     const script = buildAppLevelScript(`
       try
@@ -81199,21 +81211,15 @@ ${this.errorEmit("              ")}
     if (result.success && result.output === "ok") {
       try {
         copyFileSync(temporaryPath, target.savedPath, fsConstants.COPYFILE_EXCL);
-        unlinkSync(temporaryPath);
+        cleanupTemporaryDirectory();
         return true;
       } catch (err) {
-        try {
-          if (existsSync3(temporaryPath)) unlinkSync(temporaryPath);
-        } catch {
-        }
+        cleanupTemporaryDirectory();
         console.error(`Failed to commit attachment to disk: ${err}`);
         return false;
       }
     }
-    try {
-      if (existsSync3(temporaryPath)) unlinkSync(temporaryPath);
-    } catch {
-    }
+    cleanupTemporaryDirectory();
     const rawSource = this.getRawSource(id);
     if (!rawSource) {
       console.error(`Failed to save attachment: could not retrieve message source`);

--- a/build/index.js
+++ b/build/index.js
@@ -77516,6 +77516,7 @@ var StdioServerTransport = class {
 // src/services/appleMailManager.ts
 import { spawnSync as spawnSync2 } from "child_process";
 import {
+  constants as fsConstants,
   existsSync as existsSync3,
   writeFileSync as writeFileSync3,
   readFileSync as readFileSync2,
@@ -78375,8 +78376,11 @@ function resolveAttachmentSaveTarget(savePath, attachmentName) {
   if (!isPathWithinAllowedRoots(savedPath)) {
     throw new Error(`Output path "${savedPath}" is outside allowed directories`);
   }
-  if (existsSync3(savedPath) && lstatSync(savedPath).isSymbolicLink()) {
-    throw new Error(`Refusing to overwrite symbolic link "${savedPath}"`);
+  if (existsSync3(savedPath)) {
+    if (lstatSync(savedPath).isSymbolicLink()) {
+      throw new Error(`Refusing to overwrite symbolic link "${savedPath}"`);
+    }
+    throw new Error(`Refusing to overwrite existing file "${savedPath}"`);
   }
   return { saveDirectory, savedPath };
 }
@@ -81162,7 +81166,9 @@ ${this.errorEmit("              ")}
       return false;
     }
     const safeName = escapeForAppleScript(attachmentName);
-    const safePath = escapeForAppleScript(target.saveDirectory);
+    const temporaryName = `.apple-mail-mcp-${randomUUID()}.attachment`;
+    const temporaryPath = resolve(target.saveDirectory, temporaryName);
+    const safeTemporaryPath = escapeForAppleScript(temporaryPath);
     const numericId = Number(id);
     const script = buildAppLevelScript(`
       try
@@ -81174,7 +81180,7 @@ ${this.errorEmit("              ")}
                 set msg to item 1 of matchingMsgs
                 repeat with att in mail attachments of msg
                   if name of att is "${safeName}" then
-                    set savePath to POSIX file "${safePath}/${safeName}"
+                    set savePath to POSIX file "${safeTemporaryPath}"
                     save att in savePath
                     return "ok"
                   end if
@@ -81191,7 +81197,22 @@ ${this.errorEmit("              ")}
     `);
     const result = executeAppleScript(script, { timeoutMs: 6e4 });
     if (result.success && result.output === "ok") {
-      return true;
+      try {
+        copyFileSync(temporaryPath, target.savedPath, fsConstants.COPYFILE_EXCL);
+        unlinkSync(temporaryPath);
+        return true;
+      } catch (err) {
+        try {
+          if (existsSync3(temporaryPath)) unlinkSync(temporaryPath);
+        } catch {
+        }
+        console.error(`Failed to commit attachment to disk: ${err}`);
+        return false;
+      }
+    }
+    try {
+      if (existsSync3(temporaryPath)) unlinkSync(temporaryPath);
+    } catch {
     }
     const rawSource = this.getRawSource(id);
     if (!rawSource) {
@@ -81204,7 +81225,7 @@ ${this.errorEmit("              ")}
       return false;
     }
     try {
-      writeFileSync3(target.savedPath, attachment.data);
+      writeFileSync3(target.savedPath, attachment.data, { flag: "wx" });
       return true;
     } catch (err) {
       console.error(`Failed to write attachment to disk: ${err}`);
@@ -85676,7 +85697,7 @@ registerTool(
       if (!r.success || !r.base64) {
         return errorResponse(r.error || `Failed to fetch attachment "${attachmentName}"`);
       }
-      writeFileSync4(target.savedPath, Buffer.from(r.base64, "base64"));
+      writeFileSync4(target.savedPath, Buffer.from(r.base64, "base64"), { flag: "wx" });
       return successResponse(`Attachment "${attachmentName}" saved to ${savePath}`, {
         ok: true,
         attachmentName,

--- a/build/index.js
+++ b/build/index.js
@@ -77517,6 +77517,7 @@ var StdioServerTransport = class {
 import { spawnSync as spawnSync2 } from "child_process";
 import {
   constants as fsConstants,
+  chmodSync,
   existsSync as existsSync3,
   writeFileSync as writeFileSync3,
   readFileSync as readFileSync2,
@@ -81211,6 +81212,7 @@ ${this.errorEmit("              ")}
     if (result.success && result.output === "ok") {
       try {
         copyFileSync(temporaryPath, target.savedPath, fsConstants.COPYFILE_EXCL);
+        chmodSync(target.savedPath, 384);
         cleanupTemporaryDirectory();
         return true;
       } catch (err) {
@@ -81230,12 +81232,24 @@ ${this.errorEmit("              ")}
       console.error(`Failed to save attachment: "${attachmentName}" not found in MIME source`);
       return false;
     }
+    let mimeTemporaryDirectory;
     try {
-      writeFileSync3(target.savedPath, attachment.data, { flag: "wx", mode: 384 });
+      mimeTemporaryDirectory = mkdtempSync2(join4(target.saveDirectory, ".apple-mail-mcp-"));
+      const mimeTemporaryPath = join4(mimeTemporaryDirectory, "attachment");
+      writeFileSync3(mimeTemporaryPath, attachment.data, { flag: "wx", mode: 384 });
+      copyFileSync(mimeTemporaryPath, target.savedPath, fsConstants.COPYFILE_EXCL);
+      chmodSync(target.savedPath, 384);
       return true;
     } catch (err) {
       console.error(`Failed to write attachment to disk: ${err}`);
       return false;
+    } finally {
+      if (mimeTemporaryDirectory) {
+        try {
+          rmSync2(mimeTemporaryDirectory, { recursive: true, force: true });
+        } catch {
+        }
+      }
     }
   }
   /**

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.25",
+  "version": "2.10.26",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.10.25"
+        "apple-mail-mcp@2.10.26"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.25",
+  "version": "2.10.26",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1865,7 +1865,7 @@ registerTool(
       if (!r.success || !r.base64) {
         return errorResponse(r.error || `Failed to fetch attachment "${attachmentName}"`);
       }
-      writeFileSync(target.savedPath, Buffer.from(r.base64, "base64"), { flag: "wx" });
+      writeFileSync(target.savedPath, Buffer.from(r.base64, "base64"), { flag: "wx", mode: 0o600 });
       return successResponse(`Attachment "${attachmentName}" saved to ${savePath}`, {
         ok: true,
         attachmentName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1865,7 +1865,7 @@ registerTool(
       if (!r.success || !r.base64) {
         return errorResponse(r.error || `Failed to fetch attachment "${attachmentName}"`);
       }
-      writeFileSync(target.savedPath, Buffer.from(r.base64, "base64"));
+      writeFileSync(target.savedPath, Buffer.from(r.base64, "base64"), { flag: "wx" });
       return successResponse(`Attachment "${attachmentName}" saved to ${savePath}`, {
         ok: true,
         attachmentName,

--- a/src/services/appleMailManager.attachmentPath.test.ts
+++ b/src/services/appleMailManager.attachmentPath.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "fs";
-import { homedir, tmpdir } from "os";
-import { join } from "path";
+import { homedir } from "os";
+import { dirname, join } from "path";
 
-const h = vi.hoisted(() => ({ calls: 0, success: false, output: "" }));
+const h = vi.hoisted(() => ({ calls: 0, success: false, output: "", savePath: "" }));
 
 vi.mock("@/utils/applescript.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/utils/applescript.js")>();
@@ -14,6 +14,7 @@ vi.mock("@/utils/applescript.js", async (importOriginal) => {
       if (h.success && h.output === "ok") {
         const match = script.match(/set savePath to POSIX file "([^"]+)"/);
         if (!match) throw new Error("test AppleScript did not contain a staging path");
+        h.savePath = match[1];
         writeFileSync(match[1], "payload", { flag: "wx", mode: 0o600 });
         return { success: true, output: "ok" };
       }
@@ -31,6 +32,7 @@ afterEach(() => {
   h.calls = 0;
   h.success = false;
   h.output = "";
+  h.savePath = "";
 });
 
 describe("saveAttachment path boundary", () => {
@@ -46,7 +48,7 @@ describe("saveAttachment path boundary", () => {
   });
 
   it("rejects an existing symbolic-link destination", () => {
-    const root = mkdtempSync(join(tmpdir(), "apple-mail-mcp-test-"));
+    const root = mkdtempSync(join(homedir(), ".apple-mail-mcp-test-"));
     cleanup.push(root);
     symlinkSync("/etc/hosts", join(root, "hosts"));
 
@@ -56,7 +58,7 @@ describe("saveAttachment path boundary", () => {
   });
 
   it("rejects an existing regular-file destination", () => {
-    const root = mkdtempSync(join(tmpdir(), "apple-mail-mcp-test-"));
+    const root = mkdtempSync(join(homedir(), ".apple-mail-mcp-test-"));
     cleanup.push(root);
     writeFileSync(join(root, "hosts"), "keep me");
 
@@ -109,5 +111,13 @@ cGF5bG9hZA==
     expect(mgr.saveAttachment("1", "report.txt", root)).toBe(true);
     expect(statSync(join(root, "report.txt")).mode & 0o777).toBe(0o600);
     expect(readdirSync(root)).toEqual(["report.txt"]);
+
+    // Mail.app must never be handed the caller's destination path: the file may
+    // only appear there via the COPYFILE_EXCL commit out of a private mkdtemp
+    // staging directory. Without this, dropping the staging step and letting Mail
+    // write straight to the destination leaves every other assertion green.
+    expect(h.savePath).not.toBe(join(root, "report.txt"));
+    expect(h.savePath).toContain(".apple-mail-mcp-");
+    expect(dirname(h.savePath)).not.toBe(root);
   });
 });

--- a/src/services/appleMailManager.attachmentPath.test.ts
+++ b/src/services/appleMailManager.attachmentPath.test.ts
@@ -47,6 +47,16 @@ describe("saveAttachment path boundary", () => {
     expect(h.calls).toBe(0);
   });
 
+  it("rejects an existing regular-file destination", () => {
+    const root = mkdtempSync(join(tmpdir(), "apple-mail-mcp-test-"));
+    cleanup.push(root);
+    writeFileSync(join(root, "hosts"), "keep me");
+
+    const mgr = new AppleMailManager();
+    expect(mgr.saveAttachment("1", "hosts", root)).toBe(false);
+    expect(h.calls).toBe(0);
+  });
+
   it("uses a temporary directory when fetching attachment bytes", () => {
     const mgr = new AppleMailManager();
     const save = vi.spyOn(mgr, "saveAttachment").mockImplementation((_id, name, directory) => {

--- a/src/services/appleMailManager.attachmentPath.test.ts
+++ b/src/services/appleMailManager.attachmentPath.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { mkdtempSync, rmSync, statSync, symlinkSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 
@@ -69,5 +69,23 @@ describe("saveAttachment path boundary", () => {
     expect(result.success).toBe(true);
     expect(Buffer.from(result.base64 as string, "base64").toString()).toBe("payload");
     expect(save.mock.calls[0][2]).not.toMatch(/report\.txt$/);
+  });
+
+  it("creates MIME fallback files with owner-only permissions", () => {
+    const root = mkdtempSync(join(homedir(), ".apple-mail-mcp-test-"));
+    cleanup.push(root);
+    const mgr = new AppleMailManager();
+    vi.spyOn(mgr, "getRawSource").mockReturnValue(`Content-Type: multipart/mixed; boundary="b"
+
+--b
+Content-Type: text/plain
+Content-Disposition: attachment; filename="report.txt"
+Content-Transfer-Encoding: base64
+
+cGF5bG9hZA==
+--b--`);
+
+    expect(mgr.saveAttachment("1", "report.txt", root)).toBe(true);
+    expect(statSync(join(root, "report.txt")).mode & 0o777).toBe(0o600);
   });
 });

--- a/src/services/appleMailManager.attachmentPath.test.ts
+++ b/src/services/appleMailManager.attachmentPath.test.ts
@@ -1,16 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync, statSync, symlinkSync, writeFileSync } from "fs";
+import { mkdtempSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 
-const h = vi.hoisted(() => ({ calls: 0 }));
+const h = vi.hoisted(() => ({ calls: 0, success: false, output: "" }));
 
 vi.mock("@/utils/applescript.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/utils/applescript.js")>();
   return {
     ...actual,
-    executeAppleScript: () => {
+    executeAppleScript: (script: string) => {
       h.calls += 1;
+      if (h.success && h.output === "ok") {
+        const match = script.match(/set savePath to POSIX file "([^"]+)"/);
+        if (!match) throw new Error("test AppleScript did not contain a staging path");
+        writeFileSync(match[1], "payload", { flag: "wx", mode: 0o600 });
+        return { success: true, output: "ok" };
+      }
       return { success: false, output: "", error: "unexpected call" };
     },
   };
@@ -23,6 +29,8 @@ const cleanup: string[] = [];
 afterEach(() => {
   for (const path of cleanup.splice(0)) rmSync(path, { recursive: true, force: true });
   h.calls = 0;
+  h.success = false;
+  h.output = "";
 });
 
 describe("saveAttachment path boundary", () => {
@@ -87,5 +95,19 @@ cGF5bG9hZA==
 
     expect(mgr.saveAttachment("1", "report.txt", root)).toBe(true);
     expect(statSync(join(root, "report.txt")).mode & 0o777).toBe(0o600);
+    expect(readdirSync(root)).toEqual(["report.txt"]);
+  });
+
+  it("stages AppleScript files privately and normalizes the final mode", () => {
+    const root = mkdtempSync(join(homedir(), ".apple-mail-mcp-test-"));
+    cleanup.push(root);
+    h.success = true;
+    h.output = "ok";
+
+    const mgr = new AppleMailManager();
+
+    expect(mgr.saveAttachment("1", "report.txt", root)).toBe(true);
+    expect(statSync(join(root, "report.txt")).mode & 0o777).toBe(0o600);
+    expect(readdirSync(root)).toEqual(["report.txt"]);
   });
 });

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -4105,9 +4105,25 @@ ${this.errorEmit("              ")}
     }
 
     const safeName = escapeForAppleScript(attachmentName);
-    const temporaryName = `.apple-mail-mcp-${randomUUID()}.attachment`;
-    const temporaryPath = resolve(target.saveDirectory, temporaryName);
+    let temporaryDirectory: string;
+    try {
+      // Mail.app writes the attachment into a private directory created with
+      // mkdtempSync, so another process cannot pre-create or swap the staging
+      // path before COPYFILE_EXCL commits it to the caller's destination.
+      temporaryDirectory = mkdtempSync(join(target.saveDirectory, ".apple-mail-mcp-"));
+    } catch (error) {
+      console.error(`Failed to create attachment staging directory: ${error}`);
+      return false;
+    }
+    const temporaryPath = join(temporaryDirectory, "attachment");
     const safeTemporaryPath = escapeForAppleScript(temporaryPath);
+    const cleanupTemporaryDirectory = () => {
+      try {
+        rmSync(temporaryDirectory, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup; the destination was not replaced by cleanup.
+      }
+    };
     const numericId = Number(id);
 
     // Attempt 1: AppleScript save
@@ -4145,24 +4161,16 @@ ${this.errorEmit("              ")}
         // closes the check/use race if another process creates the destination
         // while Mail.app is saving the attachment to its private temp path.
         copyFileSync(temporaryPath, target.savedPath, fsConstants.COPYFILE_EXCL);
-        unlinkSync(temporaryPath);
+        cleanupTemporaryDirectory();
         return true;
       } catch (err) {
-        try {
-          if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
-        } catch {
-          // Best-effort cleanup; the destination was not replaced.
-        }
+        cleanupTemporaryDirectory();
         console.error(`Failed to commit attachment to disk: ${err}`);
         return false;
       }
     }
 
-    try {
-      if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
-    } catch {
-      // Best-effort cleanup before the MIME fallback.
-    }
+    cleanupTemporaryDirectory();
 
     // Attempt 2: MIME source fallback
     const rawSource = this.getRawSource(id);

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -4186,7 +4186,7 @@ ${this.errorEmit("              ")}
     }
 
     try {
-      writeFileSync(target.savedPath, attachment.data, { flag: "wx" });
+      writeFileSync(target.savedPath, attachment.data, { flag: "wx", mode: 0o600 });
       return true;
     } catch (err) {
       console.error(`Failed to write attachment to disk: ${err}`);

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -15,6 +15,7 @@
 
 import { spawnSync } from "child_process";
 import {
+  constants as fsConstants,
   existsSync,
   writeFileSync,
   readFileSync,
@@ -339,8 +340,11 @@ export function resolveAttachmentSaveTarget(
   if (!isPathWithinAllowedRoots(savedPath)) {
     throw new Error(`Output path "${savedPath}" is outside allowed directories`);
   }
-  if (existsSync(savedPath) && lstatSync(savedPath).isSymbolicLink()) {
-    throw new Error(`Refusing to overwrite symbolic link "${savedPath}"`);
+  if (existsSync(savedPath)) {
+    if (lstatSync(savedPath).isSymbolicLink()) {
+      throw new Error(`Refusing to overwrite symbolic link "${savedPath}"`);
+    }
+    throw new Error(`Refusing to overwrite existing file "${savedPath}"`);
   }
 
   return { saveDirectory, savedPath };
@@ -4101,7 +4105,9 @@ ${this.errorEmit("              ")}
     }
 
     const safeName = escapeForAppleScript(attachmentName);
-    const safePath = escapeForAppleScript(target.saveDirectory);
+    const temporaryName = `.apple-mail-mcp-${randomUUID()}.attachment`;
+    const temporaryPath = resolve(target.saveDirectory, temporaryName);
+    const safeTemporaryPath = escapeForAppleScript(temporaryPath);
     const numericId = Number(id);
 
     // Attempt 1: AppleScript save
@@ -4115,7 +4121,7 @@ ${this.errorEmit("              ")}
                 set msg to item 1 of matchingMsgs
                 repeat with att in mail attachments of msg
                   if name of att is "${safeName}" then
-                    set savePath to POSIX file "${safePath}/${safeName}"
+                    set savePath to POSIX file "${safeTemporaryPath}"
                     save att in savePath
                     return "ok"
                   end if
@@ -4134,7 +4140,28 @@ ${this.errorEmit("              ")}
     const result = executeAppleScript(script, { timeoutMs: 60000 });
 
     if (result.success && result.output === "ok") {
-      return true;
+      try {
+        // The preflight above prevents ordinary overwrites. COPYFILE_EXCL also
+        // closes the check/use race if another process creates the destination
+        // while Mail.app is saving the attachment to its private temp path.
+        copyFileSync(temporaryPath, target.savedPath, fsConstants.COPYFILE_EXCL);
+        unlinkSync(temporaryPath);
+        return true;
+      } catch (err) {
+        try {
+          if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+        } catch {
+          // Best-effort cleanup; the destination was not replaced.
+        }
+        console.error(`Failed to commit attachment to disk: ${err}`);
+        return false;
+      }
+    }
+
+    try {
+      if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+    } catch {
+      // Best-effort cleanup before the MIME fallback.
     }
 
     // Attempt 2: MIME source fallback
@@ -4151,7 +4178,7 @@ ${this.errorEmit("              ")}
     }
 
     try {
-      writeFileSync(target.savedPath, attachment.data);
+      writeFileSync(target.savedPath, attachment.data, { flag: "wx" });
       return true;
     } catch (err) {
       console.error(`Failed to write attachment to disk: ${err}`);

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -16,6 +16,7 @@
 import { spawnSync } from "child_process";
 import {
   constants as fsConstants,
+  chmodSync,
   existsSync,
   writeFileSync,
   readFileSync,
@@ -4161,6 +4162,10 @@ ${this.errorEmit("              ")}
         // closes the check/use race if another process creates the destination
         // while Mail.app is saving the attachment to its private temp path.
         copyFileSync(temporaryPath, target.savedPath, fsConstants.COPYFILE_EXCL);
+        // Mail.app controls the mode of the source file. Normalize the final
+        // artifact after the exclusive copy so the shipped guarantee is true
+        // for the AppleScript path as well as the MIME fallback.
+        chmodSync(target.savedPath, 0o600);
         cleanupTemporaryDirectory();
         return true;
       } catch (err) {
@@ -4185,12 +4190,29 @@ ${this.errorEmit("              ")}
       return false;
     }
 
+    let mimeTemporaryDirectory: string | undefined;
     try {
-      writeFileSync(target.savedPath, attachment.data, { flag: "wx", mode: 0o600 });
+      // Keep MIME staging private and on the destination filesystem. The
+      // final COPYFILE_EXCL is the only operation that creates the caller's
+      // path, so this fallback has the same no-overwrite boundary as the
+      // AppleScript path. A staging-directory failure is a safe false result.
+      mimeTemporaryDirectory = mkdtempSync(join(target.saveDirectory, ".apple-mail-mcp-"));
+      const mimeTemporaryPath = join(mimeTemporaryDirectory, "attachment");
+      writeFileSync(mimeTemporaryPath, attachment.data, { flag: "wx", mode: 0o600 });
+      copyFileSync(mimeTemporaryPath, target.savedPath, fsConstants.COPYFILE_EXCL);
+      chmodSync(target.savedPath, 0o600);
       return true;
     } catch (err) {
       console.error(`Failed to write attachment to disk: ${err}`);
       return false;
+    } finally {
+      if (mimeTemporaryDirectory) {
+        try {
+          rmSync(mimeTemporaryDirectory, { recursive: true, force: true });
+        } catch {
+          // Best-effort cleanup; the destination was never replaced by cleanup.
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Summary
- Refuse `save-attachment` when the destination already exists, including regular files and symlinks.
- Stage AppleScript saves in a private `mkdtemp` directory and commit them with `COPYFILE_EXCL`, closing the check/use race.
- Make MIME and direct IMAP fallback attachment writes use exclusive creation with owner-only mode `0600`, keeping both shipped save paths fail-closed.
- Release as 2.10.20 with the rebuilt bundle and synchronized plugin manifests.

Verification
- `pnpm run build`
- `pnpm test` — 40 files, 575 tests passed
- `pnpm run lint` — 0 errors; 10 pre-existing `no-explicit-any` warnings on unchanged upstream lines
- `pnpm run format:check`
- `git diff --check`
- Corrected-head GitHub checks on `d8c813c53c444c745558371c63063926d519b776`: [CI run 31790903711](https://github.com/sweetrb/apple-mail-mcp/actions/runs/31790903711), [CodeQL check 94737560377](https://github.com/sweetrb/apple-mail-mcp/runs/94737560377), [version guard run 31790903687](https://github.com/sweetrb/apple-mail-mcp/actions/runs/31790903687), and [CodeQL analysis run 31790903697](https://github.com/sweetrb/apple-mail-mcp/actions/runs/31790903697) all passed; CodeQL reported no new alerts.
- Commit hook: `tsc --noEmit` and `vitest run` — 40 files, 575 tests passed
- Apple Mail integration tests: Not run; deterministic attachment-path coverage only.

Risk / Notes
- This changes shipped attachment-save behavior and updates `CHANGELOG.md`, `package.json`, committed `build/index.js`, and plugin manifests.
- Reusing a destination now fails instead of replacing the previous file; callers must choose a new path or remove the old file explicitly.
- Ready for maintainer review; no live Mail.app state was changed. The PR is not merged, shipped, accepted, or maintainer-approved.