### PR TITLE
fix: guard batch ops against a disabled account, and make the batch wiring testable (#156)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.30",
+      "version": "2.10.31",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.30",
+      "version": "2.10.31",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.30",
+  "version": "2.10.31",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.30",
+  "version": "2.10.31",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.30",
+      "version": "2.10.31",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.30",
+  "version": "2.10.31",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## [Unreleased]
 
+## [2.10.31] - 2026-08-14
+
+### Fixed
+
+- **Batch operations scoped to a disabled account are now refused instead of half-applied.**
+  `disabledAccountGuard` was consulted by the single-message paths but never by
+  `runBatchOperation`, so a batch pinned to an account that is switched off in Mail went
+  straight to AppleScript, failed server-side with AppleEvent -10000, and could leave a
+  mailbox partially changed. The guard still fails **open** — an inconclusive probe never
+  blocks a valid operation. Closes item 3 of #156.
+
+### Changed
+
+- **The two destructive batch tool handlers moved into `src/tools/batchMutations.ts`.**
+  `sourceMailbox`/`sourceAccount` were forwarded into the manager by code inside
+  `index.ts`, which opens a stdio transport at import and therefore cannot be loaded by a
+  unit test — so transposing the two fields, or dropping one, passed the entire suite.
+  The handlers now take an injected dependency bundle, and the forwarding (including that
+  a move's destination `account` stays distinct from `sourceAccount`) is asserted directly.
+  No behaviour change. Closes item 4 of #156.
+
 ## [2.10.30] - 2026-08-14
 
 ### Fixed

--- a/build/index.js
+++ b/build/index.js
@@ -80959,6 +80959,12 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     if (resolved.kind === "unresolvable") {
       return operands.map((id) => ({ id, success: false, error: resolved.error }));
     }
+    if (resolved.kind === "scoped") {
+      const disabled = this.disabledAccountGuard(resolved.account);
+      if (disabled) {
+        return operands.map((id) => ({ id, success: false, error: disabled }));
+      }
+    }
     const callerScope = resolved.kind === "scoped" ? resolved : void 0;
     const groups = /* @__PURE__ */ new Map();
     const unlocated = [];
@@ -84006,6 +84012,72 @@ ${warnings.join("\n")}` : "";
   return successResponse(`${messages.partial(success, fail)}${suffix}${warn}`, structured);
 }
 
+// src/tools/batchMutations.ts
+function toManagerScope(args) {
+  return { account: args.sourceAccount, mailbox: args.sourceMailbox };
+}
+async function runBatchDelete(deps, args) {
+  const { ids, sourceMailbox, sourceAccount } = args;
+  let forensics = { warnings: [] };
+  const counts = await hybridBatchCounts(
+    ids,
+    (n) => {
+      const res = deps.batchDeleteMessages(n, toManagerScope({ sourceAccount, sourceMailbox }));
+      forensics = deps.collectForensics("batch-delete-messages", {
+        ids,
+        sourceMailbox,
+        sourceAccount
+      });
+      return res;
+    },
+    (im) => deps.imapBatchDelete(im)
+  );
+  return batchResponse(
+    counts,
+    {
+      allSucceeded: (n) => `Successfully deleted ${n} message(s)`,
+      allFailed: (n) => `Failed to delete all ${n} message(s)`,
+      partial: (ok, failed) => `Deleted ${ok} message(s), ${failed} failed`
+    },
+    forensics.countDelta ? { countDelta: forensics.countDelta } : {},
+    forensics.warnings
+  );
+}
+async function runBatchMove(deps, args) {
+  const { ids, mailbox, account, sourceMailbox, sourceAccount } = args;
+  let forensics = { warnings: [] };
+  const counts = await hybridBatchCounts(
+    ids,
+    (n) => {
+      const res = deps.batchMoveMessages(
+        n,
+        mailbox,
+        account,
+        toManagerScope({ sourceAccount, sourceMailbox })
+      );
+      forensics = deps.collectForensics("batch-move-messages", {
+        ids,
+        mailbox,
+        account,
+        sourceMailbox,
+        sourceAccount
+      });
+      return res;
+    },
+    (im) => deps.imapBatchMove(im, mailbox, { account })
+  );
+  return batchResponse(
+    counts,
+    {
+      allSucceeded: (n) => `Successfully moved ${n} message(s) to "${mailbox}"`,
+      allFailed: (n) => `Failed to move all ${n} message(s)`,
+      partial: (ok, failed) => `Moved ${ok} message(s) to "${mailbox}", ${failed} failed`
+    },
+    { mailbox, ...forensics.countDelta ? { countDelta: forensics.countDelta } : {} },
+    forensics.warnings
+  );
+}
+
 // src/services/imapMultiAccount.ts
 function normalizeMessageId2(row) {
   const raw = typeof row.messageId === "string" ? row.messageId.trim() : "";
@@ -85578,6 +85650,13 @@ ${warnings.join("\n")}` : ""}`,
     "Error moving message"
   )
 );
+var batchMutationDeps = {
+  batchDeleteMessages: (ids, scope) => mailManager.batchDeleteMessages(ids, scope),
+  batchMoveMessages: (ids, mailbox, account, scope) => mailManager.batchMoveMessages(ids, mailbox, account, scope),
+  imapBatchDelete: (ids) => imapBatchDelete(ids),
+  imapBatchMove: (ids, mailbox, opts) => imapBatchMove(ids, mailbox, opts),
+  collectForensics: (tool, args) => collectForensics(tool, args)
+};
 registerTool(
   "batch-delete-messages",
   {
@@ -85589,35 +85668,10 @@ registerTool(
     },
     outputSchema: { ...BATCH_COUNT_OUTPUT_SCHEMA, countDelta: COUNT_DELTA_OUTPUT_SCHEMA }
   },
-  withErrorHandling(async ({ ids, sourceMailbox, sourceAccount }) => {
-    let forensics = { warnings: [] };
-    const counts = await hybridBatchCounts(
-      ids,
-      (n) => {
-        const res = mailManager.batchDeleteMessages(n, {
-          account: sourceAccount,
-          mailbox: sourceMailbox
-        });
-        forensics = collectForensics("batch-delete-messages", {
-          ids,
-          sourceMailbox,
-          sourceAccount
-        });
-        return res;
-      },
-      (im) => imapBatchDelete(im)
-    );
-    return batchResponse(
-      counts,
-      {
-        allSucceeded: (n) => `Successfully deleted ${n} message(s)`,
-        allFailed: (n) => `Failed to delete all ${n} message(s)`,
-        partial: (ok, failed) => `Deleted ${ok} message(s), ${failed} failed`
-      },
-      forensics.countDelta ? { countDelta: forensics.countDelta } : {},
-      forensics.warnings
-    );
-  }, "Error batch deleting messages")
+  withErrorHandling(
+    async ({ ids, sourceMailbox, sourceAccount }) => runBatchDelete(batchMutationDeps, { ids, sourceMailbox, sourceAccount }),
+    "Error batch deleting messages"
+  )
 );
 registerTool(
   "batch-move-messages",
@@ -85632,37 +85686,10 @@ registerTool(
     },
     outputSchema: { ...BATCH_COUNT_OUTPUT_SCHEMA, countDelta: COUNT_DELTA_OUTPUT_SCHEMA }
   },
-  withErrorHandling(async ({ ids, mailbox, account, sourceMailbox, sourceAccount }) => {
-    let forensics = { warnings: [] };
-    const counts = await hybridBatchCounts(
-      ids,
-      (n) => {
-        const res = mailManager.batchMoveMessages(n, mailbox, account, {
-          account: sourceAccount,
-          mailbox: sourceMailbox
-        });
-        forensics = collectForensics("batch-move-messages", {
-          ids,
-          mailbox,
-          account,
-          sourceMailbox,
-          sourceAccount
-        });
-        return res;
-      },
-      (im) => imapBatchMove(im, mailbox, { account })
-    );
-    return batchResponse(
-      counts,
-      {
-        allSucceeded: (n) => `Successfully moved ${n} message(s) to "${mailbox}"`,
-        allFailed: (n) => `Failed to move all ${n} message(s)`,
-        partial: (ok, failed) => `Moved ${ok} message(s) to "${mailbox}", ${failed} failed`
-      },
-      { mailbox, ...forensics.countDelta ? { countDelta: forensics.countDelta } : {} },
-      forensics.warnings
-    );
-  }, "Error batch moving messages")
+  withErrorHandling(
+    async ({ ids, mailbox, account, sourceMailbox, sourceAccount }) => runBatchMove(batchMutationDeps, { ids, mailbox, account, sourceMailbox, sourceAccount }),
+    "Error batch moving messages"
+  )
 );
 registerTool(
   "batch-mark-as-read",

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.30",
+  "version": "2.10.31",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.10.30"
+        "apple-mail-mcp@2.10.31"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.30",
+  "version": "2.10.31",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ import {
   messageSummary,
 } from "@/tools/respond.js";
 import { hybridBatchCounts, batchResponse } from "@/tools/batchResults.js";
+import { runBatchDelete, runBatchMove } from "@/tools/batchMutations.js";
 import {
   fanOutImapMessages,
   mergeMessages,
@@ -1525,6 +1526,27 @@ registerTool(
   )
 );
 
+/**
+ * The live wiring the batch mutation handlers run against (#156 item 4). The
+ * handlers themselves live in `@/tools/batchMutations.js` so this forwarding is
+ * assertable without importing `index.ts`, which opens a stdio transport at
+ * import and therefore cannot be loaded by a unit test.
+ */
+const batchMutationDeps = {
+  batchDeleteMessages: (ids: string[], scope: { account?: string; mailbox?: string }) =>
+    mailManager.batchDeleteMessages(ids, scope),
+  batchMoveMessages: (
+    ids: string[],
+    mailbox: string,
+    account: string | undefined,
+    scope: { account?: string; mailbox?: string }
+  ) => mailManager.batchMoveMessages(ids, mailbox, account, scope),
+  imapBatchDelete: (ids: string[]) => imapBatchDelete(ids),
+  imapBatchMove: (ids: string[], mailbox: string, opts: { account?: string }) =>
+    imapBatchMove(ids, mailbox, opts),
+  collectForensics: (tool: string, args: Record<string, unknown>) => collectForensics(tool, args),
+};
+
 // --- batch-delete-messages ---
 
 registerTool(
@@ -1539,35 +1561,11 @@ registerTool(
     },
     outputSchema: { ...BATCH_COUNT_OUTPUT_SCHEMA, countDelta: COUNT_DELTA_OUTPUT_SCHEMA },
   },
-  withErrorHandling(async ({ ids, sourceMailbox, sourceAccount }) => {
-    let forensics: ReturnType<typeof collectForensics> = { warnings: [] };
-    const counts = await hybridBatchCounts(
-      ids,
-      (n) => {
-        const res = mailManager.batchDeleteMessages(n, {
-          account: sourceAccount,
-          mailbox: sourceMailbox,
-        });
-        forensics = collectForensics("batch-delete-messages", {
-          ids,
-          sourceMailbox,
-          sourceAccount,
-        });
-        return res;
-      },
-      (im) => imapBatchDelete(im)
-    );
-    return batchResponse(
-      counts,
-      {
-        allSucceeded: (n) => `Successfully deleted ${n} message(s)`,
-        allFailed: (n) => `Failed to delete all ${n} message(s)`,
-        partial: (ok, failed) => `Deleted ${ok} message(s), ${failed} failed`,
-      },
-      forensics.countDelta ? { countDelta: forensics.countDelta } : {},
-      forensics.warnings
-    );
-  }, "Error batch deleting messages")
+  withErrorHandling(
+    async ({ ids, sourceMailbox, sourceAccount }) =>
+      runBatchDelete(batchMutationDeps, { ids, sourceMailbox, sourceAccount }),
+    "Error batch deleting messages"
+  )
 );
 
 // --- batch-move-messages ---
@@ -1586,37 +1584,11 @@ registerTool(
     },
     outputSchema: { ...BATCH_COUNT_OUTPUT_SCHEMA, countDelta: COUNT_DELTA_OUTPUT_SCHEMA },
   },
-  withErrorHandling(async ({ ids, mailbox, account, sourceMailbox, sourceAccount }) => {
-    let forensics: ReturnType<typeof collectForensics> = { warnings: [] };
-    const counts = await hybridBatchCounts(
-      ids,
-      (n) => {
-        const res = mailManager.batchMoveMessages(n, mailbox, account, {
-          account: sourceAccount,
-          mailbox: sourceMailbox,
-        });
-        forensics = collectForensics("batch-move-messages", {
-          ids,
-          mailbox,
-          account,
-          sourceMailbox,
-          sourceAccount,
-        });
-        return res;
-      },
-      (im) => imapBatchMove(im, mailbox, { account })
-    );
-    return batchResponse(
-      counts,
-      {
-        allSucceeded: (n) => `Successfully moved ${n} message(s) to "${mailbox}"`,
-        allFailed: (n) => `Failed to move all ${n} message(s)`,
-        partial: (ok, failed) => `Moved ${ok} message(s) to "${mailbox}", ${failed} failed`,
-      },
-      { mailbox, ...(forensics.countDelta ? { countDelta: forensics.countDelta } : {}) },
-      forensics.warnings
-    );
-  }, "Error batch moving messages")
+  withErrorHandling(
+    async ({ ids, mailbox, account, sourceMailbox, sourceAccount }) =>
+      runBatchMove(batchMutationDeps, { ids, mailbox, account, sourceMailbox, sourceAccount }),
+    "Error batch moving messages"
+  )
 );
 
 // --- batch-mark-as-read ---

--- a/src/services/appleMailManager.disabledAccount.test.ts
+++ b/src/services/appleMailManager.disabledAccount.test.ts
@@ -1,0 +1,87 @@
+/**
+ * #156 item 3 — a batch scoped to a DISABLED account must be refused up front.
+ *
+ * `disabledAccountGuard` existed and was consulted by the single-message paths,
+ * but `runBatchOperation` never called it. A batch pinned to a disabled account
+ * therefore went straight to AppleScript, failed server-side with AppleEvent
+ * -10000, and could leave a mailbox half-changed — the precise outcome the guard
+ * was written to prevent.
+ *
+ * executeAppleScript is mocked, so the "disabled" verdict is injected rather
+ * than requiring a real disabled Mail account.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const h = vi.hoisted(() => ({ calls: [] as string[], accountEnabled: "true" }));
+
+vi.mock("@/utils/applescript.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/applescript.js")>();
+  return {
+    ...actual,
+    executeAppleScript: (script: string) => {
+      h.calls.push(script);
+      // The enabled-probe is the only script that reads `enabled of account`.
+      if (script.includes("enabled of account")) {
+        return { success: true, output: h.accountEnabled, error: undefined as string | undefined };
+      }
+      return { success: true, output: "ok", error: undefined as string | undefined };
+    },
+  };
+});
+
+import { AppleMailManager } from "@/services/appleMailManager.js";
+
+describe("#156 item 3 — batch operations refuse a disabled source account", () => {
+  let mgr: AppleMailManager;
+
+  beforeEach(() => {
+    h.calls.length = 0;
+    h.accountEnabled = "true";
+    mgr = new AppleMailManager();
+  });
+
+  it("refuses every id when the scoped account is disabled, without mutating", () => {
+    h.accountEnabled = "false";
+    const results = mgr.batchDeleteMessages(["101", "102"], {
+      account: "Disabled Acct",
+      mailbox: "INBOX",
+    });
+
+    expect(results).toHaveLength(2);
+    for (const r of results) {
+      expect(r.success).toBe(false);
+      expect(r.error).toMatch(/disabled in Mail/);
+    }
+    // Nothing may have been deleted: no mutation script was ever generated.
+    expect(h.calls.some((s) => s.includes("delete _msg"))).toBe(false);
+  });
+
+  it("refuses a scoped move to a disabled account the same way", () => {
+    h.accountEnabled = "false";
+    const results = mgr.batchMoveMessages(["101"], "Archive", undefined, {
+      account: "Disabled Acct",
+      mailbox: "INBOX",
+    });
+    expect(results[0].success).toBe(false);
+    expect(results[0].error).toMatch(/disabled in Mail/);
+  });
+
+  it("proceeds normally when the account is enabled", () => {
+    h.accountEnabled = "true";
+    const results = mgr.batchDeleteMessages(["101"], {
+      account: "Live Acct",
+      mailbox: "INBOX",
+    });
+    expect(results[0].error).not.toMatch(/disabled in Mail/);
+  });
+
+  it("fails OPEN when Mail will not report the account state", () => {
+    // An inconclusive probe must never block an otherwise-valid operation.
+    h.accountEnabled = "missing";
+    const results = mgr.batchDeleteMessages(["101"], {
+      account: "Unknown Acct",
+      mailbox: "INBOX",
+    });
+    expect(results[0].error).not.toMatch(/disabled in Mail/);
+  });
+});

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -3661,6 +3661,19 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     if (resolved.kind === "unresolvable") {
       return operands.map((id) => ({ id, success: false, error: resolved.error }));
     }
+    // #156 item 3. `runBatchOperation` never consulted this guard, so a batch
+    // scoped to a disabled account went straight to AppleScript, failed
+    // server-side with AppleEvent -10000, and could leave a mailbox half-changed
+    // — the exact case disabledAccountGuard exists to refuse up front for the
+    // single-message paths. The guard fails OPEN (an inconclusive probe returns
+    // null), so this cannot block an operation on an account whose state Mail
+    // will not report.
+    if (resolved.kind === "scoped") {
+      const disabled = this.disabledAccountGuard(resolved.account);
+      if (disabled) {
+        return operands.map((id) => ({ id, success: false, error: disabled }));
+      }
+    }
     const callerScope = resolved.kind === "scoped" ? resolved : undefined;
 
     // Group the ids by the mailbox they were listed from. Each group opens that

--- a/src/tools/batchMutations.test.ts
+++ b/src/tools/batchMutations.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Executable coverage for the batch tool wiring (#156 item 4).
+ *
+ * Before this, `sourceMailbox`/`sourceAccount` were forwarded from the tool
+ * schema into the manager by code that no test could load — `index.ts` opens a
+ * stdio transport at import. Swapping the two, or dropping one, passed the
+ * entire suite. These tests assert the forwarding itself.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  runBatchDelete,
+  runBatchMove,
+  toManagerScope,
+  type BatchMutationDeps,
+} from "@/tools/batchMutations.js";
+
+function deps(overrides: Partial<BatchMutationDeps> = {}) {
+  const batchDeleteMessages = vi.fn((ids: string[]) => ids.map((id) => ({ id, success: true })));
+  const batchMoveMessages = vi.fn((ids: string[]) => ids.map((id) => ({ id, success: true })));
+  const imapBatchDelete = vi.fn(async () => ({ success: 0, failed: 0, fail: 0, errors: [] }));
+  const imapBatchMove = vi.fn(async () => ({ success: 0, failed: 0, fail: 0, errors: [] }));
+  const collectForensics = vi.fn(() => ({ warnings: [] as string[] }));
+  return {
+    batchDeleteMessages,
+    batchMoveMessages,
+    imapBatchDelete,
+    imapBatchMove,
+    collectForensics,
+    ...overrides,
+  } as unknown as BatchMutationDeps & {
+    batchDeleteMessages: ReturnType<typeof vi.fn>;
+    batchMoveMessages: ReturnType<typeof vi.fn>;
+    imapBatchMove: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("toManagerScope", () => {
+  it("maps sourceAccount -> account and sourceMailbox -> mailbox", () => {
+    expect(toManagerScope({ sourceAccount: "Work", sourceMailbox: "INBOX" })).toEqual({
+      account: "Work",
+      mailbox: "INBOX",
+    });
+  });
+
+  it("does not transpose the two fields", () => {
+    const scope = toManagerScope({ sourceAccount: "Work", sourceMailbox: "Archive" });
+    expect(scope.account).toBe("Work");
+    expect(scope.mailbox).toBe("Archive");
+  });
+
+  it("leaves both undefined when neither is supplied", () => {
+    expect(toManagerScope({})).toEqual({ account: undefined, mailbox: undefined });
+  });
+});
+
+describe("batch-delete-messages wiring", () => {
+  it("forwards sourceMailbox/sourceAccount into the manager as a scope pair", async () => {
+    const d = deps();
+    await runBatchDelete(d, {
+      ids: ["101", "102"],
+      sourceMailbox: "INBOX",
+      sourceAccount: "iCloud",
+    });
+
+    expect(d.batchDeleteMessages).toHaveBeenCalledTimes(1);
+    const [ids, scope] = d.batchDeleteMessages.mock.calls[0];
+    expect(ids).toEqual(["101", "102"]);
+    expect(scope).toEqual({ account: "iCloud", mailbox: "INBOX" });
+  });
+
+  it("passes an unscoped call through as both-undefined, not as a partial scope", async () => {
+    const d = deps();
+    await runBatchDelete(d, { ids: ["101"] });
+    expect(d.batchDeleteMessages.mock.calls[0][1]).toEqual({
+      account: undefined,
+      mailbox: undefined,
+    });
+  });
+
+  it("surfaces reconciliation warnings from the forensics report", async () => {
+    const d = deps({
+      collectForensics: () => ({ warnings: ['⚠️ Effect mismatch in "INBOX"'] }),
+    } as Partial<BatchMutationDeps>);
+    const res = await runBatchDelete(d, {
+      ids: ["101"],
+      sourceMailbox: "INBOX",
+      sourceAccount: "A",
+    });
+    expect(JSON.stringify(res)).toContain("Effect mismatch");
+  });
+});
+
+describe("batch-move-messages wiring", () => {
+  it("keeps the destination account distinct from the source scope", async () => {
+    const d = deps();
+    await runBatchMove(d, {
+      ids: ["201"],
+      mailbox: "Archive",
+      account: "Destination",
+      sourceMailbox: "INBOX",
+      sourceAccount: "Source",
+    });
+
+    const [ids, mailbox, account, scope] = d.batchMoveMessages.mock.calls[0];
+    expect(ids).toEqual(["201"]);
+    expect(mailbox).toBe("Archive");
+    // The DESTINATION account — conflating this with sourceAccount would move
+    // messages out of the wrong account entirely.
+    expect(account).toBe("Destination");
+    expect(scope).toEqual({ account: "Source", mailbox: "INBOX" });
+  });
+
+  it("routes imap: ids to the IMAP path with the destination account only", async () => {
+    const d = deps();
+    await runBatchMove(d, {
+      ids: ["imap:a/INBOX/7"],
+      mailbox: "Archive",
+      account: "Destination",
+      sourceMailbox: "INBOX",
+      sourceAccount: "Source",
+    });
+    expect(d.imapBatchMove).toHaveBeenCalledWith(["imap:a/INBOX/7"], "Archive", {
+      account: "Destination",
+    });
+  });
+});

--- a/src/tools/batchMutations.ts
+++ b/src/tools/batchMutations.ts
@@ -1,0 +1,147 @@
+/**
+ * The two destructive batch tool handlers, lifted out of `index.ts` so the
+ * wiring between the tool schema and the manager is executable in a test.
+ *
+ * Why this module exists (#156 item 4): `batch-delete-messages` and
+ * `batch-move-messages` grew `sourceMailbox`/`sourceAccount` in #154 and had
+ * their meaning tightened in #159 — but nothing exercised `index.ts` actually
+ * *forwarding* those two fields into the manager. `index.ts` opens a stdio
+ * transport at import, so no unit test can load it; the forwarding was verified
+ * by reading the code. A silent swap of the two arguments, or dropping one,
+ * would have passed the whole suite.
+ *
+ * The fix is the move #154 already made for `batchResults`: keep the handler
+ * body here, behind an injected dependency bundle, and let `index.ts` supply the
+ * real manager. The scope-forwarding contract is then a normal assertion.
+ */
+import type { BatchOperationResult } from "@/types.js";
+import type { ToolResponse } from "@/tools/respond.js";
+import type { ImapBatchResult } from "@/services/imapClient.js";
+import { hybridBatchCounts, batchResponse } from "@/tools/batchResults.js";
+
+/** The source scope a caller pins numeric ids to. Both fields or neither (#159). */
+export interface BatchSourceScope {
+  account?: string;
+  mailbox?: string;
+}
+
+/** Forensic material a destructive batch produces (#155/#157). */
+export interface BatchForensics {
+  countDelta?: unknown;
+  warnings: string[];
+}
+
+/**
+ * Everything the handlers need from the module graph `index.ts` owns. Injected
+ * rather than imported so a test can drive the handler without a live Mail.app,
+ * an audit-log file, or a stdio transport.
+ */
+export interface BatchMutationDeps {
+  batchDeleteMessages(ids: string[], scope: BatchSourceScope): BatchOperationResult[];
+  batchMoveMessages(
+    ids: string[],
+    mailbox: string,
+    account: string | undefined,
+    scope: BatchSourceScope
+  ): BatchOperationResult[];
+  imapBatchDelete(ids: string[]): Promise<ImapBatchResult>;
+  imapBatchMove(
+    ids: string[],
+    mailbox: string,
+    opts: { account?: string }
+  ): Promise<ImapBatchResult>;
+  collectForensics(tool: string, args: Record<string, unknown>): BatchForensics;
+}
+
+/**
+ * `sourceMailbox`/`sourceAccount` as the manager expects them.
+ *
+ * Named and exported so the mapping is a thing a test can point at: the tool
+ * argument is `sourceAccount`, the manager field is `account`, and getting that
+ * transposition wrong is exactly the defect class #154 and #159 were about.
+ */
+export function toManagerScope(args: {
+  sourceAccount?: string;
+  sourceMailbox?: string;
+}): BatchSourceScope {
+  return { account: args.sourceAccount, mailbox: args.sourceMailbox };
+}
+
+/** `batch-delete-messages`. */
+export async function runBatchDelete(
+  deps: BatchMutationDeps,
+  args: { ids: string[]; sourceMailbox?: string; sourceAccount?: string }
+): Promise<ToolResponse> {
+  const { ids, sourceMailbox, sourceAccount } = args;
+  let forensics: BatchForensics = { warnings: [] };
+  const counts = await hybridBatchCounts(
+    ids,
+    (n) => {
+      const res = deps.batchDeleteMessages(n, toManagerScope({ sourceAccount, sourceMailbox }));
+      forensics = deps.collectForensics("batch-delete-messages", {
+        ids,
+        sourceMailbox,
+        sourceAccount,
+      });
+      return res;
+    },
+    (im) => deps.imapBatchDelete(im)
+  );
+  return batchResponse(
+    counts,
+    {
+      allSucceeded: (n) => `Successfully deleted ${n} message(s)`,
+      allFailed: (n) => `Failed to delete all ${n} message(s)`,
+      partial: (ok, failed) => `Deleted ${ok} message(s), ${failed} failed`,
+    },
+    forensics.countDelta ? { countDelta: forensics.countDelta } : {},
+    forensics.warnings
+  );
+}
+
+/** `batch-move-messages`. */
+export async function runBatchMove(
+  deps: BatchMutationDeps,
+  args: {
+    ids: string[];
+    mailbox: string;
+    account?: string;
+    sourceMailbox?: string;
+    sourceAccount?: string;
+  }
+): Promise<ToolResponse> {
+  const { ids, mailbox, account, sourceMailbox, sourceAccount } = args;
+  let forensics: BatchForensics = { warnings: [] };
+  const counts = await hybridBatchCounts(
+    ids,
+    (n) => {
+      // `account` is the DESTINATION account; `sourceAccount` pins where the ids
+      // were listed FROM. They are different arguments and must not be conflated.
+      const res = deps.batchMoveMessages(
+        n,
+        mailbox,
+        account,
+        toManagerScope({ sourceAccount, sourceMailbox })
+      );
+      forensics = deps.collectForensics("batch-move-messages", {
+        ids,
+        mailbox,
+        account,
+        sourceMailbox,
+        sourceAccount,
+      });
+      return res;
+    },
+    (im) => deps.imapBatchMove(im, mailbox, { account })
+  );
+  return batchResponse(
+    counts,
+    {
+      allSucceeded: (n) => `Successfully moved ${n} message(s) to "${mailbox}"`,
+      allFailed: (n) => `Failed to move all ${n} message(s)`,
+      partial: (ok, failed) => `Moved ${ok} message(s) to "${mailbox}", ${failed} failed`,
+    },
+    { mailbox, ...(forensics.countDelta ? { countDelta: forensics.countDelta } : {}) },
+    forensics.warnings
+  );
+}


### PR DESCRIPTION
Closes items **3** and **4** of #156 — the two that #159 left open. With these, #156 can close.

## Item 3 — `runBatchOperation` never consulted `disabledAccountGuard`

The guard existed and the single-message paths used it, but the batch path did not. A batch scoped to an account that is switched off in Mail went straight to AppleScript, failed server-side with AppleEvent −10000, and could leave a mailbox **half-changed** — exactly the outcome the guard was written to prevent.

It now runs before any mutation script is generated. It still **fails open**: `isAccountEnabled` returning `null` (Mail won't say) never blocks an otherwise-valid operation, so this cannot turn an inconclusive probe into an outage.

## Item 4 — nothing executable asserted `index.ts`'s forwarding

`sourceMailbox`/`sourceAccount` were threaded into the manager by code living in `index.ts`, which opens a stdio transport at import and therefore **cannot be loaded by a unit test**. The forwarding was verified by reading it. Transposing the two fields, or dropping one, passed the entire suite — and given that these parameters exist specifically to stop #152-class mis-targeting, that is the wrong thing to have unguarded.

The two destructive handlers move to `src/tools/batchMutations.ts` behind an injected dependency bundle — the same move #154 made for `batchResults` — and `index.ts` supplies the real manager. **No behaviour change**; the handler bodies are transplanted, not rewritten.

The new tests assert what could previously only be read:

- `sourceAccount` → `account`, `sourceMailbox` → `mailbox`, not transposed
- an unscoped call forwards **both** as `undefined`, not a partial scope (which #159 made illegal)
- a move's destination `account` stays distinct from `sourceAccount`
- `imap:` ids route to the IMAP path with the destination account only

## Verification

Each guard was proven by reverting it independently:

| Reverted | Result |
|---|---|
| the disabled-account guard | **2 tests fail** |
| `toManagerScope` transposed | **4 tests fail** |
| `sourceAccount` passed as the move destination | **1 test fails** |

Full suite 623 passing; typecheck, lint, format clean; bundle rebuilt and committed. 2.10.31 with a real CHANGELOG heading.

https://claude.ai/code/session_01PnVGWuj73YQTvpPzFfdWs9