### PR TITLE
ci: stop auto-merging npm dev dependencies

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,8 +1,9 @@
 name: dependabot-automerge
 
-# Auto-merge Dependabot PRs once required checks pass — but only the SAFE ones:
-# dev-dependency and github-actions bumps, which never ship to npm. Runtime
-# ("production") dependency bumps are left open for a human to review.
+# Auto-merge Dependabot GitHub Actions PRs once required checks pass. npm
+# dependency updates, including direct development dependencies, stay open for
+# human review because the build toolchain can change the committed bundle that
+# ships to npm even when the dependency is not in `dependencies`.
 on: pull_request
 
 permissions:
@@ -17,8 +18,8 @@ jobs:
       - name: Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-      - name: Enable auto-merge for dev-deps and github-actions
-        if: ${{ steps.meta.outputs.package-ecosystem == 'github_actions' || steps.meta.outputs.dependency-type == 'direct:development' }}
+      - name: Enable auto-merge for GitHub Actions updates
+        if: ${{ steps.meta.outputs.package-ecosystem == 'github_actions' }}
         run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Summary
- Stop Dependabot from automatically merging direct npm development-dependency updates.
- Preserve the existing action-only auto-merge lane after required checks pass.
- Keep npm toolchain changes open for human review because TypeScript, esbuild, Vitest, and related dev dependencies can change the committed bundle shipped to npm.

Verification
- Ruby YAML parse of `.github/workflows/dependabot-automerge.yml`
- `git diff --check`
- Commit/push hooks: `tsc --noEmit` and `vitest run` — 40 files, 573 tests passed

Risk / Notes
- This is a workflow-governance-only change; no runtime, package, or public API files changed.
- Dependabot npm PRs will require human review; GitHub Actions PRs retain the existing auto-merge path.
- Open for maintainer review; no repository settings or existing automation runs were changed. The PR is not merged, shipped, accepted, or maintainer-approved.