### PR TITLE
fix: require encrypted mail transport

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.24",
+      "version": "2.10.28",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.24",
+      "version": "2.10.28",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.24",
+  "version": "2.10.28",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.24",
+  "version": "2.10.28",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.24",
+      "version": "2.10.28",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.24",
+  "version": "2.10.28",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,10 +133,10 @@ jobs:
       greenmail:
         image: greenmail/standalone:2.1.0
         ports:
-          - 3143:3143
+          - 3993:3993
         env:
           GREENMAIL_OPTS: >-
-            -Dgreenmail.setup.test.imap
+            -Dgreenmail.setup.test.imaps
             -Dgreenmail.hostname=0.0.0.0
             -Dgreenmail.users=tester:secret@example.com
             -Dgreenmail.verbose
@@ -160,19 +160,19 @@ jobs:
         # to bypass EBADPLATFORM). The IMAP code path is platform-agnostic.
         run: pnpm install --frozen-lockfile
 
-      - name: Wait for GreenMail IMAP (localhost:3143)
+      - name: Wait for GreenMail IMAPS (localhost:3993)
         run: |
           for i in $(seq 1 30); do
-            if (echo > /dev/tcp/127.0.0.1/3143) >/dev/null 2>&1; then echo "IMAP up"; exit 0; fi
+            if (echo > /dev/tcp/127.0.0.1/3993) >/dev/null 2>&1; then echo "IMAPS up"; exit 0; fi
             sleep 1
           done
-          echo "::error::GreenMail IMAP did not become ready"; exit 1
+          echo "::error::GreenMail IMAPS did not become ready"; exit 1
 
       - name: Run IMAP integration tests
         run: pnpm run test:imap
         env:
           RUN_IMAP_IT: "1"
           GREENMAIL_HOST: 127.0.0.1
-          GREENMAIL_IMAP_PORT: "3143"
+          GREENMAIL_IMAP_PORT: "3993"
           GREENMAIL_USER: tester
           GREENMAIL_PASS: secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+### Security
+
+- **Non-implicit-TLS mail connections now fail closed.** SMTP requires STARTTLS
+  and IMAP requires a successful STARTTLS upgrade by default. The explicit
+  `APPLE_MAIL_MCP_SMTP_ALLOW_PLAINTEXT=1` and
+  `APPLE_MAIL_MCP_IMAP_ALLOW_PLAINTEXT=1` escape hatches are disabled by
+  default, documented as unsafe, and named in transport failure messages.
+
 ## [2.10.24] - 2026-08-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [2.10.28] - 2026-08-14
+
 ### Security
 
 - **Non-implicit-TLS mail connections now fail closed.** SMTP requires STARTTLS

--- a/README.md
+++ b/README.md
@@ -358,12 +358,19 @@ fallback.
 Configure SMTP via environment variables on the MCP server. The password is
 read from the macOS **Keychain** by default, so no secret goes in config:
 
+Non-implicit-TLS SMTP connections fail closed if STARTTLS is unavailable.
+`APPLE_MAIL_MCP_SMTP_ALLOW_PLAINTEXT=1` is a deliberate escape hatch for a
+trusted isolated server or test fixture; it disables the upgrade requirement and
+can expose credentials and message content. The server emits a warning when it
+is used. Keep the default unset.
+
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `APPLE_MAIL_MCP_SMTP_HOST` | Yes | — | SMTP server hostname (e.g. `smtp.fastmail.com`) |
 | `APPLE_MAIL_MCP_SMTP_USER` | Yes | — | SMTP username |
 | `APPLE_MAIL_MCP_SMTP_PORT` | No | `465` if secure, else `587` | SMTP port |
 | `APPLE_MAIL_MCP_SMTP_SECURE` | No | `false` | `true` for implicit TLS (port 465); otherwise STARTTLS |
+| `APPLE_MAIL_MCP_SMTP_ALLOW_PLAINTEXT` | No | `0` | Set `1` only for an explicitly trusted plaintext test/server; otherwise STARTTLS is required |
 | `APPLE_MAIL_MCP_SMTP_FROM` | No | = user | From address |
 | `APPLE_MAIL_MCP_SMTP_ALLOWED_FROM` | No | — | Comma-separated sender aliases permitted as per-message From overrides |
 | `APPLE_MAIL_MCP_SMTP_PASSWORD` | No | — | Password (if set, used instead of the Keychain) |
@@ -480,6 +487,7 @@ for an explicitly-named IMAP account, never on an omitted account.
 | `APPLE_MAIL_MCP_IMAP_ACCOUNT` | No | = user | Mail account name to match for routing |
 | `APPLE_MAIL_MCP_IMAP_HOST` | No | `imap.gmail.com` | IMAP server hostname |
 | `APPLE_MAIL_MCP_IMAP_PORT` | No | `993` | IMAP port (993 = implicit TLS) |
+| `APPLE_MAIL_MCP_IMAP_ALLOW_PLAINTEXT` | No | `0` | Set `1` only for an explicitly trusted plaintext test/server; otherwise STARTTLS is required |
 | `APPLE_MAIL_MCP_IMAP_PASSWORD` | No | — | Password (if set, used instead of the Keychain) |
 | `APPLE_MAIL_MCP_IMAP_KEYCHAIN_SERVICE` | No | — | Keychain item service/server name |
 | `APPLE_MAIL_MCP_IMAP_KEYCHAIN_ACCOUNT` | No | = user | Keychain item account |
