### PR TITLE
fix: chunk the collateral snapshot so it stops giving up on large mailboxes (#176)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.32",
+      "version": "2.10.33",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.32",
+      "version": "2.10.33",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.32",
+  "version": "2.10.33",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.32",
+  "version": "2.10.33",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.32",
+      "version": "2.10.33",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.32",
+  "version": "2.10.33",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,42 @@
 ## [Unreleased]
 
+## [2.10.33] - 2026-08-15
+
+### Fixed
+
+- **The collateral snapshot no longer gives up on a large mailbox**
+  ([#176](https://github.com/sweetrb/apple-mail-mcp/issues/176)). It used to issue one
+  whole-mailbox property read; when Mail declined it, the entire diff came back
+  `"snapshot": "unavailable"` and an unrequested departure became un-attributable. The
+  cost of that request grows with the mailbox, so the one mechanism that can attribute
+  collateral damage was **least** reliable exactly when the batch and the blast radius
+  were largest — that correlation was the defect, not any individual failure. Reported by
+  [@scottstern0325](https://github.com/scottstern0325) on a 29-id batch, during which an
+  Amazon shipment notice they had never named left INBOX and could not be attributed.
+
+  The mailbox is now read in `APPLE_MAIL_MCP_AUDIT_SNAPSHOT_CHUNK`-sized slices (default
+  250), each retried once on its own, so a refusal costs one slice instead of the whole
+  snapshot.
+
+### Added
+
+- **`"snapshot": "partial"` — a diff that names its own gap.** When a slice still will not
+  read, the record reports what it *could* observe plus an `unobserved` list of the
+  unreadable position ranges per phase, instead of the old all-or-nothing `unavailable`.
+  "Nothing unrequested left the 400 messages I could see, and I could not see the other
+  120" is strictly more useful than no diff, and honest about the hole.
+- **`APPLE_MAIL_MCP_AUDIT_SNAPSHOT_CHUNK`** (default `250`) — messages read per request.
+
 ### Changed
 
+- **Each half of the collateral diff is now gated on the snapshot that could refute it.**
+  `disappeared` / `unrequested` are reported only when the **after** snapshot is complete;
+  `appeared` only when the **before** snapshot is. A message absent from a partial `after`
+  may merely be unread, so naming it would put an innocent message in front of someone
+  mid-incident as evidence of data loss — a fabricated finding is worse than a stated gap.
+  **An absent field now means "not computable", not "empty"**; check `"snapshot": "ok"`
+  before reading `disappeared` as a clean result. The false-ok warning already required
+  `"ok"`, so a `partial` snapshot cannot raise it.
 - **Supply-chain soak raised from 1 day to 7 days** (`minimumReleaseAge: 10080` in
   `pnpm-workspace.yaml`), thanks to [@anupamme](https://github.com/anupamme) in
   [#174](https://github.com/sweetrb/apple-mail-mcp/pull/174). Development/CI-time policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@
   120" is strictly more useful than no diff, and honest about the hole.
 - **`APPLE_MAIL_MCP_AUDIT_SNAPSHOT_CHUNK`** (default `250`) — messages read per request.
 
+### Documentation
+
+- **`fetch-attachment`'s description no longer claims it works "without touching disk".**
+  On the AppleScript path Mail writes the attachment into a private temp directory, which
+  is read back and deleted — no file is left behind, but the operation is not disk-free.
+  The description now says that, and states that the tool needs **no Full Disk Access**
+  (Mail performs the write under the Automation grant; this server never reads the mail
+  store). Prompted by a review of the Hermes catalog entry that inferred an FDA
+  requirement from the silence.
+
 ### Changed
 
 - **Each half of the collateral diff is now gated on the snapshot that could refute it.**

--- a/README.md
+++ b/README.md
@@ -1399,6 +1399,7 @@ batch of only `imap:` ids returns no `countDelta` rather than a fabricated one.
 | `APPLE_MAIL_MCP_AUDIT_LOG` | *(off)* | Absolute path to an NDJSON file. Setting it enables the audit log **and** the collateral diff below |
 | `APPLE_MAIL_MCP_AUDIT_SUBJECTS` | `0` | Set `1` to also record message **subjects**. Separate, deliberate second opt-in — see Privacy |
 | `APPLE_MAIL_MCP_AUDIT_SNAPSHOT_MAX` | `2000` | Skip the collateral snapshot for mailboxes larger than this many messages. `0` disables the snapshot entirely |
+| `APPLE_MAIL_MCP_AUDIT_SNAPSHOT_CHUNK` | `250` | How many messages the collateral snapshot reads from Mail per request. Lower it if Mail declines slices on a very large mailbox |
 
 When set, each destructive operation appends **one JSON object per line**
 containing: timestamp, tool name, server version, the arguments it was called
@@ -1451,12 +1452,45 @@ exceed AppleScript's 2^29 integer range (where Mail hands them back as
 compared in the raw form, a message you explicitly asked to delete would be
 reported here as collateral.
 
-This costs one bulk property read per snapshot and is O(mailbox size), so it is
-bounded by `APPLE_MAIL_MCP_AUDIT_SNAPSHOT_MAX`. When the bound bites, the record
-says so explicitly (`"snapshot": "skipped"` with a reason) rather than omitting
-the field — a silently skipped snapshot would read as "nothing collateral
-happened", which is worse than no snapshot at all. `countDelta` is unaffected by
-the skip and still reconciles the counts.
+This is O(mailbox size), so it is bounded by `APPLE_MAIL_MCP_AUDIT_SNAPSHOT_MAX`.
+When the bound bites, the record says so explicitly (`"snapshot": "skipped"` with
+a reason) rather than omitting the field — a silently skipped snapshot would read
+as "nothing collateral happened", which is worse than no snapshot at all.
+`countDelta` is unaffected by the skip and still reconciles the counts.
+
+#### Partial snapshots on large mailboxes
+
+The mailbox is read in `APPLE_MAIL_MCP_AUDIT_SNAPSHOT_CHUNK`-sized slices, each
+retried once on its own. It used to be a single whole-mailbox read, which meant
+Mail declining that one request lost the **entire** diff — and the bigger the
+mailbox, the more likely that was. The mechanism that attributes collateral
+damage was therefore least reliable exactly when the blast radius was largest.
+
+When a slice still will not read, the snapshot is reported as `partial` and it
+**names its own gap**:
+
+```json
+{
+  "snapshot": "partial",
+  "unobserved": [{ "phase": "after", "ranges": "251-500" }],
+  "appeared": [],
+  "skipReason": "Mail would not read 251-500 (after) of this mailbox, so the snapshot has a hole in it. …"
+}
+```
+
+Each half of the diff is withheld when the snapshot that could **refute** it has
+a hole, because a wrong name here is worse than a missing one:
+
+| Hole in | `disappeared` / `unrequested` | `appeared` |
+|---------|-------------------------------|------------|
+| neither (`"ok"`) | reported | reported |
+| `before` | reported (an undercount — a message never read before cannot be missed after) | withheld |
+| `after` | **withheld** — a message absent from a partial `after` may merely be unread, and naming it would present an innocent message as evidence of data loss | reported |
+| both | withheld | withheld |
+
+**An absent field means "not computable", never "empty".** Check
+`"snapshot": "ok"` before reading `disappeared` as a clean bill of health — the
+false-ok warning does exactly that, so a `partial` snapshot never triggers it.
 
 ### Privacy, and what the file costs you
 

--- a/build/index.js
+++ b/build/index.js
@@ -86461,7 +86461,7 @@ registerTool(
 registerTool(
   "fetch-attachment",
   {
-    description: "Use when: retrieving an attachment's raw bytes inline as base64 (by message id and attachmentName), e.g. to process its contents without touching disk.\nReturns: the attachment's bytes base64-encoded, with its size and (for IMAP) MIME type.\nDo not use when: you don't know the attachment name (use list-attachments first) or you just want it saved to disk (use save-attachment).",
+    description: "Use when: retrieving an attachment's raw bytes inline as base64 (by message id and attachmentName), e.g. to process its contents without keeping a file.\nReturns: the attachment's bytes base64-encoded, with its size and (for IMAP) MIME type.\nDo not use when: you don't know the attachment name (use list-attachments first) or you just want it saved to disk (use save-attachment).\nSafety: leaves no file behind, but the AppleScript path is not disk-free \u2014 Mail writes the attachment into a private temp directory, which is read back and then deleted. Needs no Full Disk Access either way: Mail performs that write under the Automation grant, and this server never reads the mail store itself.",
     inputSchema: {
       id: MESSAGE_ID_SCHEMA,
       attachmentName: external_exports.string().min(1, "Attachment name is required")

--- a/build/index.js
+++ b/build/index.js
@@ -78791,7 +78791,10 @@ import { appendFileSync } from "node:fs";
 var AUDIT_LOG_ENV = "APPLE_MAIL_MCP_AUDIT_LOG";
 var AUDIT_SUBJECTS_ENV = "APPLE_MAIL_MCP_AUDIT_SUBJECTS";
 var AUDIT_SNAPSHOT_MAX_ENV = "APPLE_MAIL_MCP_AUDIT_SNAPSHOT_MAX";
+var AUDIT_SNAPSHOT_CHUNK_ENV = "APPLE_MAIL_MCP_AUDIT_SNAPSHOT_CHUNK";
 var DEFAULT_SNAPSHOT_MAX = 2e3;
+var DEFAULT_SNAPSHOT_CHUNK = 250;
+var SNAPSHOT_SLICE_ATTEMPTS = 2;
 function isOn(raw) {
   return /^(1|true|yes|on)$/i.test((raw ?? "").trim());
 }
@@ -78810,6 +78813,13 @@ function auditSnapshotMax() {
   if (raw === void 0 || raw === "") return DEFAULT_SNAPSHOT_MAX;
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) return DEFAULT_SNAPSHOT_MAX;
+  return Math.floor(n);
+}
+function auditSnapshotChunk() {
+  const raw = process.env[AUDIT_SNAPSHOT_CHUNK_ENV]?.trim();
+  if (raw === void 0 || raw === "") return DEFAULT_SNAPSHOT_CHUNK;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_SNAPSHOT_CHUNK;
   return Math.floor(n);
 }
 function writeAuditRecord(record2) {
@@ -79402,10 +79412,24 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
    * into a SNAP record — the before/after pair the collateral diff subtracts.
    *
    * Empty string when the audit log is off or the snapshot is disabled, so the
-   * whole layer costs literally nothing by default. The two property reads are
-   * BULK (`id of messages of mb`, `message id of messages of mb`) — two Apple
-   * Events for the whole mailbox rather than two per message — and the joining
-   * is pure in-memory AppleScript.
+   * whole layer costs literally nothing by default. The property reads are BULK
+   * (`id of messages i thru j of mb`) — two Apple Events per SLICE rather than
+   * two per message — and the joining is pure in-memory AppleScript.
+   *
+   * ## Why it is sliced rather than one whole-mailbox read (#176)
+   *
+   * This used to be a single `id of messages of mb` pair. When Mail declined
+   * that request the entire snapshot came back `unavailable`, and the cost of
+   * the request grows with the mailbox — so the one mechanism that can attribute
+   * an unrequested departure was least reliable exactly when the batch and the
+   * mailbox, and therefore the blast radius, were largest. That correlation was
+   * the defect, not any individual failure.
+   *
+   * Now the mailbox is read in `APPLE_MAIL_MCP_AUDIT_SNAPSHOT_CHUNK`-sized
+   * slices; each slice is retried once on its own; and a slice that still will
+   * not read costs only its own range. The unreadable ranges are emitted in
+   * their own field, so the diff can report a PARTIAL snapshot that names its
+   * own gap instead of an all-or-nothing `unavailable`.
    *
    * Above `APPLE_MAIL_MCP_AUDIT_SNAPSHOT_MAX` messages the snapshot is skipped,
    * and the skip is EMITTED as a record with its reason. A silently skipped
@@ -79422,46 +79446,77 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
   snapshotFragment(phase, acctExpr, mbExpr, countVar, mbVar = "_tmb") {
     const max = auditSnapshotMax();
     if (!isAuditEnabled() || max <= 0) return "";
+    const chunk = auditSnapshotChunk();
     return `
         set _sStatus to "ok"
         set _sPayload to ""
-        set _sIds to {}
-        set _sMids to {}
+        set _sMiss to ""
+        set _sPairs to {}
+        set _sChunk to ${chunk}
         if ${countVar} < 0 then
           set _sStatus to "unavailable"
         else if ${countVar} > ${max} then
           set _sStatus to "skipped"
           set _sPayload to "mailbox holds " & (${countVar} as string) & " messages, above ${AUDIT_SNAPSHOT_MAX_ENV}=${max}"
         else
-          try
-            set _sIds to (id of messages of ${mbVar})
-            set _sMids to (message id of messages of ${mbVar})
-          on error
-            set _sStatus to "unavailable"
-          end try
-          if _sStatus is "ok" then
-            if (count of _sIds) is not (count of _sMids) then
+          set _sLo to 1
+          repeat while _sLo <= ${countVar}
+            set _sHi to _sLo + _sChunk - 1
+            if _sHi > ${countVar} then set _sHi to ${countVar}
+            set _sGot to false
+            repeat with _sTry from 1 to ${SNAPSHOT_SLICE_ATTEMPTS}
+              set _sIds to {}
+              set _sMids to {}
+              -- A slice is staged into _sBuf and merged only once it has been
+              -- read IN FULL. Appending as we go would leave a slice that threw
+              -- halfway both partially recorded AND marked unread, and the
+              -- retry would then record its messages a second time.
+              set _sBuf to {}
+              try
+                set _sIds to (id of messages _sLo thru _sHi of ${mbVar})
+                set _sMids to (message id of messages _sLo thru _sHi of ${mbVar})
+                if (class of _sIds) is not list then set _sIds to {_sIds}
+                if (class of _sMids) is not list then set _sMids to {_sMids}
+                if (count of _sIds) is (count of _sMids) then
+                  repeat with _q from 1 to (count of _sIds)
+                    set _sOne to ""
+                    try
+                      set _zSnapMid to ((item _q of _sMids) as string)${this.sanitizeFragment("_zSnapMid", "                      ")}
+                      set _sOne to ((item _q of _sIds) as string) & "${SNAP_PAIR}" & _zSnapMid
+                    on error
+                      set _sOne to ((item _q of _sIds) as string) & "${SNAP_PAIR}"
+                    end try
+                    set end of _sBuf to _sOne
+                  end repeat
+                  set _sGot to true
+                end if
+              end try
+              if _sGot then
+                repeat with _sB in _sBuf
+                  set end of _sPairs to (contents of _sB)
+                end repeat
+                exit repeat
+              end if
+            end repeat
+            if not _sGot then
+              if _sMiss is not "" then set _sMiss to _sMiss & ","
+              set _sMiss to _sMiss & (_sLo as string) & "-" & (_sHi as string)
+            end if
+            set _sLo to _sHi + 1
+          end repeat
+          if _sMiss is not "" then
+            if (count of _sPairs) is 0 then
               set _sStatus to "unavailable"
             else
-              set _sPairs to {}
-              repeat with _q from 1 to (count of _sIds)
-                set _sOne to ""
-                try
-                  set _zSnapMid to ((item _q of _sMids) as string)${this.sanitizeFragment("_zSnapMid", "                  ")}
-                  set _sOne to ((item _q of _sIds) as string) & "${SNAP_PAIR}" & _zSnapMid
-                on error
-                  set _sOne to ((item _q of _sIds) as string) & "${SNAP_PAIR}"
-                end try
-                set end of _sPairs to _sOne
-              end repeat
-              set _sTid to AppleScript's text item delimiters
-              set AppleScript's text item delimiters to "${SNAP_ITEM}"
-              set _sPayload to _sPairs as string
-              set AppleScript's text item delimiters to _sTid
+              set _sStatus to "partial"
             end if
           end if
+          set _sTid to AppleScript's text item delimiters
+          set AppleScript's text item delimiters to "${SNAP_ITEM}"
+          set _sPayload to _sPairs as string
+          set AppleScript's text item delimiters to _sTid
         end if
-        set _out to _out & "${SNAP_TAG}${FIELD_SEP}" & ${acctExpr} & "${FIELD_SEP}" & ${mbExpr} & "${FIELD_SEP}${phase}${FIELD_SEP}" & _sStatus & "${FIELD_SEP}" & _sPayload & "${RECORD_SEP}"`;
+        set _out to _out & "${SNAP_TAG}${FIELD_SEP}" & ${acctExpr} & "${FIELD_SEP}" & ${mbExpr} & "${FIELD_SEP}${phase}${FIELD_SEP}" & _sStatus & "${FIELD_SEP}" & _sPayload & "${FIELD_SEP}" & _sMiss & "${RECORD_SEP}"`;
   }
   /**
    * AppleScript capturing the message the op is ABOUT to touch into `_pre`,
@@ -79527,7 +79582,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           mailbox: f[2] ?? "",
           phase: f[3] === "after" ? "after" : "before",
           status: f[4] ?? "",
-          payload: f[5] ?? ""
+          payload: f[5] ?? "",
+          miss: f[6] ?? ""
         });
         continue;
       }
@@ -79677,8 +79733,9 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         });
         continue;
       }
-      if (b.status !== "ok" || a.status !== "ok") {
-        const bad = b.status !== "ok" ? b : a;
+      const dead = (s) => s.status !== "ok" && s.status !== "partial";
+      if (dead(b) || dead(a)) {
+        const bad = dead(b) ? b : a;
         collateral.push({
           account: g.account,
           mailbox: g.mailbox,
@@ -79696,13 +79753,30 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       const unrequested = disappeared.filter(
         (e) => !requestedNumericIds.has(canonicalNumericId(e.id))
       );
+      const holes = [b, a].filter((s) => s.miss !== "").map((s) => ({ phase: s.phase, ranges: s.miss }));
+      if (holes.length === 0) {
+        collateral.push({
+          account: g.account,
+          mailbox: g.mailbox,
+          snapshot: "ok",
+          disappeared,
+          unrequested,
+          appeared
+        });
+        continue;
+      }
+      const derivable = [
+        a.miss === "" ? `what left the ${beforeEntries.length} message(s) read before it` : null,
+        b.miss === "" ? "what arrived during it" : null
+      ].filter((s) => s !== null);
       collateral.push({
         account: g.account,
         mailbox: g.mailbox,
-        snapshot: "ok",
-        disappeared,
-        unrequested,
-        appeared
+        snapshot: "partial",
+        skipReason: `Mail would not read ${holes.map((h) => `${h.ranges} (${h.phase})`).join(", ")} of this mailbox, so the snapshot has a hole in it. ` + (derivable.length > 0 ? `Still derivable and reported: ${derivable.join(" and ")}. ` : `Neither half of the diff is derivable from it. `) + `Anything the unread range could refute is omitted rather than guessed \u2014 an absent field here means "not computable", not "empty".`,
+        unobserved: holes,
+        ...a.miss === "" ? { disappeared, unrequested } : {},
+        ...b.miss === "" ? { appeared } : {}
       });
     }
     return { countDeltas, preImages, outcomes: parsed.outcomes, collateral };

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.32",
+  "version": "2.10.33",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.10.32"
+        "apple-mail-mcp@2.10.33"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.32",
+  "version": "2.10.33",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1865,7 +1865,7 @@ registerTool(
   "fetch-attachment",
   {
     description:
-      "Use when: retrieving an attachment's raw bytes inline as base64 (by message id and attachmentName), e.g. to process its contents without touching disk.\nReturns: the attachment's bytes base64-encoded, with its size and (for IMAP) MIME type.\nDo not use when: you don't know the attachment name (use list-attachments first) or you just want it saved to disk (use save-attachment).",
+      "Use when: retrieving an attachment's raw bytes inline as base64 (by message id and attachmentName), e.g. to process its contents without keeping a file.\nReturns: the attachment's bytes base64-encoded, with its size and (for IMAP) MIME type.\nDo not use when: you don't know the attachment name (use list-attachments first) or you just want it saved to disk (use save-attachment).\nSafety: leaves no file behind, but the AppleScript path is not disk-free — Mail writes the attachment into a private temp directory, which is read back and then deleted. Needs no Full Disk Access either way: Mail performs that write under the Automation grant, and this server never reads the mail store itself.",
     inputSchema: {
       id: MESSAGE_ID_SCHEMA,
       attachmentName: z.string().min(1, "Attachment name is required"),

--- a/src/services/appleMailManager.forensics.test.ts
+++ b/src/services/appleMailManager.forensics.test.ts
@@ -56,6 +56,26 @@ const h = vi.hoisted(() => ({
   errorOn: {} as Record<string, string>,
   /** id → the "account/mailbox, " list Mail builds when an id is ambiguous. */
   ambiguousOn: {} as Record<string, string>,
+  /**
+   * How many messages Mail will answer for in ONE property request. A request
+   * covering more than this is REFUSED — which is #176: the whole-mailbox read
+   * the snapshot used to issue gets less likely to succeed the bigger the
+   * mailbox is, so the one mechanism that can attribute collateral damage was
+   * least reliable exactly when the blast radius was largest. `null` = Mail
+   * answers whatever it is asked.
+   */
+  bulkReadCeiling: null as number | null,
+  /**
+   * Position ranges ("101-200") Mail refuses no matter how often they are
+   * asked for, per phase — a slice that stays unreadable even after the retry.
+   */
+  failSliceAlways: { before: [] as string[], after: [] as string[] },
+  /**
+   * Ranges Mail refuses the FIRST time and answers on a second attempt. If the
+   * generated script does not retry, these come back unread — so the retry
+   * cannot be silently dropped and still pass.
+   */
+  failSliceOnce: [] as string[],
   account: "me@example.com",
   mailboxName: "INBOX",
 }));
@@ -163,6 +183,17 @@ function simulateDestructive(script: string): string {
   const before = h.mailbox.slice();
   let out = "";
 
+  // The slice size and retry budget the generated script asked for. `null` =
+  // the script issues ONE whole-mailbox read, which is what it did before #176.
+  const snapChunk = (() => {
+    const m = /set _sChunk to (\d+)/.exec(script);
+    return m ? Number(m[1]) : null;
+  })();
+  const snapAttempts = (() => {
+    const m = /repeat with _sTry from 1 to (\d+)/.exec(script);
+    return m ? Number(m[1]) : 1;
+  })();
+
   const emitSnapshot = (phase: "before" | "after", state: FakeMsg[]): void => {
     if (snapMax === null) return;
     if (state.length > snapMax) {
@@ -171,10 +202,34 @@ function simulateDestructive(script: string): string {
         `mailbox holds ${state.length} messages, above APPLE_MAIL_MCP_AUDIT_SNAPSHOT_MAX=${snapMax}${RECORD_SEP}`;
       return;
     }
-    const payload = state
+    // Exactly the requests the script issues: one whole-mailbox read when it
+    // names no chunk size, otherwise consecutive slices of that size.
+    const slices: [number, number][] = [];
+    if (snapChunk === null) {
+      if (state.length > 0) slices.push([1, state.length]);
+    } else {
+      for (let lo = 1; lo <= state.length; lo += snapChunk) {
+        slices.push([lo, Math.min(lo + snapChunk - 1, state.length)]);
+      }
+    }
+    const observed: FakeMsg[] = [];
+    const missed: string[] = [];
+    for (const [lo, hi] of slices) {
+      const range = `${lo}-${hi}`;
+      const tooBig = h.bulkReadCeiling !== null && hi - lo + 1 > h.bulkReadCeiling;
+      const always = h.failSliceAlways[phase].includes(range);
+      // Answered on a retry — only if the script actually retries.
+      const transient = h.failSliceOnce.includes(range) && snapAttempts < 2;
+      if (tooBig || always || transient) missed.push(range);
+      else observed.push(...state.slice(lo - 1, hi));
+    }
+    const status = missed.length === 0 ? "ok" : observed.length === 0 ? "unavailable" : "partial";
+    const payload = observed
       .map((m) => `${asMailWouldRenderId(m.id)}${SNAP_PAIR}${asMailWouldEmit("_zSnapMid", m.mid)}`)
       .join(SNAP_ITEM);
-    out += `${SNAP_TAG}${FIELD_SEP}${acct}${FIELD_SEP}${mbox}${FIELD_SEP}${phase}${FIELD_SEP}ok${FIELD_SEP}${payload}${RECORD_SEP}`;
+    out +=
+      `${SNAP_TAG}${FIELD_SEP}${acct}${FIELD_SEP}${mbox}${FIELD_SEP}${phase}${FIELD_SEP}${status}` +
+      `${FIELD_SEP}${payload}${FIELD_SEP}${missed.join(",")}${RECORD_SEP}`;
   };
 
   emitSnapshot("before", before);
@@ -225,6 +280,7 @@ import {
   AUDIT_LOG_ENV,
   AUDIT_SUBJECTS_ENV,
   AUDIT_SNAPSHOT_MAX_ENV,
+  AUDIT_SNAPSHOT_CHUNK_ENV,
   reconciliationWarnings,
   writeDestructiveAudit,
   falseOkWarning,
@@ -256,10 +312,14 @@ beforeEach(() => {
   h.flagOnlyDelete = false;
   h.errorOn = {};
   h.ambiguousOn = {};
+  h.bulkReadCeiling = null;
+  h.failSliceAlways = { before: [], after: [] };
+  h.failSliceOnce = [];
   tmp = mkdtempSync(join(tmpdir(), "amcp-audit-"));
   delete process.env[AUDIT_LOG_ENV];
   delete process.env[AUDIT_SUBJECTS_ENV];
   delete process.env[AUDIT_SNAPSHOT_MAX_ENV];
+  delete process.env[AUDIT_SNAPSHOT_CHUNK_ENV];
   seed(SAMPLE);
 });
 
@@ -267,6 +327,7 @@ afterEach(() => {
   delete process.env[AUDIT_LOG_ENV];
   delete process.env[AUDIT_SUBJECTS_ENV];
   delete process.env[AUDIT_SNAPSHOT_MAX_ENV];
+  delete process.env[AUDIT_SNAPSHOT_CHUNK_ENV];
   rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -802,6 +863,166 @@ describe("collateral identification (opt-in, gated on the audit log)", () => {
     mgr.batchDeleteMessages(["75811"], { account: h.account, mailbox: h.mailboxName });
     expect(h.calls[1]).not.toContain(SNAP_TAG);
     expect(mgr.consumeLastForensics()!.collateral).toEqual([]);
+  });
+
+  // =========================================================================
+  // #176 — the snapshot must not give up on a big mailbox
+  //
+  // Before this, the snapshot issued ONE whole-mailbox read. When Mail declined
+  // it the whole diff came back `unavailable`, and declining gets more likely
+  // the bigger the mailbox is — so the only mechanism that can attribute an
+  // unrequested departure was least reliable exactly when the batch and the
+  // blast radius were largest. That correlation is the defect.
+  //
+  // `h.bulkReadCeiling` is what makes these tests real: the simulator refuses
+  // any request covering more messages than Mail will answer for, so a script
+  // that still asks for the whole mailbox gets `unavailable` and these fail.
+  // =========================================================================
+  describe("large mailboxes (#176)", () => {
+    /** A mailbox of `n` messages, ids ascending from 90000. */
+    const many = (n: number): FakeMsg[] =>
+      Array.from({ length: n }, (_, i) => ({
+        id: String(90000 + i),
+        mid: `m${i}@example.com`,
+        subject: `Message ${i}`,
+      }));
+
+    it("still names collateral on a mailbox too big for one whole-mailbox read", () => {
+      process.env[AUDIT_LOG_ENV] = auditFile();
+      process.env[AUDIT_SNAPSHOT_CHUNK_ENV] = "100";
+      seed(many(600));
+      h.bulkReadCeiling = 250; // Mail will not answer for 600 at once
+      h.collateral = ["90500"]; // a message the caller never named leaves
+      mgr.batchDeleteMessages(["90000"], { account: h.account, mailbox: h.mailboxName });
+      const report = mgr.consumeLastForensics()!;
+      const [c] = report.collateral;
+      // Every slice fits under the ceiling, so the snapshot is COMPLETE — the
+      // pre-#176 code asked for all 600 at once and got "unavailable" here.
+      expect(c.snapshot).toBe("ok");
+      expect(c.unrequested).toEqual([{ id: "90500", messageId: "m500@example.com" }]);
+      expect(reconciliationWarnings(report)).toHaveLength(1);
+    });
+
+    it("reads the mailbox in bounded slices rather than all at once", () => {
+      process.env[AUDIT_LOG_ENV] = auditFile();
+      process.env[AUDIT_SNAPSHOT_CHUNK_ENV] = "100";
+      seed(many(600));
+      mgr.batchDeleteMessages(["90000"], { account: h.account, mailbox: h.mailboxName });
+      const script = h.calls.find((s) => s.includes("delete _msg"))!;
+      expect(script).toContain("id of messages _sLo thru _sHi of _tmb");
+      expect(script).toContain("set _sChunk to 100");
+      // The unbounded form is what #176 is about; it must be gone.
+      expect(script).not.toContain("id of messages of _tmb");
+      // Structural, because the mock cannot simulate an AppleScript raising
+      // PART WAY through a slice: entries are staged into _sBuf and merged only
+      // after the slice completes. Appending straight into _sPairs would leave a
+      // half-read slice both recorded AND marked unread, so the retry would
+      // record its messages twice.
+      expect(script).toContain("set end of _sBuf to _sOne");
+      expect(script).not.toContain("set end of _sPairs to _sOne");
+    });
+
+    it("retries a slice that fails once, and loses nothing", () => {
+      process.env[AUDIT_LOG_ENV] = auditFile();
+      process.env[AUDIT_SNAPSHOT_CHUNK_ENV] = "100";
+      seed(many(250));
+      // The ceiling is what stops this passing on the un-sliced code: a single
+      // 250-message read is refused outright there, so the retry has to sit on
+      // top of slicing to mean anything.
+      h.bulkReadCeiling = 150;
+      h.failSliceOnce = ["101-200"]; // answered on the second attempt only
+      h.collateral = ["90150"]; // inside the flaky slice
+      mgr.batchDeleteMessages(["90000"], { account: h.account, mailbox: h.mailboxName });
+      const [c] = mgr.consumeLastForensics()!.collateral;
+      expect(c.snapshot).toBe("ok");
+      expect(c.unrequested).toEqual([{ id: "90150", messageId: "m150@example.com" }]);
+    });
+
+    it("reports a PARTIAL snapshot naming its gap instead of giving up", () => {
+      process.env[AUDIT_LOG_ENV] = auditFile();
+      process.env[AUDIT_SNAPSHOT_CHUNK_ENV] = "100";
+      seed(many(250));
+      // One slice stays unreadable in both phases. 150 of 250 messages are
+      // still observed, and that is worth reporting.
+      h.failSliceAlways = { before: ["101-200"], after: ["101-200"] };
+      mgr.batchDeleteMessages(["90000"], { account: h.account, mailbox: h.mailboxName });
+      const [c] = mgr.consumeLastForensics()!.collateral;
+      expect(c.snapshot).toBe("partial");
+      expect(c.unobserved).toEqual([
+        { phase: "before", ranges: "101-200" },
+        { phase: "after", ranges: "101-200" },
+      ]);
+      expect(c.skipReason).toContain("101-200");
+      // Neither half is derivable: both snapshots have a hole, so a message
+      // missing from `after` may merely be unread. Naming it would fabricate a
+      // collateral finding — the one thing this layer must never do.
+      expect(c.disappeared).toBeUndefined();
+      expect(c.unrequested).toBeUndefined();
+      expect(c.appeared).toBeUndefined();
+    });
+
+    it("still reports what left when only the BEFORE snapshot has a hole", () => {
+      process.env[AUDIT_LOG_ENV] = auditFile();
+      process.env[AUDIT_SNAPSHOT_CHUNK_ENV] = "100";
+      seed(many(250));
+      h.failSliceAlways = { before: ["101-200"], after: [] };
+      h.collateral = ["90050"]; // in a range BEFORE could read
+      mgr.batchDeleteMessages(["90000"], { account: h.account, mailbox: h.mailboxName });
+      const [c] = mgr.consumeLastForensics()!.collateral;
+      expect(c.snapshot).toBe("partial");
+      // `after` is complete, so nothing read before can be hiding in it: what
+      // is missing really left. An undercount, not a fabrication.
+      expect(c.unrequested).toEqual([{ id: "90050", messageId: "m50@example.com" }]);
+      // `appeared` is the half BEFORE's hole poisons, so it is withheld.
+      expect(c.appeared).toBeUndefined();
+      expect(c.unobserved).toEqual([{ phase: "before", ranges: "101-200" }]);
+    });
+
+    it("withholds what left when only the AFTER snapshot has a hole", () => {
+      process.env[AUDIT_LOG_ENV] = auditFile();
+      process.env[AUDIT_SNAPSHOT_CHUNK_ENV] = "100";
+      seed(many(250));
+      h.failSliceAlways = { before: [], after: ["101-200"] };
+      mgr.batchDeleteMessages(["90000"], { account: h.account, mailbox: h.mailboxName });
+      const [c] = mgr.consumeLastForensics()!.collateral;
+      expect(c.snapshot).toBe("partial");
+      // ~100 messages were read before and not after purely because that range
+      // could not be re-read. Reporting them as gone would name innocent
+      // messages as evidence of data loss.
+      expect(c.disappeared).toBeUndefined();
+      expect(c.unrequested).toBeUndefined();
+      expect(c.appeared).toEqual([]);
+    });
+
+    it("falls back to unavailable when no slice reads at all", () => {
+      process.env[AUDIT_LOG_ENV] = auditFile();
+      process.env[AUDIT_SNAPSHOT_CHUNK_ENV] = "100";
+      seed(many(250));
+      h.bulkReadCeiling = 10; // even a slice is too big
+      mgr.batchDeleteMessages(["90000"], { account: h.account, mailbox: h.mailboxName });
+      const [c] = mgr.consumeLastForensics()!.collateral;
+      // Reached by way of the sliced path — every slice was attempted and
+      // refused — not because the script never tried to slice at all.
+      expect(h.calls.find((s) => s.includes("delete _msg"))).toContain("set _sChunk to 100");
+      expect(c.snapshot).toBe("unavailable");
+      expect(c.disappeared).toBeUndefined();
+      expect(c.unobserved).toBeUndefined();
+    });
+
+    it("never lets a partial snapshot raise the false-ok warning", () => {
+      // A flag-only account whose snapshot merely had a hole must not be told
+      // its delete silently did nothing.
+      process.env[AUDIT_LOG_ENV] = auditFile();
+      process.env[AUDIT_SNAPSHOT_CHUNK_ENV] = "100";
+      seed(many(250));
+      h.flagOnlyDelete = true; // reports ok, nothing leaves the mailbox
+      h.failSliceAlways = { before: [], after: ["101-200"] };
+      mgr.batchDeleteMessages(["90000"], { account: h.account, mailbox: h.mailboxName });
+      const report = mgr.consumeLastForensics()!;
+      expect(report.countDeltas[0]).toMatchObject({ observed: 0, expected: 1, status: "under" });
+      expect(report.collateral[0].snapshot).toBe("partial");
+      expect(reconciliationWarnings(report)).toEqual([]);
+    });
   });
 });
 

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -43,6 +43,8 @@ import {
   isAuditEnabled,
   auditSubjectsEnabled,
   auditSnapshotMax,
+  auditSnapshotChunk,
+  SNAPSHOT_SLICE_ATTEMPTS,
   AUDIT_SNAPSHOT_MAX_ENV,
   type CountDelta,
   type AuditPreImage,
@@ -1105,10 +1107,24 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
    * into a SNAP record — the before/after pair the collateral diff subtracts.
    *
    * Empty string when the audit log is off or the snapshot is disabled, so the
-   * whole layer costs literally nothing by default. The two property reads are
-   * BULK (`id of messages of mb`, `message id of messages of mb`) — two Apple
-   * Events for the whole mailbox rather than two per message — and the joining
-   * is pure in-memory AppleScript.
+   * whole layer costs literally nothing by default. The property reads are BULK
+   * (`id of messages i thru j of mb`) — two Apple Events per SLICE rather than
+   * two per message — and the joining is pure in-memory AppleScript.
+   *
+   * ## Why it is sliced rather than one whole-mailbox read (#176)
+   *
+   * This used to be a single `id of messages of mb` pair. When Mail declined
+   * that request the entire snapshot came back `unavailable`, and the cost of
+   * the request grows with the mailbox — so the one mechanism that can attribute
+   * an unrequested departure was least reliable exactly when the batch and the
+   * mailbox, and therefore the blast radius, were largest. That correlation was
+   * the defect, not any individual failure.
+   *
+   * Now the mailbox is read in `APPLE_MAIL_MCP_AUDIT_SNAPSHOT_CHUNK`-sized
+   * slices; each slice is retried once on its own; and a slice that still will
+   * not read costs only its own range. The unreadable ranges are emitted in
+   * their own field, so the diff can report a PARTIAL snapshot that names its
+   * own gap instead of an all-or-nothing `unavailable`.
    *
    * Above `APPLE_MAIL_MCP_AUDIT_SNAPSHOT_MAX` messages the snapshot is skipped,
    * and the skip is EMITTED as a record with its reason. A silently skipped
@@ -1131,46 +1147,77 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
   ): string {
     const max = auditSnapshotMax();
     if (!isAuditEnabled() || max <= 0) return "";
+    const chunk = auditSnapshotChunk();
     return `
         set _sStatus to "ok"
         set _sPayload to ""
-        set _sIds to {}
-        set _sMids to {}
+        set _sMiss to ""
+        set _sPairs to {}
+        set _sChunk to ${chunk}
         if ${countVar} < 0 then
           set _sStatus to "unavailable"
         else if ${countVar} > ${max} then
           set _sStatus to "skipped"
           set _sPayload to "mailbox holds " & (${countVar} as string) & " messages, above ${AUDIT_SNAPSHOT_MAX_ENV}=${max}"
         else
-          try
-            set _sIds to (id of messages of ${mbVar})
-            set _sMids to (message id of messages of ${mbVar})
-          on error
-            set _sStatus to "unavailable"
-          end try
-          if _sStatus is "ok" then
-            if (count of _sIds) is not (count of _sMids) then
+          set _sLo to 1
+          repeat while _sLo <= ${countVar}
+            set _sHi to _sLo + _sChunk - 1
+            if _sHi > ${countVar} then set _sHi to ${countVar}
+            set _sGot to false
+            repeat with _sTry from 1 to ${SNAPSHOT_SLICE_ATTEMPTS}
+              set _sIds to {}
+              set _sMids to {}
+              -- A slice is staged into _sBuf and merged only once it has been
+              -- read IN FULL. Appending as we go would leave a slice that threw
+              -- halfway both partially recorded AND marked unread, and the
+              -- retry would then record its messages a second time.
+              set _sBuf to {}
+              try
+                set _sIds to (id of messages _sLo thru _sHi of ${mbVar})
+                set _sMids to (message id of messages _sLo thru _sHi of ${mbVar})
+                if (class of _sIds) is not list then set _sIds to {_sIds}
+                if (class of _sMids) is not list then set _sMids to {_sMids}
+                if (count of _sIds) is (count of _sMids) then
+                  repeat with _q from 1 to (count of _sIds)
+                    set _sOne to ""
+                    try
+                      set _zSnapMid to ((item _q of _sMids) as string)${this.sanitizeFragment("_zSnapMid", "                      ")}
+                      set _sOne to ((item _q of _sIds) as string) & "${SNAP_PAIR}" & _zSnapMid
+                    on error
+                      set _sOne to ((item _q of _sIds) as string) & "${SNAP_PAIR}"
+                    end try
+                    set end of _sBuf to _sOne
+                  end repeat
+                  set _sGot to true
+                end if
+              end try
+              if _sGot then
+                repeat with _sB in _sBuf
+                  set end of _sPairs to (contents of _sB)
+                end repeat
+                exit repeat
+              end if
+            end repeat
+            if not _sGot then
+              if _sMiss is not "" then set _sMiss to _sMiss & ","
+              set _sMiss to _sMiss & (_sLo as string) & "-" & (_sHi as string)
+            end if
+            set _sLo to _sHi + 1
+          end repeat
+          if _sMiss is not "" then
+            if (count of _sPairs) is 0 then
               set _sStatus to "unavailable"
             else
-              set _sPairs to {}
-              repeat with _q from 1 to (count of _sIds)
-                set _sOne to ""
-                try
-                  set _zSnapMid to ((item _q of _sMids) as string)${this.sanitizeFragment("_zSnapMid", "                  ")}
-                  set _sOne to ((item _q of _sIds) as string) & "${SNAP_PAIR}" & _zSnapMid
-                on error
-                  set _sOne to ((item _q of _sIds) as string) & "${SNAP_PAIR}"
-                end try
-                set end of _sPairs to _sOne
-              end repeat
-              set _sTid to AppleScript's text item delimiters
-              set AppleScript's text item delimiters to "${SNAP_ITEM}"
-              set _sPayload to _sPairs as string
-              set AppleScript's text item delimiters to _sTid
+              set _sStatus to "partial"
             end if
           end if
+          set _sTid to AppleScript's text item delimiters
+          set AppleScript's text item delimiters to "${SNAP_ITEM}"
+          set _sPayload to _sPairs as string
+          set AppleScript's text item delimiters to _sTid
         end if
-        set _out to _out & "${SNAP_TAG}${FIELD_SEP}" & ${acctExpr} & "${FIELD_SEP}" & ${mbExpr} & "${FIELD_SEP}${phase}${FIELD_SEP}" & _sStatus & "${FIELD_SEP}" & _sPayload & "${RECORD_SEP}"`;
+        set _out to _out & "${SNAP_TAG}${FIELD_SEP}" & ${acctExpr} & "${FIELD_SEP}" & ${mbExpr} & "${FIELD_SEP}${phase}${FIELD_SEP}" & _sStatus & "${FIELD_SEP}" & _sPayload & "${FIELD_SEP}" & _sMiss & "${RECORD_SEP}"`;
   }
 
   /**
@@ -1235,6 +1282,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       phase: "before" | "after";
       status: string;
       payload: string;
+      /** 1-based position ranges this phase could not read ("251-500,900-1000"). */
+      miss: string;
     }[];
   } {
     const byId = new Map<string, BatchOperationResult>();
@@ -1257,6 +1306,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       phase: "before" | "after";
       status: string;
       payload: string;
+      miss: string;
     }[] = [];
 
     for (const rec of output.split(RECORD_SEP)) {
@@ -1281,6 +1331,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           phase: f[3] === "after" ? "after" : "before",
           status: f[4] ?? "",
           payload: f[5] ?? "",
+          miss: f[6] ?? "",
         });
         continue;
       }
@@ -1480,8 +1531,12 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         });
         continue;
       }
-      if (b.status !== "ok" || a.status !== "ok") {
-        const bad = b.status !== "ok" ? b : a;
+      // "skipped"/"unavailable" is terminal for the pair: nothing usable to
+      // diff. "partial" is NOT — it carries real entries plus a named gap.
+      const dead = (s: (typeof parsed.snaps)[number]): boolean =>
+        s.status !== "ok" && s.status !== "partial";
+      if (dead(b) || dead(a)) {
+        const bad = dead(b) ? b : a;
         collateral.push({
           account: g.account,
           mailbox: g.mailbox,
@@ -1505,13 +1560,45 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       const unrequested = disappeared.filter(
         (e) => !requestedNumericIds.has(canonicalNumericId(e.id))
       );
+      // Each half of the diff is gated on the completeness of the snapshot that
+      // could REFUTE it, not on both (#176). A hole in `after` means a message
+      // absent from it may merely be unread, so `disappeared` would name
+      // innocent messages as collateral — the fabricated finding this layer must
+      // never produce. A hole in `before` only undercounts it, and symmetrically
+      // poisons `appeared`.
+      const holes = [b, a]
+        .filter((s) => s.miss !== "")
+        .map((s) => ({ phase: s.phase, ranges: s.miss }));
+      if (holes.length === 0) {
+        collateral.push({
+          account: g.account,
+          mailbox: g.mailbox,
+          snapshot: "ok",
+          disappeared,
+          unrequested,
+          appeared,
+        });
+        continue;
+      }
+      const derivable = [
+        a.miss === "" ? `what left the ${beforeEntries.length} message(s) read before it` : null,
+        b.miss === "" ? "what arrived during it" : null,
+      ].filter((s): s is string => s !== null);
       collateral.push({
         account: g.account,
         mailbox: g.mailbox,
-        snapshot: "ok",
-        disappeared,
-        unrequested,
-        appeared,
+        snapshot: "partial",
+        skipReason:
+          `Mail would not read ${holes.map((h) => `${h.ranges} (${h.phase})`).join(", ")} of ` +
+          `this mailbox, so the snapshot has a hole in it. ` +
+          (derivable.length > 0
+            ? `Still derivable and reported: ${derivable.join(" and ")}. `
+            : `Neither half of the diff is derivable from it. `) +
+          `Anything the unread range could refute is omitted rather than guessed — an absent ` +
+          `field here means "not computable", not "empty".`,
+        unobserved: holes,
+        ...(a.miss === "" ? { disappeared, unrequested } : {}),
+        ...(b.miss === "" ? { appeared } : {}),
       });
     }
 

--- a/src/services/auditLog.ts
+++ b/src/services/auditLog.ts
@@ -60,9 +60,17 @@ export const AUDIT_LOG_ENV = "APPLE_MAIL_MCP_AUDIT_LOG";
 export const AUDIT_SUBJECTS_ENV = "APPLE_MAIL_MCP_AUDIT_SUBJECTS";
 /** Ceiling on the collateral snapshot, in messages per mailbox. `0` disables it. */
 export const AUDIT_SNAPSHOT_MAX_ENV = "APPLE_MAIL_MCP_AUDIT_SNAPSHOT_MAX";
+/** How many messages the snapshot reads from Mail in ONE request. */
+export const AUDIT_SNAPSHOT_CHUNK_ENV = "APPLE_MAIL_MCP_AUDIT_SNAPSHOT_CHUNK";
 
 /** Default collateral-snapshot ceiling (messages per mailbox). */
 export const DEFAULT_SNAPSHOT_MAX = 2000;
+
+/** Default snapshot slice size (messages per Apple Event round trip). */
+export const DEFAULT_SNAPSHOT_CHUNK = 250;
+
+/** How many times one slice is attempted before it is recorded as unobserved. */
+export const SNAPSHOT_SLICE_ATTEMPTS = 2;
 
 /** Truthy-string test shared with the rest of the server's env knobs. */
 function isOn(raw: string | undefined): boolean {
@@ -95,6 +103,28 @@ export function auditSnapshotMax(): number {
   if (raw === undefined || raw === "") return DEFAULT_SNAPSHOT_MAX;
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) return DEFAULT_SNAPSHOT_MAX;
+  return Math.floor(n);
+}
+
+/**
+ * Snapshot slice size: how many messages are read from Mail per request.
+ *
+ * The snapshot used to issue ONE whole-mailbox read (`id of messages of mb`).
+ * That is the cheapest possible shape when it works, and it is also the shape
+ * that fails outright when Mail declines — which it does more often the bigger
+ * the mailbox is. So the one mechanism that can attribute collateral damage was
+ * least reliable exactly when the blast radius was largest (#176). Reading in
+ * bounded slices trades a few more Apple Events for a request size that stays
+ * constant as the mailbox grows, and lets a failure cost one slice instead of
+ * the whole snapshot.
+ *
+ * Clamped to at least 1 — a zero or negative slice would loop forever.
+ */
+export function auditSnapshotChunk(): number {
+  const raw = process.env[AUDIT_SNAPSHOT_CHUNK_ENV]?.trim();
+  if (raw === undefined || raw === "") return DEFAULT_SNAPSHOT_CHUNK;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_SNAPSHOT_CHUNK;
   return Math.floor(n);
 }
 
@@ -175,21 +205,59 @@ export interface CollateralDiff {
   account: string;
   mailbox: string;
   /**
-   * `ok` — both snapshots were taken and diffed.
+   * `ok` — both snapshots were read in full and diffed.
+   * `partial` — at least one snapshot has a hole: some slices of the mailbox
+   *   could not be read even after a retry. Some of the diff is still sound and
+   *   is reported; the rest is withheld. See `unobserved` and the rules below.
    * `skipped` — deliberately not taken (over the ceiling, or the ids had no
    *   single source mailbox). `skipReason` says which.
-   * `unavailable` — Mail would not produce the snapshot.
+   * `unavailable` — Mail produced no usable snapshot at all.
+   *
+   * ## Why `partial` withholds rather than reports whatever it has (#176)
+   *
+   * A hole in the AFTER snapshot poisons `disappeared`: a message read before
+   * and not read after may have left, or may simply be sitting in the range
+   * that could not be read. Reporting it would put an innocent message's name
+   * in front of someone mid-incident as evidence of data loss — a fabricated
+   * finding, which is worse than the gap it papers over. Symmetrically, a hole
+   * in the BEFORE snapshot poisons `appeared`.
+   *
+   * So each half of the diff is gated on the completeness of the snapshot that
+   * can refute it, not on both:
+   *
+   * - `disappeared` / `unrequested` — present only when the AFTER snapshot is
+   *   complete. A hole in BEFORE only makes them an UNDERCOUNT (a message never
+   *   read before cannot be missed after), which is honest as far as it goes.
+   * - `appeared` — present only when the BEFORE snapshot is complete.
+   *
+   * An absent array therefore means "not computable", never "empty". Consumers
+   * must not read `disappeared?.length ?? 0` as "nothing disappeared" — check
+   * `snapshot === "ok"` first, which is what `falseOkWarning` does.
    */
-  snapshot: "ok" | "skipped" | "unavailable";
+  snapshot: "ok" | "partial" | "skipped" | "unavailable";
   skipReason?: string;
-  /** Messages present before and absent after. */
+  /**
+   * The slices of the mailbox that could not be read, per phase — 1-based
+   * position ranges as Mail indexes them (`"251-500,900-1000"`). Present only
+   * when `snapshot === "partial"`, and this is what makes the gap nameable:
+   * "nothing unrequested left the 400 messages I could see, and I could not see
+   * the other 120" is strictly more useful than no diff at all.
+   */
+  unobserved?: { phase: "before" | "after"; ranges: string }[];
+  /**
+   * Messages present before and absent after. Omitted when the after snapshot
+   * is incomplete — see the `partial` rules above.
+   */
   disappeared?: { id: string; messageId: string }[];
   /**
    * The subset of `disappeared` whose numeric id was NEVER in the caller's id
    * list. A non-empty array here IS the #155 symptom, with names attached.
    */
   unrequested?: { id: string; messageId: string }[];
-  /** Messages absent before and present after (new mail arriving mid-op). */
+  /**
+   * Messages absent before and present after (new mail arriving mid-op).
+   * Omitted when the before snapshot is incomplete.
+   */
   appeared?: { id: string; messageId: string }[];
 }
 
@@ -331,6 +399,12 @@ export function countDeltaWarning(d: CountDelta): string | null {
  * Deliberately narrow: `observed === 0` only. A partial under (3 of 4 removed)
  * stays unwarned, because that is exactly where a flag-only account and a
  * partial failure DO look alike.
+ *
+ * `snapshot === "ok"` also excludes a PARTIAL snapshot (#176), and must keep
+ * doing so. A partial snapshot's `disappeared` is either absent or an
+ * undercount, so "nothing left the mailbox" is precisely the claim it cannot
+ * support — warning off it would fire on a flag-only account whose snapshot
+ * merely had a hole in it.
  */
 export function falseOkWarning(d: CountDelta, collateral?: CollateralDiff): string | null {
   if (d.status !== "under" || d.expected === null) return null;


### PR DESCRIPTION
Fixes #176.

## The defect

The collateral snapshot issued **one whole-mailbox property read** (`id of messages of mb`). When Mail declined it, the entire diff came back `"snapshot": "unavailable"` — and the cost of that request grows with the mailbox. So the only mechanism that can attribute an unrequested departure was **least reliable exactly when the batch and the blast radius were largest**. That correlation is the defect, not any individual failure.

@scottstern0325 hit it on a 29-id batch: `skipReason: "Mail would not produce the after snapshot for this mailbox"`, and during that same batch an Amazon shipment notice they had never named left INBOX. Recoverable from Trash, but un-attributable — this server, a Mail rule, a server-side filter and another device all read identically.

## The fix

The mailbox is read in `APPLE_MAIL_MCP_AUDIT_SNAPSHOT_CHUNK`-sized slices (default 250), each **retried once on its own**, so a refusal costs one slice rather than the whole snapshot. A slice that still will not read is **named**: the record reports `"snapshot": "partial"` with the unreadable position ranges per phase.

```json
{
  "snapshot": "partial",
  "unobserved": [{ "phase": "after", "ranges": "251-500" }],
  "appeared": []
}
```

## Withholding, not guessing

Each half of the diff is gated on the snapshot that could **refute** it, not on both:

| Hole in | `disappeared` / `unrequested` | `appeared` |
|---|---|---|
| neither | reported | reported |
| `before` | reported (an undercount — a message never read before cannot be missed after) | withheld |
| `after` | **withheld** | reported |
| both | withheld | withheld |

A message absent from a partial `after` may merely be unread. Reporting it would put an innocent message's name in front of someone mid-incident as evidence of data loss — a fabricated finding is worse than the gap it papers over. **An absent field now means "not computable", never "empty"**; `falseOkWarning` already required `snapshot === "ok"`, so a partial snapshot cannot raise it, and there is a test pinning that.

## Guards, shown failing first

Per the project rule, all eight `#176` tests were run against the pre-fix implementation before the fix landed. All eight fail there — the core one as `expected 'unavailable' to be 'ok'`, which is the reported symptom verbatim.

What makes them non-vacuous: the simulator gained `bulkReadCeiling`, so it refuses any request covering more messages than Mail would answer for. A script that still asks for the whole mailbox gets `unavailable` and cannot pass. It also models a slice answered only on a **second** attempt, so dropping the retry fails a test too.

One defect found in this branch's own first draft and fixed: a slice that threw part-way appended its partial entries *and* got marked unread, so the retry recorded them twice. Slices are now staged into `_sBuf` and merged only once read in full.

## Verification

- `lint` / `typecheck` / `format:check` clean; **631 tests pass**.
- Committed `build/index.js` rebuilt and verified in sync with source.
- The **real generated AppleScript** was extracted and compiled with `osacompile` against Mail's actual scripting dictionary — clean, so the new `messages _sLo thru _sHi of` terminology resolves against the real app, not just a mock.
- **Not** executed against live Mail: this session's responsible process (iTerm2) carries a TCC *deny* for Apple Events → Mail, and flipping that needs a prompt I won't trigger. Worth noting the failure mode is safe regardless — any runtime refusal from a range read is caught by the slice's `try`, recorded as an unobserved range, and degrades to `partial`/`unavailable`, i.e. never worse than today's behaviour and never a fabricated finding.