### PR TITLE
harden: this pnpm workspace configuration does not set ... in...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## [Unreleased]
 
+### Changed
+
+- **Supply-chain soak raised from 1 day to 7 days** (`minimumReleaseAge: 10080` in
+  `pnpm-workspace.yaml`), thanks to [@anupamme](https://github.com/anupamme) in
+  [#174](https://github.com/sweetrb/apple-mail-mcp/pull/174). Development/CI-time policy
+  only -- no shipped bytes change. It is not redundant with Dependabot's existing 7-day
+  cooldown: the cooldown governs what Dependabot *proposes* (direct dependencies), while
+  `minimumReleaseAge` governs what a resolution *installs*, including transitives
+  Dependabot never sees. This repo was the one carrying such an entry -- a 5-day-old
+  transitive `ip-address@10.5.0`, admitted by the 1440 default with the cooldown fully in
+  force. Applied across all four Apple MCP repos so the value cannot drift.
+
 ## [2.10.32] - 2026-08-15
 
 ### Security

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,8 +13,18 @@
 allowBuilds:
   esbuild: true
 
-# Pin pnpm 11's supply-chain minimum-release-age to 10080 min (7 days)
-# so newly published packages have a soak period before installation. See https://pnpm.io/supply-chain-security.
+# Supply-chain soak: refuse any package version younger than 7 days (10080 min).
+# Deliberately stricter than pnpm 11's 1440-minute default, and deliberately NOT
+# redundant with dependabot.yml's 7-day cooldown: the cooldown governs only what
+# Dependabot *proposes* (direct deps), while this governs everything a resolution
+# *installs*. Transitive packages reach the lockfile without Dependabot ever seeing
+# them -- apple-mail-mcp carried a 5-day-old transitive ip-address@10.5.0 under the
+# 1440 default, which this value rejects. See https://pnpm.io/supply-chain-security.
+#
+# Cost of the stricter value, stated here so it is not rediscovered painfully: an
+# urgent upstream fix cannot be installed until it is 7 days old. There is no
+# minimumReleaseAgeExclude carve-out; if one is ever needed, add it narrowly and
+# remove it once the version ages past the cutoff.
 minimumReleaseAge: 10080
 
 # Keep transitive dependencies above their security floors until their direct

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,9 +13,9 @@
 allowBuilds:
   esbuild: true
 
-# Pin pnpm 11's supply-chain minimum-release-age default explicitly (1440 min = 1 day)
-# so it is documented and stable across pnpm upgrades. See https://pnpm.io/supply-chain-security.
-minimumReleaseAge: 1440
+# Pin pnpm 11's supply-chain minimum-release-age to 10080 min (7 days)
+# so newly published packages have a soak period before installation. See https://pnpm.io/supply-chain-security.
+minimumReleaseAge: 10080
 
 # Keep transitive dependencies above their security floors until their direct
 # parents' ranges move past the patched releases.


### PR DESCRIPTION
## Summary
Harden input handling in `pnpm-workspace.yaml` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | package_managers.pnpm.pnpm-missing-minimum-release-age.pnpm-minimum-release-age |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `package_managers.pnpm.pnpm-missing-minimum-release-age.pnpm-minimum-release-age` |
| **File** | `pnpm-workspace.yaml:18` |
| **Assessment** | Defensive hardening |

**Description**: This pnpm workspace configuration does not set a minimum release age. Newly published packages can be malicious or unstable. Add `minimumReleaseAge: 10080` (minutes) to wait at least seven days before installing newly published package versions. Added in: v10.16.0 Reference: https://pnpm.io/settings#minimumreleaseage

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `pnpm-workspace.yaml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