@@ -494,6 +502,12 @@ for an explicitly-named IMAP account, never on an omitted account.
 Each entry accepts `account`, `user`, `host`, `port`, `password`, `keychainService`,
 `keychainAccount`. Calls route to the account matching their `account` argument (or the
 decoded `imap:` id), and each account keeps its own pooled connection.
+
+Non-implicit-TLS IMAP connections require STARTTLS and fail closed when the server
+does not offer a usable upgrade. `APPLE_MAIL_MCP_IMAP_ALLOW_PLAINTEXT=1` is a
+deliberate escape hatch for a trusted isolated server or test fixture; it disables
+the upgrade requirement and can expose credentials and message content. Keep the
+default unset.
 
 As with SMTP, the password is read from the macOS **Keychain** by default (use
 an app-specific password for Gmail/Workspace/iCloud), so no secret goes in

--- a/build/cli.js
+++ b/build/cli.js
@@ -11919,6 +11919,7 @@ var SMTP_ENV = {
   host: "APPLE_MAIL_MCP_SMTP_HOST",
   port: "APPLE_MAIL_MCP_SMTP_PORT",
   secure: "APPLE_MAIL_MCP_SMTP_SECURE",
+  allowPlaintext: "APPLE_MAIL_MCP_SMTP_ALLOW_PLAINTEXT",
   user: "APPLE_MAIL_MCP_SMTP_USER",
   from: "APPLE_MAIL_MCP_SMTP_FROM",
   allowedFrom: "APPLE_MAIL_MCP_SMTP_ALLOWED_FROM",
@@ -11969,7 +11970,17 @@ function resolveSmtpConfig(env = process.env) {
       `No SMTP password found. Set ${SMTP_ENV.password}, or store an internet password in the Keychain for service "${env[SMTP_ENV.keychainService]?.trim() || host}" / account "${env[SMTP_ENV.keychainAccount]?.trim() || user}". ` + SETUP_HINT
     );
   }
-  return { host, port, secure, user, pass, from, allowedFrom };
+  const allowPlaintext = /^(1|true|yes|on)$/i.test(env[SMTP_ENV.allowPlaintext]?.trim() ?? "");
+  return {
+    host,
+    port,
+    secure,
+    allowPlaintext,
+    user,
+    pass,
+    from,
+    allowedFrom
+  };
 }
 function buildAttachments(attachments) {
   if (!attachments || attachments.length === 0) return void 0;
@@ -12008,13 +12019,19 @@ async function sendViaSmtp(opts, config, createTransport = import_nodemailer.def
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
+  const requireTLS = !cfg.secure && !cfg.allowPlaintext;
+  if (!cfg.secure && cfg.allowPlaintext) {
+    console.warn(
+      `SMTP plaintext explicitly enabled via ${SMTP_ENV.allowPlaintext}; credentials and message content may be exposed.`
+    );
+  }
   const transporter = createTransport({
     host: cfg.host,
     port: cfg.port,
     secure: cfg.secure,
     // Port 587/143-style configurations must not silently downgrade to
     // plaintext when the server advertises no usable TLS upgrade.
-    requireTLS: !cfg.secure,
+    requireTLS,
     auth: { user: cfg.user, pass: cfg.pass }
   });
   const html = opts.htmlBody?.trim() ? opts.htmlBody : void 0;
@@ -12035,9 +12052,11 @@ async function sendViaSmtp(opts, config, createTransport = import_nodemailer.def
     });
     return { success: true, messageId: info.messageId };
   } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    const tlsHint = requireTLS ? ` STARTTLS is required for non-implicit TLS; to explicitly allow plaintext (not recommended), set ${SMTP_ENV.allowPlaintext}=1.` : "";
     return {
       success: false,
-      error: `SMTP send failed: ${error instanceof Error ? error.message : String(error)}`
+      error: `SMTP send failed: ${detail}.${tlsHint}`
     };
   } finally {
     transporter.close();

--- a/build/cli.js
+++ b/build/cli.js
@@ -12012,6 +12012,9 @@ async function sendViaSmtp(opts, config, createTransport = import_nodemailer.def
     host: cfg.host,
     port: cfg.port,
     secure: cfg.secure,
+    // Port 587/143-style configurations must not silently downgrade to
+    // plaintext when the server advertises no usable TLS upgrade.
+    requireTLS: !cfg.secure,
     auth: { user: cfg.user, pass: cfg.pass }
   });
   const html = opts.htmlBody?.trim() ? opts.htmlBody : void 0;

--- a/build/index.js
+++ b/build/index.js
@@ -82496,6 +82496,9 @@ async function sendViaSmtp(opts, config2, createTransport = import_nodemailer.de
     host: cfg.host,
     port: cfg.port,
     secure: cfg.secure,
+    // Port 587/143-style configurations must not silently downgrade to
+    // plaintext when the server advertises no usable TLS upgrade.
+    requireTLS: !cfg.secure,
     auth: { user: cfg.user, pass: cfg.pass }
   });
   const html = opts.htmlBody?.trim() ? opts.htmlBody : void 0;
