### PR TITLE
fix: cap IMAP attachment fetches

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.17",
+      "version": "2.10.21",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.17",
+      "version": "2.10.21",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.17",
+  "version": "2.10.21",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.17",
+  "version": "2.10.21",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.17",
+      "version": "2.10.21",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.17",
+  "version": "2.10.21",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [2.10.21] - 2026-08-14
+
+### Fixed
+
+- **IMAP attachment fetches are capped at 25 MiB, matching inline attachment limits.** Declared oversized parts are rejected before download, and streamed data is bounded even when the server's BODYSTRUCTURE size is missing or inaccurate.
+
 ## [2.10.17] - 2026-08-13
 
 Instrumentation for [#155](https://github.com/sweetrb/apple-mail-mcp/issues/155) — the unexplained residual from #152, where a batch delete removed two messages whose ids were never passed. #153/#154 fixed a real mis-targeting defect, but that mechanism explains acting on the wrong *copy of a listed message*; it does not explain acting on a message nobody named. That symptom is unreproducible today for one reason: **a destructive operation reported success because the AppleScript did not throw, never because a message was observed to go away.** This release makes every delete and move check its own effect.

--- a/README.md
+++ b/README.md
@@ -1597,6 +1597,7 @@ The entrypoint is written as:
 | Date filter format | Date filters must be valid parseable dates (e.g., "January 1, 2026" or "2026-03-15"); bare numbers or non-date strings are rejected |
 | Attachment save path restrictions | `save-attachment` only allows saving to home directory, `/tmp`, `/private/tmp`, and `/Volumes`; path traversal is blocked |
 | Attachment count limit | `send-email` and `create-draft` accept a maximum of 20 file attachments |
+| IMAP attachment fetch size | `fetch-attachment` / `save-attachment` over IMAP refuse a part larger than 25 MiB — rejected before download when the server declares the size, and the stream is cut off at the limit when it does not |
 
 ### Mail.app `<blockquote>` wrapping on macOS 15+ (workaround in v1.6.0)
 

--- a/build/index.js
+++ b/build/index.js
@@ -78057,6 +78057,7 @@ import { tmpdir } from "os";
 
 // src/utils/attachmentLimits.ts
 var MAX_INLINE_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+var MAX_IMAP_ATTACHMENT_BYTES = MAX_INLINE_ATTACHMENT_BYTES;
 var MAX_INLINE_ATTACHMENT_BASE64_CHARS = Math.ceil(MAX_INLINE_ATTACHMENT_BYTES / 3) * 4;
 var MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS = MAX_INLINE_ATTACHMENT_BASE64_CHARS * 2;
 function isInlineAttachmentBase64WithinLimit(contentBase64) {
@@ -83454,9 +83455,16 @@ function collectAttachments(node, out = []) {
   for (const child of node.childNodes ?? []) collectAttachments(child, out);
   return out;
 }
-async function streamToBuffer(content) {
+async function streamToBuffer(content, maxBytes) {
   const chunks = [];
-  for await (const chunk of content) chunks.push(Buffer.from(chunk));
+  let total = 0;
+  for await (const chunk of content) {
+    total += chunk.byteLength;
+    if (total > maxBytes) {
+      throw new Error(`IMAP attachment exceeds the ${maxBytes / 1024 / 1024} MiB size limit.`);
+    }
+    chunks.push(Buffer.from(chunk));
+  }
   return Buffer.concat(chunks);
 }
 async function imapListAttachments(id, deps = {}) {
@@ -83493,14 +83501,24 @@ async function imapFetchAttachment(id, attachmentName, deps = {}) {
         error: `Attachment "${attachmentName}" not found on UID ${ref.uid}. Available: ${names}.`
       };
     }
-    const dl = await client.download(String(ref.uid), match.part, { uid: true });
-    const buf = await streamToBuffer(dl.content);
-    return {
-      success: true,
-      base64: buf.toString("base64"),
-      bytes: buf.length,
-      mimeType: match.mimeType
-    };
+    if (match.size > MAX_IMAP_ATTACHMENT_BYTES) {
+      return {
+        success: false,
+        error: `IMAP attachment "${attachmentName}" is ${match.size} bytes; the maximum is ${MAX_IMAP_ATTACHMENT_BYTES} bytes (25 MiB).`
+      };
+    }
+    try {
+      const dl = await client.download(String(ref.uid), match.part, { uid: true });
+      const buf = await streamToBuffer(dl.content, MAX_IMAP_ATTACHMENT_BYTES);
+      return {
+        success: true,
+        base64: buf.toString("base64"),
+        bytes: buf.length,
+        mimeType: match.mimeType
+      };
+    } catch (e) {
+      return { success: false, error: `IMAP attachment fetch failed: ${errText(e)}` };
+    }
   });
 }
 async function imapBatch(ids, deps, op) {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.17",
+  "version": "2.10.21",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.17",
+  "version": "2.10.21",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -37,6 +37,7 @@ import {
   type ImapClientLike,
   type ImapConfig,
 } from "@/services/imapClient.js";
+import { MAX_IMAP_ATTACHMENT_BYTES } from "@/utils/attachmentLimits.js";
 
 const cfg: ImapConfig = {
   host: "imap.gmail.com",
@@ -1007,6 +1008,61 @@ describe("attachments via BODYSTRUCTURE (I1)", () => {
     expect(r.success).toBe(true);
     expect(Buffer.from(r.base64 as string, "base64").toString()).toBe("bytes-of-2");
     expect(r.mimeType).toBe("application/pdf");
+  });
+
+  it("rejects a BODYSTRUCTURE attachment above the fetch limit before downloading", async () => {
+    let downloaded = false;
+    const base = attClient();
+    const client: ImapClientLike = {
+      ...base,
+      fetchOne: async () => ({
+        uid: 9,
+        bodyStructure: {
+          type: "multipart/mixed",
+          childNodes: [
+            {
+              part: "2",
+              type: "application/pdf",
+              disposition: "attachment",
+              dispositionParameters: { filename: "report.pdf" },
+              size: MAX_IMAP_ATTACHMENT_BYTES + 1,
+            },
+          ],
+        },
+      }),
+      download: async () => {
+        downloaded = true;
+        return { content: (async function* () {})() };
+      },
+    };
+
+    const r = await imapFetchAttachment(MID, "report.pdf", {
+      config: cfg,
+      connect: async () => client,
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/25 MiB/i);
+    expect(downloaded).toBe(false);
+  });
+
+  it("stops a streamed attachment when it crosses the fetch limit", async () => {
+    const base = attClient();
+    const client: ImapClientLike = {
+      ...base,
+      download: async () => ({
+        content: (async function* () {
+          yield Buffer.alloc(MAX_IMAP_ATTACHMENT_BYTES);
+          yield Buffer.from([0]);
+        })(),
+      }),
+    };
+
+    const r = await imapFetchAttachment(MID, "report.pdf", {
+      config: cfg,
+      connect: async () => client,
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/25 MiB/i);
   });
 
   it("errors clearly when the attachment name isn't found", async () => {

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -29,6 +29,7 @@ import { ImapFlow } from "imapflow";
 import { readKeychainPassword } from "@/services/smtpMailer.js";
 import { SETUP_HINT } from "@/utils/docsUrls.js";
 import { extractHtmlBody, extractTextBody } from "@/utils/mimeParse.js";
+import { MAX_IMAP_ATTACHMENT_BYTES } from "@/utils/attachmentLimits.js";
 
 export const IMAP_ENV = {
   user: "APPLE_MAIL_MCP_IMAP_USER",
@@ -1440,9 +1441,19 @@ function collectAttachments(node: ImapBodyStructure, out: AttachmentPart[] = [])
   return out;
 }
 
-async function streamToBuffer(content: AsyncIterable<Uint8Array>): Promise<Buffer> {
+async function streamToBuffer(
+  content: AsyncIterable<Uint8Array>,
+  maxBytes: number
+): Promise<Buffer> {
   const chunks: Buffer[] = [];
-  for await (const chunk of content) chunks.push(Buffer.from(chunk));
+  let total = 0;
+  for await (const chunk of content) {
+    total += chunk.byteLength;
+    if (total > maxBytes) {
+      throw new Error(`IMAP attachment exceeds the ${maxBytes / 1024 / 1024} MiB size limit.`);
+    }
+    chunks.push(Buffer.from(chunk));
+  }
   return Buffer.concat(chunks);
 }
 
@@ -1496,14 +1507,24 @@ export async function imapFetchAttachment(
         error: `Attachment "${attachmentName}" not found on UID ${ref.uid}. Available: ${names}.`,
       };
     }
-    const dl = await client.download(String(ref.uid), match.part, { uid: true });
-    const buf = await streamToBuffer(dl.content);
-    return {
-      success: true,
-      base64: buf.toString("base64"),
-      bytes: buf.length,
-      mimeType: match.mimeType,
-    };
+    if (match.size > MAX_IMAP_ATTACHMENT_BYTES) {
+      return {
+        success: false,
+        error: `IMAP attachment "${attachmentName}" is ${match.size} bytes; the maximum is ${MAX_IMAP_ATTACHMENT_BYTES} bytes (25 MiB).`,
+      };
+    }
+    try {
+      const dl = await client.download(String(ref.uid), match.part, { uid: true });
+      const buf = await streamToBuffer(dl.content, MAX_IMAP_ATTACHMENT_BYTES);
+      return {
+        success: true,
+        base64: buf.toString("base64"),
+        bytes: buf.length,
+        mimeType: match.mimeType,
+      };
+    } catch (e) {
+      return { success: false, error: `IMAP attachment fetch failed: ${errText(e)}` };
+    }
   });
 }
 

--- a/src/utils/attachmentLimits.ts
+++ b/src/utils/attachmentLimits.ts
@@ -1,6 +1,9 @@
 /** Maximum decoded size of one inline attachment (25 MiB). */
 export const MAX_INLINE_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 
+/** Maximum size fetched from IMAP for one attachment (25 MiB). */
+export const MAX_IMAP_ATTACHMENT_BYTES = MAX_INLINE_ATTACHMENT_BYTES;
+
 /** Maximum base64 length capable of representing the decoded byte limit. */
 export const MAX_INLINE_ATTACHMENT_BASE64_CHARS = Math.ceil(MAX_INLINE_ATTACHMENT_BYTES / 3) * 4;
 


### PR DESCRIPTION
Summary
- Cap IMAP attachment fetches at 25 MiB, matching the existing inline attachment limit.
- Reject a declared oversized BODYSTRUCTURE part before calling `download`.
- Enforce the same bound while streaming so a missing or inaccurate server size cannot cause an unbounded buffer; release as 2.10.21 with the rebuilt bundle and synchronized plugin manifests.

Verification
- `pnpm run build`
- `pnpm test` — 40 files, 575 tests passed
- `pnpm run lint` — 0 errors; 10 existing `no-explicit-any` warnings
- `pnpm run format:check`
- `git diff --check`
- Commit hook: `tsc --noEmit` and `vitest run` — 40 files, 575 tests passed
- Apple Mail integration tests: Not run; IMAP client tests use deterministic mock clients.

Risk / Notes
- This changes shipped IMAP `fetch-attachment` behavior and updates `CHANGELOG.md`, `package.json`, committed `build/index.js`, and plugin manifests.
- Attachments over 25 MiB now fail with an explicit limit error rather than being returned inline or written by `save-attachment`.
- Open for maintainer review; no live IMAP or Mail state was changed. The PR is not merged, shipped, accepted, or maintainer-approved.