### PR TITLE
fix: keep IMAP deletes recoverable

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.17",
+      "version": "2.10.22",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.17",
+      "version": "2.10.22",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.17",
+  "version": "2.10.22",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.17",
+  "version": "2.10.22",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.17",
+      "version": "2.10.22",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.17",
+  "version": "2.10.22",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [2.10.22] - 2026-08-14
+
+### Fixed
+
+- **IMAP delete is recoverable-only.** Messages already in Trash are now refused instead of being permanently expunged, and single and batch delete report the refusal without issuing an IMAP delete command.
+
 ## [2.10.17] - 2026-08-13
 
 Instrumentation for [#155](https://github.com/sweetrb/apple-mail-mcp/issues/155) — the unexplained residual from #152, where a batch delete removed two messages whose ids were never passed. #153/#154 fixed a real mis-targeting defect, but that mechanism explains acting on the wrong *copy of a listed message*; it does not explain acting on a message nobody named. That symptom is unreproducible today for one reason: **a destructive operation reported success because the AppleScript did not throw, never because a message was observed to go away.** This release makes every delete and move check its own effect.

--- a/build/index.js
+++ b/build/index.js
@@ -83417,21 +83417,22 @@ async function resolveTrashPath(client) {
 async function trashUids(client, uids, srcPath) {
   const dest = await resolveTrashPath(client);
   if (srcPath.trim().toLowerCase() === dest.trim().toLowerCase()) {
-    await client.messageDelete(uids, { uid: true });
-    return { dest, expunged: true };
+    throw new Error(
+      `Refusing to permanently delete messages already in Trash ("${srcPath}"). Delete operations are recoverable-only.`
+    );
   }
   await client.messageMove(uids, dest, { uid: true });
-  return { dest, expunged: false };
+  return { dest };
 }
 async function imapDeleteMessageById(id, deps = {}) {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
   return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
     try {
-      const { dest, expunged } = await trashUids(client, [ref.uid], ref.path);
+      const { dest } = await trashUids(client, [ref.uid], ref.path);
       return {
         success: true,
-        info: expunged ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP.` : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`
+        info: `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`
       };
     } catch (e) {
       return { success: false, error: `IMAP delete failed for UID ${ref.uid}: ${errText(e)}` };

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.17",
+  "version": "2.10.22",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.17",
+  "version": "2.10.22",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -27,6 +27,7 @@ import {
   imapListAttachments,
   imapFetchAttachment,
   imapBatchMarkRead,
+  imapBatchDelete,
   imapBatchMove,
   imapThread,
   listImapAccountLabels,
@@ -751,15 +752,29 @@ describe("IMAP message mutations (#43 Phase 3)", () => {
     expect(rec.moved).toEqual([[1], "Deleted Messages"]);
   });
 
-  it("delete from within Trash permanently expunges (empty-from-Trash)", async () => {
+  it("refuses to permanently delete a message already in Trash", async () => {
     const rec: MsgRec = {};
     const trashId = encodeImapId("iCloud", "[Gmail]/Trash", 1);
     const r = await imapDeleteMessageById(trashId, {
       config: cfg,
       connect: async () => makeMsgClient(rec),
     });
-    expect(r.success).toBe(true);
-    expect(rec.deleted).toEqual([1]);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/recoverable-only/i);
+    expect(rec.deleted).toBeUndefined();
+    expect(rec.moved).toBeUndefined();
+  });
+
+  it("reports a recoverability failure for a batch already in Trash", async () => {
+    const rec: MsgRec = {};
+    const trashId = encodeImapId("iCloud", "[Gmail]/Trash", 1);
+    const r = await imapBatchDelete([trashId], {
+      config: cfg,
+      connect: async () => makeMsgClient(rec),
+    });
+    expect(r).toMatchObject({ success: 0, failed: 1 });
+    expect(r.errors.join(" ")).toMatch(/recoverable-only/i);
+    expect(rec.deleted).toBeUndefined();
     expect(rec.moved).toBeUndefined();
   });
 

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -1359,22 +1359,22 @@ async function resolveTrashPath(client: ImapClientLike): Promise<string> {
 
 /**
  * Trash a set of UIDs from the currently-selected `srcPath`: move them to the
- * account's Trash mailbox (recoverable). If the messages are *already* in Trash,
- * expunge them instead (the "empty from Trash" case). Returns the resolved
- * destination and whether it expunged.
+ * account's Trash mailbox (recoverable). Messages already in Trash are refused
+ * rather than expunged, because this tool's delete contract is recoverable-only.
  */
 async function trashUids(
   client: ImapClientLike,
   uids: number[],
   srcPath: string
-): Promise<{ dest: string; expunged: boolean }> {
+): Promise<{ dest: string }> {
   const dest = await resolveTrashPath(client);
   if (srcPath.trim().toLowerCase() === dest.trim().toLowerCase()) {
-    await client.messageDelete(uids, { uid: true });
-    return { dest, expunged: true };
+    throw new Error(
+      `Refusing to permanently delete messages already in Trash ("${srcPath}"). Delete operations are recoverable-only.`
+    );
   }
   await client.messageMove(uids, dest, { uid: true });
-  return { dest, expunged: false };
+  return { dest };
 }
 
 export async function imapDeleteMessageById(
@@ -1385,12 +1385,10 @@ export async function imapDeleteMessageById(
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
   return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
     try {
-      const { dest, expunged } = await trashUids(client, [ref.uid], ref.path);
+      const { dest } = await trashUids(client, [ref.uid], ref.path);
       return {
         success: true,
-        info: expunged
-          ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP.`
-          : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`,
+        info: `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`,
       };
     } catch (e) {
       return { success: false, error: `IMAP delete failed for UID ${ref.uid}: ${errText(e)}` };


### PR DESCRIPTION
Summary
- Make IMAP `delete-message` and `batch-delete-messages` recoverable-only.
- Refuse messages already in Trash instead of issuing `messageDelete`/EXPUNGE, and report the refusal through the existing single and batch error paths.
- Add regression coverage proving neither operation issues a destructive delete command; release as 2.10.22 with the rebuilt bundle and synchronized plugin manifests.

Verification
- `pnpm run build`
- `pnpm test` — 40 files, 574 tests passed
- `pnpm run lint` — 0 errors; 10 existing `no-explicit-any` warnings
- `pnpm run format:check`
- `git diff --check`
- Commit hook: `tsc --noEmit` and `vitest run` — 40 files, 574 tests passed
- Live IMAP integration: Not run; deterministic client mocks only.

Risk / Notes
- This changes shipped IMAP delete behavior and updates `CHANGELOG.md`, `package.json`, committed `build/index.js`, and plugin manifests.
- Deleting from Trash now fails safely; it cannot be used to empty Trash. There is no permanent-delete tool in this patch.
- Open for maintainer review; no live IMAP state was changed. The PR is not merged, shipped, accepted, or maintainer-approved.