### PR TITLE
test: share validation schemas

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.21",
+      "version": "2.10.22",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.21",
+      "version": "2.10.22",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.21",
+  "version": "2.10.22",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.21",
+  "version": "2.10.22",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.21",
+      "version": "2.10.22",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.21",
+  "version": "2.10.22",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+## [2.10.22] - 2026-08-14
+
+### Internal
+
+- **Shared validation schemas.** The message-id, batch-id, date-filter, and
+  attachment schemas now live in one imported module used by both the MCP
+  tool registrations and security tests, preventing test-only copies from
+  drifting away from the public validation contract.
+
 ## [2.10.21] - 2026-08-14
 
 ### Fixed

--- a/build/index.js
+++ b/build/index.js
@@ -84110,6 +84110,33 @@ function registerResourcesAndPrompts(server2, mailManager2) {
   );
 }
 
+// src/schemas.ts
+var MESSAGE_ID_SCHEMA = external_exports.string().regex(/^(\d+|imap:[A-Za-z0-9_-]+)$/, "Message ID must be numeric or an IMAP id (imap:\u2026)");
+var BATCH_IDS_SCHEMA = external_exports.array(MESSAGE_ID_SCHEMA).min(1, "At least one message ID is required").max(100, "Cannot process more than 100 messages in a single batch");
+var DATE_FILTER_SCHEMA = external_exports.string().regex(
+  /^[a-zA-Z0-9 ,/\-:]+$/,
+  "Date must contain only alphanumeric characters, spaces, commas, slashes, hyphens, and colons"
+).refine((val) => !isNaN(new Date(val).getTime()), {
+  message: "Date string must be a valid date (e.g., 'January 1, 2026' or '2026-03-15')"
+}).optional();
+var ATTACHMENTS_SCHEMA = external_exports.array(
+  external_exports.union([
+    external_exports.string().describe("Absolute path to an existing file"),
+    external_exports.object({
+      filename: external_exports.string().min(1).max(255).describe("Filename to give the attachment"),
+      contentBase64: external_exports.string().min(1).max(
+        MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS,
+        "Inline attachment exceeds the 25 MiB decoded size limit"
+      ).refine(
+        isInlineAttachmentBase64WithinLimit,
+        "Inline attachment exceeds the 25 MiB decoded size limit"
+      ).describe("Base64-encoded file content (maximum 25 MiB decoded)")
+    })
+  ])
+).max(20, "Cannot attach more than 20 files").optional().describe(
+  "Files to attach: absolute paths (e.g. '/Users/me/report.pdf') and/or inline {filename, contentBase64} objects up to 25 MiB decoded each."
+);
+
 // src/tools/thread.ts
 function normalizeSubject(subject) {
   const prefix = /^\s*(?:(?:re|fwd?|fw|aw|wg|sv|vs|antw|antwort|enc|rif)\s*(?:\[\d+\])?\s*:\s*)+/i;
@@ -84392,8 +84419,6 @@ function withJsonSchema2020_12(transport2) {
 
 // src/index.ts
 loadFileConfig();
-var MESSAGE_ID_SCHEMA = external_exports.string().regex(/^(\d+|imap:[A-Za-z0-9_-]+)$/, "Message ID must be numeric or an IMAP id (imap:\u2026)");
-var BATCH_IDS_SCHEMA = external_exports.array(MESSAGE_ID_SCHEMA).min(1, "At least one message ID is required").max(100, "Cannot process more than 100 messages in a single batch");
 var BATCH_SOURCE_MAILBOX_SCHEMA = external_exports.string().optional().describe(
   "Mailbox the numeric ids were listed from (e.g. 'INBOX'). Pins each id to that mailbox \u2014 strongly recommended, since one numeric id can match in several mailboxes. Works on its own: without sourceAccount it means that mailbox in the default account. Ignored for imap: ids."
 );
@@ -84412,29 +84437,6 @@ var FLAG_COLOR_INDEX = {
 };
 var FLAG_COLOR_SCHEMA = external_exports.enum(["red", "orange", "yellow", "green", "blue", "purple", "gray", "grey"]).optional().describe(
   "Optional flag color (Apple Mail palette: red, orange, yellow, green, blue, purple, gray \u2014 'grey' accepted). Omit for Mail's default flag. The color is applied on both routes: AppleScript sets the flag index, and IMAP writes the equivalent $MailFlagBit0/1/2 keywords Mail.app reads \u2014 so a smart mailbox keyed on flag color matches either way."
-);
-var DATE_FILTER_SCHEMA = external_exports.string().regex(
-  /^[a-zA-Z0-9 ,/\-:]+$/,
-  "Date must contain only alphanumeric characters, spaces, commas, slashes, hyphens, and colons"
-).refine((val) => !isNaN(new Date(val).getTime()), {
-  message: "Date string must be a valid date (e.g., 'January 1, 2026' or '2026-03-15')"
-}).optional();
-var ATTACHMENTS_SCHEMA = external_exports.array(
-  external_exports.union([
-    external_exports.string().describe("Absolute path to an existing file"),
-    external_exports.object({
-      filename: external_exports.string().min(1).max(255).describe("Filename to give the attachment"),
-      contentBase64: external_exports.string().min(1).max(
-        MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS,
-        "Inline attachment exceeds the 25 MiB decoded size limit"
-      ).refine(
-        isInlineAttachmentBase64WithinLimit,
-        "Inline attachment exceeds the 25 MiB decoded size limit"
-      ).describe("Base64-encoded file content (maximum 25 MiB decoded)")
-    })
-  ])
-).max(20, "Cannot attach more than 20 files").optional().describe(
-  "Files to attach: absolute paths (e.g. '/Users/me/report.pdf') and/or inline {filename, contentBase64} objects up to 25 MiB decoded each."
 );
 var MESSAGE_ROW_SCHEMA = external_exports.object({}).passthrough();
 var LIST_OUTPUT_SCHEMA = {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.21",
+  "version": "2.10.22",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.21",
+  "version": "2.10.22",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,9 +99,11 @@ import { routeMessage } from "@/services/messageRouter.js";
 import { runDoctor, formatDoctorReport } from "@/tools/doctor.js";
 import { registerResourcesAndPrompts } from "@/tools/resourcesAndPrompts.js";
 import {
-  isInlineAttachmentBase64WithinLimit,
-  MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS,
-} from "@/utils/attachmentLimits.js";
+  ATTACHMENTS_SCHEMA,
+  BATCH_IDS_SCHEMA,
+  DATE_FILTER_SCHEMA,
+  MESSAGE_ID_SCHEMA,
+} from "@/schemas.js";
 import { normalizeSubject, subjectFromGetMessage } from "@/tools/thread.js";
 import { extractRfcMessageIdFromSource } from "@/utils/mimeParse.js";
 import { ImapIdleWatcher } from "@/services/imapIdle.js";
@@ -121,22 +123,6 @@ loadFileConfig();
 // =============================================================================
 // Shared Validation Schemas
 // =============================================================================
-
-/** A single-message id is EITHER an AppleScript numeric id OR an IMAP composite
- *  token (`imap:<base64url>`, emitted by the IMAP read path). The IMAP form is
- *  base64url so it stays injection-safe; it never reaches AppleScript (it's
- *  decoded and routed to IMAP instead). */
-const MESSAGE_ID_SCHEMA = z
-  .string()
-  .regex(/^(\d+|imap:[A-Za-z0-9_-]+)$/, "Message ID must be numeric or an IMAP id (imap:…)");
-
-/** Batch operations accept numeric (AppleScript) and/or imap: ids (I2) and are
- *  capped to prevent unbounded loops / DoS. Numeric ids run via AppleScript;
- *  imap: ids are grouped by mailbox and applied in a single UID command. */
-const BATCH_IDS_SCHEMA = z
-  .array(MESSAGE_ID_SCHEMA)
-  .min(1, "At least one message ID is required")
-  .max(100, "Cannot process more than 100 messages in a single batch");
 
 /** Source scope for a batch of NUMERIC ids: the account+mailbox they were listed
  *  from. A numeric Mail.app id can match in several mailboxes at once (Gmail
@@ -177,48 +163,6 @@ const FLAG_COLOR_SCHEMA = z
   .optional()
   .describe(
     "Optional flag color (Apple Mail palette: red, orange, yellow, green, blue, purple, gray — 'grey' accepted). Omit for Mail's default flag. The color is applied on both routes: AppleScript sets the flag index, and IMAP writes the equivalent $MailFlagBit0/1/2 keywords Mail.app reads — so a smart mailbox keyed on flag color matches either way."
-  );
-
-/** Date filter strings must look like natural-language dates (e.g. "March 1, 2026").
- *  Block characters that could escape an AppleScript `date "..."` literal. */
-const DATE_FILTER_SCHEMA = z
-  .string()
-  .regex(
-    /^[a-zA-Z0-9 ,/\-:]+$/,
-    "Date must contain only alphanumeric characters, spaces, commas, slashes, hyphens, and colons"
-  )
-  .refine((val) => !isNaN(new Date(val).getTime()), {
-    message: "Date string must be a valid date (e.g., 'January 1, 2026' or '2026-03-15')",
-  })
-  .optional();
-
-// Attachments: absolute file paths and/or inline base64 content (B4).
-const ATTACHMENTS_SCHEMA = z
-  .array(
-    z.union([
-      z.string().describe("Absolute path to an existing file"),
-      z.object({
-        filename: z.string().min(1).max(255).describe("Filename to give the attachment"),
-        contentBase64: z
-          .string()
-          .min(1)
-          .max(
-            MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS,
-            "Inline attachment exceeds the 25 MiB decoded size limit"
-          )
-          .refine(
-            isInlineAttachmentBase64WithinLimit,
-            "Inline attachment exceeds the 25 MiB decoded size limit"
-          )
-          .describe("Base64-encoded file content (maximum 25 MiB decoded)"),
-      }),
-    ])
-  )
-  .max(20, "Cannot attach more than 20 files")
-  .optional()
-  .describe(
-    "Files to attach: absolute paths (e.g. '/Users/me/report.pdf') and/or " +
-      "inline {filename, contentBase64} objects up to 25 MiB decoded each."
   );
 
 // =============================================================================

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared MCP input schemas.
+ *
+ * Keep the schemas that define the public validation contract in one module so
+ * security tests and the server's tool registrations cannot silently drift
+ * apart.
+ */
+import { z } from "zod";
+import {
+  isInlineAttachmentBase64WithinLimit,
+  MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS,
+} from "@/utils/attachmentLimits.js";
+
+/** A single-message id is EITHER an AppleScript numeric id OR an IMAP composite
+ *  token (`imap:<base64url>`, emitted by the IMAP read path). The IMAP form is
+ *  base64url so it stays injection-safe; it never reaches AppleScript (it's
+ *  decoded and routed to IMAP instead). */
+export const MESSAGE_ID_SCHEMA = z
+  .string()
+  .regex(/^(\d+|imap:[A-Za-z0-9_-]+)$/, "Message ID must be numeric or an IMAP id (imap:…)");
+
+/** Batch operations accept numeric (AppleScript) and/or imap: ids (I2) and are
+ *  capped to prevent unbounded loops / DoS. Numeric ids run via AppleScript;
+ *  imap: ids are grouped by mailbox and applied in a single UID command. */
+export const BATCH_IDS_SCHEMA = z
+  .array(MESSAGE_ID_SCHEMA)
+  .min(1, "At least one message ID is required")
+  .max(100, "Cannot process more than 100 messages in a single batch");
+
+/** Date filter strings must look like natural-language dates (e.g. "March 1, 2026").
+ *  Block characters that could escape an AppleScript `date "..."` literal. */
+export const DATE_FILTER_SCHEMA = z
+  .string()
+  .regex(
+    /^[a-zA-Z0-9 ,/\-:]+$/,
+    "Date must contain only alphanumeric characters, spaces, commas, slashes, hyphens, and colons"
+  )
+  .refine((val) => !isNaN(new Date(val).getTime()), {
+    message: "Date string must be a valid date (e.g., 'January 1, 2026' or '2026-03-15')",
+  })
+  .optional();
+
+// Attachments: absolute file paths and/or inline base64 content (B4).
+export const ATTACHMENTS_SCHEMA = z
+  .array(
+    z.union([
+      z.string().describe("Absolute path to an existing file"),
+      z.object({
+        filename: z.string().min(1).max(255).describe("Filename to give the attachment"),
+        contentBase64: z
+          .string()
+          .min(1)
+          .max(
+            MAX_INLINE_ATTACHMENT_BASE64_INPUT_CHARS,
+            "Inline attachment exceeds the 25 MiB decoded size limit"
+          )
+          .refine(
+            isInlineAttachmentBase64WithinLimit,
+            "Inline attachment exceeds the 25 MiB decoded size limit"
+          )
+          .describe("Base64-encoded file content (maximum 25 MiB decoded)"),
+      }),
+    ])
+  )
+  .max(20, "Cannot attach more than 20 files")
+  .optional()
+  .describe(
+    "Files to attach: absolute paths (e.g. '/Users/me/report.pdf') and/or " +
+      "inline {filename, contentBase64} objects up to 25 MiB decoded each."
+  );

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -6,33 +6,23 @@ import { describe, it, expect } from "vitest";
 import { resolve, isAbsolute } from "path";
 import { homedir } from "os";
 import { existsSync } from "fs";
-import { z } from "zod";
 import { escapeForAppleScript, escapeForAppleScriptBody } from "@/services/appleMailManager.js";
-
-// Re-define the schemas here to test them in isolation (they're module-scoped in index.ts)
-const MESSAGE_ID_SCHEMA = z.string().regex(/^\d+$/, "Message ID must be numeric");
-
-const BATCH_IDS_SCHEMA = z
-  .array(MESSAGE_ID_SCHEMA)
-  .min(1, "At least one message ID is required")
-  .max(100, "Cannot process more than 100 messages in a single batch");
-
-const DATE_FILTER_SCHEMA = z
-  .string()
-  .regex(
-    /^[a-zA-Z0-9 ,/\-:]+$/,
-    "Date must contain only alphanumeric characters, spaces, commas, slashes, hyphens, and colons"
-  )
-  .refine((val) => !isNaN(new Date(val).getTime()), {
-    message: "Date string must be a valid date (e.g., 'January 1, 2026' or '2026-03-15')",
-  })
-  .optional();
+import {
+  ATTACHMENTS_SCHEMA,
+  BATCH_IDS_SCHEMA,
+  DATE_FILTER_SCHEMA,
+  MESSAGE_ID_SCHEMA,
+} from "@/schemas.js";
 
 describe("MESSAGE_ID_SCHEMA", () => {
   it("accepts valid numeric IDs", () => {
     expect(MESSAGE_ID_SCHEMA.parse("12345")).toBe("12345");
     expect(MESSAGE_ID_SCHEMA.parse("0")).toBe("0");
     expect(MESSAGE_ID_SCHEMA.parse("999999999")).toBe("999999999");
+  });
+
+  it("accepts injection-safe IMAP ids", () => {
+    expect(MESSAGE_ID_SCHEMA.parse("imap:YWJjXzEyMw")).toBe("imap:YWJjXzEyMw");
   });
 
   it("rejects non-numeric IDs", () => {
@@ -56,6 +46,10 @@ describe("BATCH_IDS_SCHEMA", () => {
   it("accepts valid batch of numeric IDs", () => {
     const result = BATCH_IDS_SCHEMA.parse(["1", "2", "3"]);
     expect(result).toEqual(["1", "2", "3"]);
+  });
+
+  it("accepts a batch of IMAP ids", () => {
+    expect(BATCH_IDS_SCHEMA.parse(["imap:YWJj", "imap:ZGVm"])).toEqual(["imap:YWJj", "imap:ZGVm"]);
   });
 
   it("rejects empty array", () => {
@@ -236,12 +230,6 @@ describe("buildAttachmentCommands validation", () => {
     const matches = result.match(/make new attachment/g);
     expect(matches).toHaveLength(2);
   });
-
-  // Schema-level test: attachment array cap
-  const ATTACHMENTS_SCHEMA = z
-    .array(z.string())
-    .max(20, "Cannot attach more than 20 files")
-    .optional();
 
   it("rejects more than 20 attachments at schema level", () => {
     const paths = Array.from({ length: 21 }, (_, i) => `/tmp/file${i}.pdf`);


### PR DESCRIPTION
## Summary

- Move the production message-id, batch-id, date-filter, and attachment schemas into a shared module so the MCP tool registrations and security tests use the same validation contract.
- Remove the stale security-test schema copies and add coverage for injection-safe IMAP ids and the real attachment union/cap.
- Publish patch version 2.10.26 with the rebuilt bundle; runtime validation behavior is preserved.

## Verification

- `pnpm test` — 40 test files, 575 tests passed.
- `pnpm run typecheck` — passed.
- `pnpm run lint` — 0 errors, 10 existing warnings.
- `pnpm run format:check` — passed.
- `pnpm run build` — passed; committed `build/` refreshed.
- `git diff --check` — passed.
- Commit and push hooks — typecheck and 575 tests passed.
- Live Mail.app integration — Not run; this is a schema/test-contract change and the local environment has no live Mail.app fixture.

## Risk / Notes

- Public-facing files changed: `CHANGELOG.md`, `package.json`, plugin manifests, and committed `build/`; `README.md` is unchanged.
- This is a source-organization change intended to prevent security tests from silently validating a different contract than the server advertises. The schema expressions and messages are preserved.
- No live GitHub settings or automations were changed. Open for maintainer review; not merged, shipped, accepted, or maintainer-approved.
- This branch is intentionally based on current upstream main; it may need a normal rebase if another version-bumping hardening PR lands first.