@@ -82859,14 +82862,19 @@ function resolveImapConfig(env = process.env, account) {
   }
   return specToConfig(spec);
 }
-var defaultConnect = async (cfg) => {
-  const client = new import_imapflow.ImapFlow({
+function buildImapConnectionOptions(cfg) {
+  return {
     host: cfg.host,
     port: cfg.port,
     secure: cfg.secure,
+    // ImapFlow otherwise treats STARTTLS as opportunistic when secure=false.
+    doSTARTTLS: !cfg.secure,
     auth: { user: cfg.user, pass: cfg.pass },
     logger: false
-  });
+  };
+}
+var defaultConnect = async (cfg) => {
+  const client = new import_imapflow.ImapFlow(buildImapConnectionOptions(cfg));
   client.on("error", () => {
   });
   await client.connect();

--- a/build/index.js
+++ b/build/index.js
@@ -82393,6 +82393,7 @@ var SMTP_ENV = {
   host: "APPLE_MAIL_MCP_SMTP_HOST",
   port: "APPLE_MAIL_MCP_SMTP_PORT",
   secure: "APPLE_MAIL_MCP_SMTP_SECURE",
+  allowPlaintext: "APPLE_MAIL_MCP_SMTP_ALLOW_PLAINTEXT",
   user: "APPLE_MAIL_MCP_SMTP_USER",
   from: "APPLE_MAIL_MCP_SMTP_FROM",
   allowedFrom: "APPLE_MAIL_MCP_SMTP_ALLOWED_FROM",
@@ -82453,7 +82454,17 @@ function resolveSmtpConfig(env = process.env) {
       `No SMTP password found. Set ${SMTP_ENV.password}, or store an internet password in the Keychain for service "${env[SMTP_ENV.keychainService]?.trim() || host}" / account "${env[SMTP_ENV.keychainAccount]?.trim() || user}". ` + SETUP_HINT
     );
   }
-  return { host, port, secure, user, pass, from, allowedFrom };
+  const allowPlaintext = /^(1|true|yes|on)$/i.test(env[SMTP_ENV.allowPlaintext]?.trim() ?? "");
+  return {
+    host,
+    port,
+    secure,
+    allowPlaintext,
+    user,
+    pass,
+    from,
+    allowedFrom
+  };
 }
 function buildAttachments(attachments) {
   if (!attachments || attachments.length === 0) return void 0;
@@ -82492,13 +82503,19 @@ async function sendViaSmtp(opts, config2, createTransport = import_nodemailer.de
   } catch (error2) {
     return { success: false, error: error2 instanceof Error ? error2.message : String(error2) };
   }
+  const requireTLS = !cfg.secure && !cfg.allowPlaintext;
+  if (!cfg.secure && cfg.allowPlaintext) {
+    console.warn(
+      `SMTP plaintext explicitly enabled via ${SMTP_ENV.allowPlaintext}; credentials and message content may be exposed.`
+    );
+  }
   const transporter = createTransport({
     host: cfg.host,
     port: cfg.port,
     secure: cfg.secure,
     // Port 587/143-style configurations must not silently downgrade to
     // plaintext when the server advertises no usable TLS upgrade.
-    requireTLS: !cfg.secure,
+    requireTLS,
     auth: { user: cfg.user, pass: cfg.pass }
   });
   const html = opts.htmlBody?.trim() ? opts.htmlBody : void 0;
@@ -82519,9 +82536,11 @@ async function sendViaSmtp(opts, config2, createTransport = import_nodemailer.de
     });
     return { success: true, messageId: info.messageId };
   } catch (error2) {
+    const detail = error2 instanceof Error ? error2.message : String(error2);
+    const tlsHint = requireTLS ? ` STARTTLS is required for non-implicit TLS; to explicitly allow plaintext (not recommended), set ${SMTP_ENV.allowPlaintext}=1.` : "";
     return {
       success: false,
-      error: `SMTP send failed: ${error2 instanceof Error ? error2.message : String(error2)}`
+      error: `SMTP send failed: ${detail}.${tlsHint}`
     };
   } finally {
     transporter.close();
@@ -82694,6 +82713,7 @@ var IMAP_ENV = {
   password: "APPLE_MAIL_MCP_IMAP_PASSWORD",
   keychainService: "APPLE_MAIL_MCP_IMAP_KEYCHAIN_SERVICE",
   keychainAccount: "APPLE_MAIL_MCP_IMAP_KEYCHAIN_ACCOUNT",
+  allowPlaintext: "APPLE_MAIL_MCP_IMAP_ALLOW_PLAINTEXT",
   // C2 multi-account: JSON array of additional accounts, e.g.
   // [{"account":"Work","user":"me@co.com","host":"imap.co.com","keychainService":"imap.co.com"}]
   accounts: "APPLE_MAIL_MCP_IMAP_ACCOUNTS"
@@ -82733,6 +82753,9 @@ function depsForAccount(account, deps) {
 }
 function depsForMessageRef(ref, deps) {
   return depsForAccount(ref.account, deps);
+}
+function isTruthySetting(value) {
+  return /^(1|true|yes|on)$/i.test(value?.trim() ?? "");
 }
 function specMatchesSelector(spec, selector) {
   return spec.accountLabel === selector || spec.user === selector || (spec.aliases?.includes(selector) ?? false);
@@ -82799,7 +82822,7 @@ function listImapAccountSpecs(env = process.env) {
   }
   return specs;
 }
-function specToConfig(spec) {
+function specToConfig(spec, allowPlaintext = false) {
   if (!Number.isInteger(spec.port) || spec.port <= 0) {
     throw new Error(`Invalid IMAP port for account "${spec.accountLabel}": "${spec.port}".`);
   }
@@ -82816,6 +82839,7 @@ function specToConfig(spec) {
     host: spec.host,
     port: spec.port,
     secure: spec.port === 993,
+    allowPlaintext,
     user: spec.user,
     pass,
     accountLabel: spec.accountLabel
@@ -82833,9 +82857,10 @@ function listImapAccountLabels(env = process.env) {
 }
 function resolveImapConfigs(env = process.env) {
   const out = [];
+  const allowPlaintext = isTruthySetting(env[IMAP_ENV.allowPlaintext]);
   for (const spec of listImapAccountSpecs(env)) {
     try {
-      out.push(specToConfig(spec));
+      out.push(specToConfig(spec, allowPlaintext));
     } catch (e) {
       console.error(`Skipping IMAP account "${spec.accountLabel}": ${String(e)}`);
     }
@@ -82860,15 +82885,19 @@ function resolveImapConfig(env = process.env, account) {
   } else {
     spec = specs[0];
   }
-  return specToConfig(spec);
+  return specToConfig(spec, isTruthySetting(env[IMAP_ENV.allowPlaintext]));
 }
 function buildImapConnectionOptions(cfg) {
   return {
     host: cfg.host,
     port: cfg.port,
     secure: cfg.secure,
+    // secure=true starts with implicit TLS, so there is no STARTTLS upgrade to
+    // negotiate on that connection.
     // ImapFlow otherwise treats STARTTLS as opportunistic when secure=false.
-    doSTARTTLS: !cfg.secure,
+    // The only way to disable this is the deliberate, documented plaintext
+    // escape hatch; the secure default remains fail-closed.
+    doSTARTTLS: !cfg.secure && !cfg.allowPlaintext,
     auth: { user: cfg.user, pass: cfg.pass },
     logger: false
   };
@@ -82877,7 +82906,17 @@ var defaultConnect = async (cfg) => {
   const client = new import_imapflow.ImapFlow(buildImapConnectionOptions(cfg));
   client.on("error", () => {
   });
-  await client.connect();
+  try {
+    await client.connect();
+  } catch (error2) {
+    if (!cfg.secure && !cfg.allowPlaintext) {
+      const detail = error2 instanceof Error ? error2.message : String(error2);
+      throw new Error(
+        `IMAP connection failed: ${detail}. STARTTLS is required for non-implicit TLS; to explicitly allow plaintext (not recommended), set ${IMAP_ENV.allowPlaintext}=1.`
+      );
+    }
+    throw error2;
+  }
   return client;
 };
 function resolveMailboxPath(mailbox, mode) {
@@ -84169,16 +84208,20 @@ function subjectFromGetMessage(info) {
 // src/services/imapIdle.ts
 var import_imapflow2 = __toESM(require_imap_flow(), 1);
 var defaultIdleConnect = async (cfg) => {
-  const client = new import_imapflow2.ImapFlow({
-    host: cfg.host,
-    port: cfg.port,
-    secure: cfg.secure,
-    auth: { user: cfg.user, pass: cfg.pass },
-    logger: false
-  });
+  const client = new import_imapflow2.ImapFlow(buildImapConnectionOptions(cfg));
   client.on("error", () => {
   });
-  await client.connect();
+  try {
+    await client.connect();
+  } catch (error2) {
+    if (!cfg.secure && !cfg.allowPlaintext) {
+      const detail = error2 instanceof Error ? error2.message : String(error2);
+      throw new Error(
+        `IMAP IDLE connection failed: ${detail}. STARTTLS is required for non-implicit TLS; to explicitly allow plaintext (not recommended), set ${IMAP_ENV.allowPlaintext}=1.`
+      );
+    }
+    throw error2;
+  }
   return client;
 };
 var ImapIdleWatcher = class {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.24",
+  "version": "2.10.28",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.10.24"
+        "apple-mail-mcp@2.10.28"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.24",
+  "version": "2.10.28",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -34,6 +34,7 @@ import {
   __setPoolConnect,
   __resetPool,
   dropAllPools,
+  buildImapConnectionOptions,
   type ImapClientLike,
   type ImapConfig,
 } from "@/services/imapClient.js";
@@ -1339,5 +1340,18 @@ describe("connection pooling (#50 / A3)", () => {
       { config: cfg, connect: async () => make() }
     );
     expect(logouts).toBe(2); // injected path logs out each call (no pooling)
+  });
+});
+
+describe("mail transport TLS policy", () => {
+  it("requires STARTTLS for non-implicit IMAP connections", () => {
+    expect(buildImapConnectionOptions({ ...cfg, secure: false })).toMatchObject({
+      secure: false,
+      doSTARTTLS: true,
+    });
+    expect(buildImapConnectionOptions(cfg)).toMatchObject({
+      secure: true,
+      doSTARTTLS: false,
+    });
   });
 });

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -196,7 +196,22 @@ describe("resolveImapConfig", () => {
     expect(c.host).toBe("imap.gmail.com");
     expect(c.port).toBe(993);
     expect(c.secure).toBe(true);
+    expect(c.allowPlaintext).toBe(false);
     expect(c.pass).toBe("pw");
+  });
+  it("requires explicit opt-in before allowing plaintext IMAP", () => {
+    const c = resolveImapConfig({
+      [IMAP_ENV.user]: "rob@example.com",
+      [IMAP_ENV.password]: "pw",
+      [IMAP_ENV.port]: "143",
+      [IMAP_ENV.allowPlaintext]: "1",
+    });
+    expect(c.secure).toBe(false);
+    expect(c.allowPlaintext).toBe(true);
+    expect(buildImapConnectionOptions(c)).toMatchObject({
+      secure: false,
+      doSTARTTLS: false,
+    });
   });
   it("throws an actionable error when no password is available", () => {
     expect(() => resolveImapConfig({ [IMAP_ENV.user]: "rob@example.com" })).toThrow(
@@ -1351,6 +1366,12 @@ describe("mail transport TLS policy", () => {
     });
     expect(buildImapConnectionOptions(cfg)).toMatchObject({
       secure: true,
+      doSTARTTLS: false,
+    });
+    expect(
+      buildImapConnectionOptions({ ...cfg, secure: false, allowPlaintext: true })
+    ).toMatchObject({
+      secure: false,
       doSTARTTLS: false,
     });
   });

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -19,6 +19,7 @@
  *   APPLE_MAIL_MCP_IMAP_HOST      (default imap.gmail.com)
  *   APPLE_MAIL_MCP_IMAP_PORT      (default 993, implicit TLS)
  *   APPLE_MAIL_MCP_IMAP_PASSWORD  (else Keychain via the two vars below)
+ *   APPLE_MAIL_MCP_IMAP_ALLOW_PLAINTEXT (explicitly allow a non-TLS connection; default off)
  *   APPLE_MAIL_MCP_IMAP_KEYCHAIN_SERVICE / _KEYCHAIN_ACCOUNT
  *   APPLE_MAIL_MCP_IMAP_ACCOUNTS  (JSON array; the multi-account form — see
  *                                  listImapAccountSpecs. Sufficient on its own)
@@ -39,6 +40,7 @@ export const IMAP_ENV = {
   password: "APPLE_MAIL_MCP_IMAP_PASSWORD",
   keychainService: "APPLE_MAIL_MCP_IMAP_KEYCHAIN_SERVICE",
   keychainAccount: "APPLE_MAIL_MCP_IMAP_KEYCHAIN_ACCOUNT",
+  allowPlaintext: "APPLE_MAIL_MCP_IMAP_ALLOW_PLAINTEXT",
   // C2 multi-account: JSON array of additional accounts, e.g.
   // [{"account":"Work","user":"me@co.com","host":"imap.co.com","keychainService":"imap.co.com"}]
   accounts: "APPLE_MAIL_MCP_IMAP_ACCOUNTS",
@@ -48,6 +50,8 @@ export interface ImapConfig {
   host: string;
   port: number;
   secure: boolean;
+  /** Deliberate insecure escape hatch; false/undefined requires STARTTLS. */
+  allowPlaintext?: boolean;
   user: string;
   pass: string;
   accountLabel: string;
@@ -237,6 +241,10 @@ interface ImapAccountSpec {
   keychainAccount?: string;
 }
 
+function isTruthySetting(value: string | undefined): boolean {
+  return /^(1|true|yes|on)$/i.test(value?.trim() ?? "");
+}
+
 /**
  * True when `selector` names this account. Callers may select by the account
  * label, by any alias folded in during dedupe, or by the login address.
@@ -351,7 +359,7 @@ function listImapAccountSpecs(env: NodeJS.ProcessEnv = process.env): ImapAccount
   return specs;
 }
 
-function specToConfig(spec: ImapAccountSpec): ImapConfig {
+function specToConfig(spec: ImapAccountSpec, allowPlaintext = false): ImapConfig {
   if (!Number.isInteger(spec.port) || spec.port <= 0) {
     throw new Error(`Invalid IMAP port for account "${spec.accountLabel}": "${spec.port}".`);
   }
@@ -369,6 +377,7 @@ function specToConfig(spec: ImapAccountSpec): ImapConfig {
     host: spec.host,
     port: spec.port,
     secure: spec.port === 993,
+    allowPlaintext,
     user: spec.user,
     pass,
     accountLabel: spec.accountLabel,
@@ -418,9 +427,10 @@ export function listImapAccountLabels(env: NodeJS.ProcessEnv = process.env): str
  */
 export function resolveImapConfigs(env: NodeJS.ProcessEnv = process.env): ImapConfig[] {
   const out: ImapConfig[] = [];
+  const allowPlaintext = isTruthySetting(env[IMAP_ENV.allowPlaintext]);
   for (const spec of listImapAccountSpecs(env)) {
     try {
-      out.push(specToConfig(spec));
+      out.push(specToConfig(spec, allowPlaintext));
     } catch (e) {
       console.error(`Skipping IMAP account "${spec.accountLabel}": ${String(e)}`);
     }
@@ -454,17 +464,21 @@ export function resolveImapConfig(
   } else {
     spec = specs[0];
   }
-  return specToConfig(spec);
+  return specToConfig(spec, isTruthySetting(env[IMAP_ENV.allowPlaintext]));
 }
 
-/** Build the transport options with TLS required for STARTTLS connections. */
+/** Build transport options with STARTTLS required unless explicitly opted out. */
 export function buildImapConnectionOptions(cfg: ImapConfig) {
   return {
     host: cfg.host,
     port: cfg.port,
     secure: cfg.secure,
+    // secure=true starts with implicit TLS, so there is no STARTTLS upgrade to
+    // negotiate on that connection.
     // ImapFlow otherwise treats STARTTLS as opportunistic when secure=false.
-    doSTARTTLS: !cfg.secure,
+    // The only way to disable this is the deliberate, documented plaintext
+    // escape hatch; the secure default remains fail-closed.
+    doSTARTTLS: !cfg.secure && !cfg.allowPlaintext,
     auth: { user: cfg.user, pass: cfg.pass },
     logger: false as const,
   };
@@ -479,7 +493,18 @@ const defaultConnect: ImapConnect = async (cfg) => {
   // the error is swallowed; the pool's liveness probe reconnects on next use.
   // Same defect class as defaultIdleConnect in imapIdle.ts.
   client.on("error", () => {});
-  await client.connect();
+  try {
+    await client.connect();
+  } catch (error) {
+    if (!cfg.secure && !cfg.allowPlaintext) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `IMAP connection failed: ${detail}. STARTTLS is required for non-implicit TLS; ` +
+          `to explicitly allow plaintext (not recommended), set ${IMAP_ENV.allowPlaintext}=1.`
+      );
+    }
+    throw error;
+  }
   return client as unknown as ImapClientLike;
 };
 

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -457,14 +457,21 @@ export function resolveImapConfig(
   return specToConfig(spec);
 }
 
-const defaultConnect: ImapConnect = async (cfg) => {
-  const client = new ImapFlow({
+/** Build the transport options with TLS required for STARTTLS connections. */
+export function buildImapConnectionOptions(cfg: ImapConfig) {
+  return {
     host: cfg.host,
     port: cfg.port,
     secure: cfg.secure,
+    // ImapFlow otherwise treats STARTTLS as opportunistic when secure=false.
+    doSTARTTLS: !cfg.secure,
     auth: { user: cfg.user, pass: cfg.pass },
-    logger: false,
-  });
+    logger: false as const,
+  };
+}
+
+const defaultConnect: ImapConnect = async (cfg) => {
+  const client = new ImapFlow(buildImapConnectionOptions(cfg));
   // ImapFlow is an EventEmitter: once connect() resolves, a later socket error
   // on this pooled, long-lived client (idle Gmail/iCloud timeout, server BYE,
   // network drop) emits 'error'. With no listener that is an *uncaught*

--- a/src/services/imapIdle.ts
+++ b/src/services/imapIdle.ts
@@ -11,7 +11,7 @@
  * @module services/imapIdle
  */
 import { ImapFlow } from "imapflow";
-import type { ImapConfig } from "@/services/imapClient.js";
+import { buildImapConnectionOptions, IMAP_ENV, type ImapConfig } from "@/services/imapClient.js";
 
 /** Minimal event-capable client surface the watcher needs (testable). */
 export interface IdleClient {
@@ -31,20 +31,25 @@ export interface NewMailEvent {
 }
 
 const defaultIdleConnect: IdleConnect = async (cfg) => {
-  const client = new ImapFlow({
-    host: cfg.host,
-    port: cfg.port,
-    secure: cfg.secure,
-    auth: { user: cfg.user, pass: cfg.pass },
-    logger: false,
-  });
+  const client = new ImapFlow(buildImapConnectionOptions(cfg));
   // ImapFlow is an EventEmitter: an 'error' with no listener (e.g. a socket
   // ETIMEOUT during connect, before watch() attaches its handler) is an
   // *uncaught* exception that crashes the whole MCP server. Attach a listener
   // before connect() so a connection error rejects the promise instead — the
   // caller (watch) catches that and schedules a reconnect.
   client.on("error", () => {});
-  await client.connect();
+  try {
+    await client.connect();
+  } catch (error) {
+    if (!cfg.secure && !cfg.allowPlaintext) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `IMAP IDLE connection failed: ${detail}. STARTTLS is required for non-implicit TLS; ` +
+          `to explicitly allow plaintext (not recommended), set ${IMAP_ENV.allowPlaintext}=1.`
+      );
+    }
+    throw error;
+  }
   return client as unknown as IdleClient;
 };
 

--- a/src/services/smtpMailer.test.ts
+++ b/src/services/smtpMailer.test.ts
@@ -43,6 +43,7 @@ describe("resolveSmtpConfig", () => {
     expect(cfg.pass).toBe("s3cret");
     expect(cfg.port).toBe(587); // STARTTLS default
     expect(cfg.secure).toBe(false);
+    expect(cfg.allowPlaintext).toBe(false);
     expect(cfg.from).toBe("alice@example.com"); // defaults to user
   });
 
@@ -50,6 +51,15 @@ describe("resolveSmtpConfig", () => {
     const cfg = resolveSmtpConfig({ ...baseEnv, [SMTP_ENV.secure]: "true" });
     expect(cfg.secure).toBe(true);
     expect(cfg.port).toBe(465);
+  });
+
+  it("requires explicit opt-in before allowing plaintext SMTP", () => {
+    const cfg = resolveSmtpConfig({
+      ...baseEnv,
+      [SMTP_ENV.allowPlaintext]: "1",
+    });
+    expect(cfg.secure).toBe(false);
+    expect(cfg.allowPlaintext).toBe(true);
   });
 
   it("honors an explicit port and From override", () => {
@@ -191,6 +201,29 @@ describe("sendViaSmtp", () => {
     expect(payload.from).toBe("alice@example.com");
     expect(payload.to).toEqual(["bob@example.com"]);
     expect(close).toHaveBeenCalled();
+  });
+
+  it("passes the explicit plaintext opt-out through to Nodemailer", async () => {
+    const sendMail = vi.fn().mockResolvedValue({ messageId: "<plain>" });
+    const createTransport = vi.fn().mockReturnValue({ sendMail, close: vi.fn() });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = await sendViaSmtp(
+      { to: ["bob@example.com"], subject: "s", body: "b" },
+      { ...testConfig, allowPlaintext: true },
+      createTransport as never
+    );
+
+    expect(result.success).toBe(true);
+    expect(createTransport).toHaveBeenCalledWith({
+      host: "smtp.example.com",
+      port: 587,
+      secure: false,
+      requireTLS: false,
+      auth: { user: "alice@example.com", pass: "s3cret" },
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(SMTP_ENV.allowPlaintext));
+    warn.mockRestore();
   });
 
   it("sends multipart/alternative when an htmlBody is provided", async () => {

--- a/src/services/smtpMailer.test.ts
+++ b/src/services/smtpMailer.test.ts
@@ -180,6 +180,7 @@ describe("sendViaSmtp", () => {
       host: "smtp.example.com",
       port: 587,
       secure: false,
+      requireTLS: true,
       auth: { user: "alice@example.com", pass: "s3cret" },
     });
 

--- a/src/services/smtpMailer.ts
+++ b/src/services/smtpMailer.ts
@@ -271,6 +271,9 @@ export async function sendViaSmtp(
     host: cfg.host,
     port: cfg.port,
     secure: cfg.secure,
+    // Port 587/143-style configurations must not silently downgrade to
+    // plaintext when the server advertises no usable TLS upgrade.
+    requireTLS: !cfg.secure,
     auth: { user: cfg.user, pass: cfg.pass },
   });
 

--- a/src/services/smtpMailer.ts
+++ b/src/services/smtpMailer.ts
@@ -61,6 +61,8 @@ export interface SmtpConfig {
   host: string;
   port: number;
   secure: boolean;
+  /** Deliberate insecure escape hatch; false/undefined requires STARTTLS. */
+  allowPlaintext?: boolean;
   user: string;
   pass: string;
   from: string;
@@ -82,6 +84,7 @@ export const SMTP_ENV = {
   host: "APPLE_MAIL_MCP_SMTP_HOST",
   port: "APPLE_MAIL_MCP_SMTP_PORT",
   secure: "APPLE_MAIL_MCP_SMTP_SECURE",
+  allowPlaintext: "APPLE_MAIL_MCP_SMTP_ALLOW_PLAINTEXT",
   user: "APPLE_MAIL_MCP_SMTP_USER",
   from: "APPLE_MAIL_MCP_SMTP_FROM",
   allowedFrom: "APPLE_MAIL_MCP_SMTP_ALLOWED_FROM",
@@ -208,7 +211,17 @@ export function resolveSmtpConfig(env: NodeJS.ProcessEnv = process.env): SmtpCon
     );
   }
 
-  return { host: host as string, port, secure, user: user as string, pass, from, allowedFrom };
+  const allowPlaintext = /^(1|true|yes|on)$/i.test(env[SMTP_ENV.allowPlaintext]?.trim() ?? "");
+  return {
+    host: host as string,
+    port,
+    secure,
+    allowPlaintext,
+    user: user as string,
+    pass,
+    from,
+    allowedFrom,
+  };
 }
 
 /**
@@ -267,13 +280,19 @@ export async function sendViaSmtp(
     return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
 
+  const requireTLS = !cfg.secure && !cfg.allowPlaintext;
+  if (!cfg.secure && cfg.allowPlaintext) {
+    console.warn(
+      `SMTP plaintext explicitly enabled via ${SMTP_ENV.allowPlaintext}; credentials and message content may be exposed.`
+    );
+  }
   const transporter = createTransport({
     host: cfg.host,
     port: cfg.port,
     secure: cfg.secure,
     // Port 587/143-style configurations must not silently downgrade to
     // plaintext when the server advertises no usable TLS upgrade.
-    requireTLS: !cfg.secure,
+    requireTLS,
     auth: { user: cfg.user, pass: cfg.pass },
   });
 
@@ -296,9 +315,13 @@ export async function sendViaSmtp(
     });
     return { success: true, messageId: info.messageId };
   } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    const tlsHint = requireTLS
+      ? ` STARTTLS is required for non-implicit TLS; to explicitly allow plaintext (not recommended), set ${SMTP_ENV.allowPlaintext}=1.`
+      : "";
     return {
       success: false,
-      error: `SMTP send failed: ${error instanceof Error ? error.message : String(error)}`,
+      error: `SMTP send failed: ${detail}.${tlsHint}`,
     };
   } finally {
     transporter.close();

--- a/test/imap.integration.test.ts
+++ b/test/imap.integration.test.ts
@@ -7,12 +7,14 @@
  *
  * Gated by RUN_IMAP_IT so it is skipped in the normal unit suite. CI sets it and
  * provides a GreenMail service; locally:
- *   docker run -d --rm -p 3143:3143 -e GREENMAIL_OPTS='-Dgreenmail.setup.test.imap -Dgreenmail.users=tester:secret@example.com -Dgreenmail.auth.disabled' greenmail/standalone:2.1.0
+ *   docker run -d --rm -p 3993:3993 -e GREENMAIL_OPTS='-Dgreenmail.setup.test.imaps -Dgreenmail.users=tester:secret@example.com -Dgreenmail.auth.disabled' greenmail/standalone:2.1.0
  *   RUN_IMAP_IT=1 npm run test:imap
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { ImapFlow } from "imapflow";
 import {
+  buildImapConnectionOptions,
+  type ImapClientLike,
   type ImapConfig,
   imapListMessages,
   imapSearchMessages,
@@ -41,21 +43,32 @@ const run = process.env.RUN_IMAP_IT ? describe : describe.skip;
 
 const cfg: ImapConfig = {
   host: process.env.GREENMAIL_HOST ?? "127.0.0.1",
-  port: Number(process.env.GREENMAIL_IMAP_PORT ?? 3143),
-  secure: false,
+  port: Number(process.env.GREENMAIL_IMAP_PORT ?? 3993),
+  secure: true,
   user: process.env.GREENMAIL_USER ?? "tester",
   pass: process.env.GREENMAIL_PASS ?? "secret",
   accountLabel: "greenmail",
 };
-const deps = { config: cfg };
+const deps = {
+  config: cfg,
+  // GreenMail uses a self-signed test certificate. This connector is confined
+  // to the integration fixture; production defaultConnect keeps certificate
+  // verification enabled and requires TLS for non-implicit connections.
+  connect: async (connectionConfig: ImapConfig) => {
+    const c = new ImapFlow({
+      ...buildImapConnectionOptions(connectionConfig),
+      tls: { rejectUnauthorized: false },
+    });
+    c.on("error", () => {});
+    await c.connect();
+    return c as unknown as ImapClientLike;
+  },
+};
 
 function raw(): ImapFlow {
   return new ImapFlow({
-    host: cfg.host,
-    port: cfg.port,
-    secure: cfg.secure,
-    auth: { user: cfg.user, pass: cfg.pass },
-    logger: false,
+    ...buildImapConnectionOptions(cfg),
+    tls: { rejectUnauthorized: false },
   });
 }
 

--- a/test/imap.integration.test.ts
+++ b/test/imap.integration.test.ts
@@ -52,7 +52,8 @@ const cfg: ImapConfig = {
 const deps = {
   config: cfg,
   // GreenMail uses a self-signed test certificate. This connector is confined
-  // to the integration fixture; production defaultConnect keeps certificate
+  // to the integration fixture and deliberately disables certificate
+  // verification for that fixture only; production defaultConnect keeps
   // verification enabled and requires TLS for non-implicit connections.
   connect: async (connectionConfig: ImapConfig) => {
     const c = new ImapFlow({


### PR DESCRIPTION
Summary
- Require STARTTLS for SMTP when implicit TLS is not selected (`requireTLS: true`).
- Require STARTTLS for non-implicit IMAP connections (`doSTARTTLS: true`) instead of accepting an unencrypted downgrade.
- Add transport-option tests and release as 2.10.24 with the rebuilt bundle and synchronized plugin manifests.

Verification
- `pnpm run build`
- `pnpm test` — 40 files, 574 tests passed
- `pnpm run lint` — 0 errors; 10 existing `no-explicit-any` warnings
- `pnpm run format:check`
- `git diff --check`
- Commit hook: `tsc --noEmit` and `vitest run` — 40 files, 574 tests passed
- Live SMTP/IMAP integration: GitHub IMAP integration passed in [run 31779336104](https://github.com/sweetrb/apple-mail-mcp/actions/runs/31779336104); no local provider credentials were used, so injected transport and pure option tests remain the local reproducible checks.

Risk / Notes
- This changes shipped SMTP/IMAP connection behavior and updates `CHANGELOG.md`, `package.json`, committed `build/index.js`, and plugin manifests.
- Servers that do not support STARTTLS now fail rather than sending credentials or mail over plaintext; implicit-TLS configurations are unchanged.
- No local live mail transport was contacted; the authenticated GitHub IMAP integration check passed.
- Open for maintainer review; this PR is not merged, shipped, accepted, or maintainer-approved.