### PR TITLE
fix: disable new mail rules by default

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.26",
+      "version": "2.10.27",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.26",
+      "version": "2.10.27",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.26",
+  "version": "2.10.27",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.26",
+  "version": "2.10.27",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.26",
+      "version": "2.10.27",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.26",
+  "version": "2.10.27",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+## [2.10.27] - 2026-08-14
+
+### Changed
+
+- **New Mail rules are disabled by default.** `create-rule` now creates a rule
+  with `enabled: false`; callers must review it with `list-rules` and Mail.app,
+  then explicitly enable it with `enable-rule` when the behavior is intended.
+
 ## [2.10.26] - 2026-08-14
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -1085,9 +1085,14 @@ Create a Mail rule with one or more conditions and actions.
 | `conditions` | object[] | Yes | One or more `{field, operator, value}` (see below) |
 | `actions` | object | Yes | At least one of `markRead`, `markFlagged`, `delete`, `moveTo` |
 | `matchAll` | boolean | No | `true` (default) = all conditions must match; `false` = any |
-| `enabled` | boolean | No | Whether the rule is enabled on creation (default `true`) |
+| `enabled` | boolean | No | Whether the rule is enabled on creation (default `false`) |
 
 Each condition is `{ field, operator, value }` where `field` is one of `from`, `to`, `cc`, `subject`, `content` and `operator` is one of `contains`, `notContains`, `equals`, `beginsWith`, `endsWith`. Actions: `markRead` / `markFlagged` / `delete` (booleans), `moveTo` (mailbox name) with optional `moveToAccount`.
+
+New rules are created **disabled by default**, including rules that delete or move
+messages. Review the conditions and actions with `list-rules` and in Mail.app,
+then call `enable-rule` explicitly when the rule is approved. Set
+`enabled: true` only when immediate activation is deliberate.
 
 **Example:**
 ```json

--- a/build/index.js
+++ b/build/index.js
@@ -82068,7 +82068,7 @@ end tell`;
     if (!actionStmts.length) {
       return { success: false, error: "A rule needs at least one action." };
     }
-    const enabled = opts.enabled !== false;
+    const enabled = opts.enabled === true;
     const matchAll = opts.matchAll !== false;
     const script = buildAppLevelScript(`
       try
@@ -86249,7 +86249,7 @@ registerTool(
         "At least one action is required (markRead, markFlagged, delete, or moveTo)"
       ),
       matchAll: external_exports.boolean().default(true),
-      enabled: external_exports.boolean().default(true)
+      enabled: external_exports.boolean().default(false).describe("Enable immediately; defaults to false so the rule must be reviewed first")
     },
     outputSchema: {
       name: external_exports.string().optional(),

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.26",
+  "version": "2.10.27",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.10.26"
+        "apple-mail-mcp@2.10.27"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.26",
+  "version": "2.10.27",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2546,7 +2546,10 @@ registerTool(
           "At least one action is required (markRead, markFlagged, delete, or moveTo)"
         ),
       matchAll: z.boolean().default(true),
-      enabled: z.boolean().default(true),
+      enabled: z
+        .boolean()
+        .default(false)
+        .describe("Enable immediately; defaults to false so the rule must be reviewed first"),
     },
     outputSchema: {
       name: z.string().optional(),

--- a/src/services/appleMailManager.ruleSafety.test.ts
+++ b/src/services/appleMailManager.ruleSafety.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Regression guards for rule creation safety.
+ *
+ * Mail rules can act on future messages without another MCP call. Creating
+ * them disabled by default gives the user a review point before automation
+ * starts. executeAppleScript is mocked, so this test only inspects the rule
+ * properties sent to Mail.app.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const h = vi.hoisted(() => ({ calls: [] as string[] }));
+
+vi.mock("@/utils/applescript.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/applescript.js")>();
+  return {
+    ...actual,
+    executeAppleScript: (script: string) => {
+      h.calls.push(script);
+      return { success: true, output: "ok", error: undefined as string | undefined };
+    },
+  };
+});
+
+import { AppleMailManager } from "@/services/appleMailManager.js";
+
+const spec = {
+  name: "Review before automation",
+  conditions: [{ field: "subject" as const, operator: "contains" as const, value: "invoice" }],
+  actions: { delete: true },
+};
+
+describe("mail rule creation safety", () => {
+  let mgr: AppleMailManager;
+
+  beforeEach(() => {
+    h.calls.length = 0;
+    mgr = new AppleMailManager();
+  });
+
+  it("creates a new rule disabled when enabled is omitted", () => {
+    expect(mgr.createRule(spec)).toEqual({ success: true });
+    expect(h.calls.at(-1)).toContain("enabled:false");
+  });
+
+  it("allows an explicit review-approved enabled rule", () => {
+    expect(mgr.createRule({ ...spec, enabled: true })).toEqual({ success: true });
+    expect(h.calls.at(-1)).toContain("enabled:true");
+  });
+});

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -5260,7 +5260,7 @@ end tell`;
       return { success: false, error: "A rule needs at least one action." };
     }
 
-    const enabled = opts.enabled !== false;
+    const enabled = opts.enabled === true;
     const matchAll = opts.matchAll !== false; // default: all conditions must match
 
     const script = buildAppLevelScript(`

--- a/src/types.ts
+++ b/src/types.ts
@@ -542,7 +542,7 @@ export interface RuleSpec {
   actions?: RuleActions;
   /** true (default) = all conditions must match; false = any. */
   matchAll?: boolean;
-  /** Whether the rule is enabled on creation (default true). */
+  /** Whether the rule is enabled on creation (default false). */
   enabled?: boolean;
 }
 


### PR DESCRIPTION
Summary
- Make new `create-rule` entries disabled by default so an automation that can delete or move future mail has a review point.
- Preserve explicit opt-in with `enabled: true`; update the tool schema, type documentation, and manager behavior.
- Add deterministic AppleScript-shape tests and release as 2.10.23 with the rebuilt bundle and synchronized plugin manifests.

Verification
- `pnpm run build`
- `pnpm test` — 41 files, 575 tests passed
- `pnpm run lint` — 0 errors; 10 existing `no-explicit-any` warnings
- `pnpm run format:check`
- `git diff --check`
- Commit hook: `tsc --noEmit` and `vitest run` — 41 files, 575 tests passed
- Live Mail integration: Not run; deterministic AppleScript mocks only.

Risk / Notes
- This changes shipped `create-rule` behavior and updates `CHANGELOG.md`, `package.json`, committed `build/index.js`, and plugin manifests.
- Existing rules are unchanged; only newly created rules default to disabled. Callers that require immediate automation must pass `enabled: true` explicitly.
- Open for maintainer review; no live Mail state was changed. The PR is not merged, shipped, accepted, or maintainer-approved.