### PR TITLE
ci: stop auto-merging npm dev-dependency bumps (continued from #167, @jjoanna2-debug)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,8 +1,9 @@
 name: dependabot-automerge
 
-# Auto-merge Dependabot PRs once required checks pass — but only the SAFE ones:
-# dev-dependency and github-actions bumps, which never ship to npm. Runtime
-# ("production") dependency bumps are left open for a human to review.
+# Auto-merge Dependabot GitHub Actions PRs once required checks pass. npm
+# dependency updates, including direct development dependencies, stay open for
+# human review because the build toolchain can change the committed bundle that
+# ships to npm even when the dependency is not in `dependencies`.
 on: pull_request
 
 permissions:
@@ -17,8 +18,8 @@ jobs:
       - name: Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-      - name: Enable auto-merge for dev-deps and github-actions
-        if: ${{ steps.meta.outputs.package-ecosystem == 'github_actions' || steps.meta.outputs.dependency-type == 'direct:development' }}
+      - name: Enable auto-merge for GitHub Actions updates
+        if: ${{ steps.meta.outputs.package-ecosystem == 'github_actions' }}
         run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Carries forward @jjoanna2-debug's commit from #167 — a fork PR touching `.github/workflows/**` can't be merged here (the merge API refuses without `workflow` scope), so it needs an in-repo branch. Original: #167.

**Why:** `dependabot-rebuild.yml` regenerates the committed esbuild bundle on npm Dependabot PRs, pushes it to the PR branch and re-dispatches the required checks. Combined with auto-merge on `direct:development`, a toolchain bump (esbuild, typescript) could change the bundle bytes that ship to npm and land with nobody reviewing it. `github_actions` bumps keep auto-merging — they touch only `.github/**` and never reach the bundle.

**Cost:** npm dev-dependency Dependabot PRs now wait for a human (or the daily `/mcpscan` pass).

Propagated to the other three in the same pass — this file is in `conformance-check.sh`'s IDENTICAL set: sweetrb/apple-notes-mcp#138, sweetrb/apple-numbers-mcp#66, sweetrb/apple-photos-mcp#75 (all merged).

CI-only change: no shipped bytes, so no version bump.