### PR TITLE
fix: retract the false-ok warning and the `under` status (#155)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.33",
+      "version": "2.11.0",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.10.33",
+      "version": "2.11.0",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.33",
+  "version": "2.11.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.10.33",
+  "version": "2.11.0",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.10.33",
+      "version": "2.11.0",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.33",
+  "version": "2.11.0",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 ## [Unreleased]
 
+## [2.11.0] - 2026-08-16
+
+Retraction release. A warning shipped in 2.10.30 was firing on stores that had
+done exactly what they were asked, and the `under` status it was built on
+asserted something this server cannot know. Both are gone.
+
+### Removed
+
+- **The "reported success with no observed effect" warning** (`falseOkWarning`,
+  added 2.10.30 for [#155](https://github.com/sweetrb/apple-mail-mcp/issues/155)).
+  Its stated discriminator was that the collateral snapshot corroborated the flat
+  count. It does not: the count and the snapshot are consecutive Apple Events in
+  the same script, and the very record that motivated the warning had **both**
+  instruments stale at once — @scottstern0325 has since located those messages in
+  Trash, so they had already left a mailbox the snapshot reported as unchanged.
+  Reproduced directly: a flag-only account with the audit log on, deleting two
+  messages successfully, was told its operation had no observed effect.
+
+  The guard that was supposed to prevent exactly this
+  (`"does NOT cry wolf when fewer messages leave than expected"`) ran with
+  `APPLE_MAIL_MCP_AUDIT_LOG` unset, so it produced no collateral, never reached
+  the warning's gates, and passed for a reason unrelated to its title. It now
+  runs with the audit log on.
+
+- **`status: "under"`.** Removed rather than deprecated so the compiler
+  enumerates every consumer — a dead status string gets re-implemented by the
+  next author. Readings that used to be `under` are now `unknown` with an
+  `unknownReason`.
+
+### Changed
+
+- **`observed` is documented as a LOWER BOUND on how many messages left** — the
+  movement of Mail's *count*, which has been observed lagging a delete it had
+  already performed. It is not "how many messages left", and a short reading is
+  not evidence about your operation. **The per-id outcomes report success; this
+  number does not.**
+
+  The evidence, from @scottstern0325 on iCloud: for two batches reporting
+  `observed: 0` the messages were found in Trash, matched by `date received` +
+  sender against the audit-log pre-image. Four readings — 0 of 4, 0 of 1 (a
+  *single-id* delete), 15 of 16, 14 of 15 — with a shortfall unrelated to batch
+  size.
+
+- **`unknownReason` distinguishes four cases that are not interchangeable**:
+  `count-unreadable`, `no-expectation`, `count-did-not-move`, `count-partial`.
+  A flat count (`count-did-not-move`) keeps its reassurance that this is ordinary
+  on a store which flags deletions instead of removing them, and deliberately
+  does **not** tell the reader to go check a destination — on such a store the
+  message was never moved, and its absence from Trash would read as failure.
+  `count-partial` is the shape a flag-only store cannot produce, so that one can
+  talk about a lag without being wrong on the commonest benign account.
+
+- **Where to look when you do want to confirm a destination**: match by
+  `date received` plus sender, **not** by the numeric ids you passed. Per
+  @scottstern0325, ids are renumbered by the move and do not survive it — the
+  pre-image ids are not a usable key at the destination.
+
+### Documentation
+
+- **The collateral diff's `"snapshot": "ok"` is documented as necessary but not
+  sufficient.** The enumeration is bounded by Mail's message count, so a count
+  reading *low* truncates it silently: the unread tail is never requested, never
+  registers as a failed slice, and the status still says `"ok"`, while messages
+  past the bound look like they disappeared. This narrows the guarantee stated in
+  2.10.33 and is tracked as its own defect.
+
 ## [2.10.33] - 2026-08-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1319,14 +1319,26 @@ returns the comparison in `structuredContent`:
 }
 ```
 
-`status` is deliberately four-valued rather than a pass/fail flag:
+`status` is deliberately not a pass/fail flag:
 
 | `status` | Meaning | Warns? |
 |----------|---------|--------|
 | `match` | Exactly as many messages left the mailbox as the operation acted on. | No |
 | `over` | **More** left than were operated on. Messages are unaccounted for. | **Yes** |
-| `under` | **Fewer** left than expected. | No |
-| `unknown` | No comparison was possible: either Mail would not report a count (`before`/`after` null) or there is no predictable expectation (`expected` null — see the self-move rule below). | No |
+| `unknown` | No comparison this server is willing to assert. `unknownReason` says which of four situations produced it. | No |
+
+`unknownReason` distinguishes four cases that are *not* interchangeable:
+
+| `unknownReason` | Meaning |
+|-----------------|---------|
+| `count-unreadable` | Mail would not report a count at all (`before`/`after` null). |
+| `no-expectation` | No expectation is predictable, so no comparison exists — a move whose destination **is** the source mailbox. |
+| `count-did-not-move` | The count did not move. On a store that flags deletions instead of removing them this is the **ordinary, correct** reading for an operation that fully succeeded. |
+| `count-partial` | The count moved, but by less than the operation accounted for. A flag-only store cannot produce this, which is why it is worth telling apart. |
+
+> **`under` was removed in 2.11.0.** It used to mean "fewer left than expected"
+> and was documented as routine. Field evidence retired it — see
+> [Why `observed` is a lower bound](#why-observed-is-a-lower-bound-155).
 
 #### What an `over` warning does and does not tell you
 
@@ -1346,7 +1358,7 @@ trusted:
 **Concurrent departure is the benign cause to rule out first**, and the warning
 text says so. What the asymmetry argument actually buys is the other half:
 concurrent *arrivals* cannot produce `over`, because a message arriving
-mid-operation *raises* the after-count and biases the reading toward `under`.
+mid-operation *raises* the after-count and biases the reading short.
 That is why `over` is the interesting direction — a strong signal, not a proof.
 
 Setting `APPLE_MAIL_MCP_AUDIT_LOG` is what settles which one you have: the
@@ -1354,12 +1366,42 @@ collateral diff below **names** the messages that disappeared, and "the
 newsletter my rule files every morning" is a very different report from a message
 nothing should have touched.
 
-`under`, by contrast, is routine: an account that flags deletions rather than
-removing them leaves the message in place and the count does not move, and a
-Gmail label mailbox can behave the same way while the delete genuinely succeeded.
-A warning that fires on every ordinary Gmail delete would be ignored exactly when
-it matters, so `under` is **reported** in `countDelta` (with a `note` explaining
-it) and never warned about.
+#### Why `observed` is a lower bound (#155)
+
+**`observed` is the movement of Mail's count. It is a lower bound on how many
+messages left, not a count of how many left.**
+
+On iCloud, @scottstern0325 ran the check that settled this: for two batches
+reporting `observed: 0`, the messages were located **in Trash**, matched by
+`date received` + sender against the audit log's pre-image. The deletes had
+happened. Mail's count had not caught up. Across four readings — 0 of 4, 0 of 1
+(a *single-id* delete), 15 of 16, and 14 of 15 — the shortfall bore no relation
+to batch size, which is what a lagging count looks like and not what a
+store-behaviour rule looks like.
+
+So a short reading is not evidence about your operation. **The per-id outcomes
+are what report success; this number is not. Do not retry on the strength of
+it** — that is how a message gets deleted twice.
+
+Two things follow:
+
+- A count that does not move at all is still the ordinary reading on a store that
+  flags deletions instead of removing them (Gmail label mailboxes, IMAP accounts
+  with "move deleted messages to Trash" off). It reports
+  `unknownReason: "count-did-not-move"` and says so, and it is never warned about
+  — a warning that fires on every ordinary Gmail delete would be ignored exactly
+  when it matters.
+- **To confirm where messages went, match them at the destination by `date
+  received` plus sender — not by the numeric ids you passed.** Ids are renumbered
+  by the move and do not survive it.
+
+**Removed in 2.11.0: the "reported success with no observed effect" warning.**
+Shipped in 2.10.30, it fired when the count was flat, the snapshot read cleanly
+and nothing had disappeared. Its premise was that the snapshot corroborated the
+count — but both are read back-to-back in the same script, and the record that
+prompted it turns out to have had *both* instruments stale at once. It therefore
+fired on stores that had done exactly what they were asked. It is gone rather
+than narrowed; `over` is the only surviving assertion.
 
 Three more honesty rules:
 
@@ -1489,8 +1531,15 @@ a hole, because a wrong name here is worse than a missing one:
 | both | withheld | withheld |
 
 **An absent field means "not computable", never "empty".** Check
-`"snapshot": "ok"` before reading `disappeared` as a clean bill of health — the
-false-ok warning does exactly that, so a `partial` snapshot never triggers it.
+`"snapshot": "ok"` before reading `disappeared` as a clean bill of health.
+
+> ⚠️ **`"ok"` is necessary, not sufficient.** The enumeration's range is bounded
+> by Mail's own message count, and #155 established that count can lag the
+> mutation. A count reading **low** truncates the enumeration silently — the
+> unread tail is never requested, so it never registers as a failed slice and the
+> status still says `"ok"` — and messages past that bound would then look like
+> they disappeared. Until that is fixed, treat a `disappeared` entry as a lead to
+> check, not a proof.
 
 ### Privacy, and what the file costs you
 

--- a/build/index.js
+++ b/build/index.js
@@ -78854,17 +78854,8 @@ function countDeltaWarning(d) {
   const where = d.account ? `"${d.mailbox}" in account "${d.account}"` : `"${d.mailbox}"`;
   return `\u26A0\uFE0F Effect mismatch in ${where}: ${d.observed} message(s) left the mailbox but only ${d.expected} were operated on (count ${d.before} \u2192 ${d.after}). ${extra} message(s) are unaccounted for. Anything else removing mail from this mailbox at the same moment \u2014 a Mail rule, a server-side filter, another client, an IMAP expunge \u2014 reads the same way, so rule that out first. If nothing else was touching it, this is the signature of https://github.com/sweetrb/apple-mail-mcp/issues/155 \u2014 please report it there, and set ${AUDIT_LOG_ENV}=/path/to/audit.ndjson to capture which messages disappeared.`;
 }
-function falseOkWarning(d, collateral) {
-  if (d.status !== "under" || d.expected === null) return null;
-  if (d.observed !== 0 || d.expected <= 0) return null;
-  if (!collateral || collateral.snapshot !== "ok") return null;
-  if ((collateral.disappeared?.length ?? 0) !== 0) return null;
-  const where = d.account ? `"${d.mailbox}" in account "${d.account}"` : `"${d.mailbox}"`;
-  return `\u26A0\uFE0F Reported success with no observed effect in ${where}: ${d.expected} message(s) were operated on and reported ok, but the mailbox count did not move (${d.before} \u2192 ${d.after}) and the collateral snapshot \u2014 which read this mailbox successfully \u2014 shows no message left it. Either the operation silently did nothing, or Mail's count and listing are both stale and the messages did move. Check the destination (Trash for a delete) before assuming either: if they are there, this is a measurement-timing bug; if they are still in the source mailbox minutes later, the operation failed while reporting success. Please report at https://github.com/sweetrb/apple-mail-mcp/issues/155 with ${AUDIT_LOG_ENV}=/path/to/audit.ndjson set.`;
-}
 function reconciliationWarnings(report) {
-  const collateralFor = (d) => report.collateral.find((c) => c.account === d.account && c.mailbox === d.mailbox);
-  return report.countDeltas.flatMap((d) => [countDeltaWarning(d), falseOkWarning(d, collateralFor(d))]).filter((w) => w !== null);
+  return report.countDeltas.map((d) => countDeltaWarning(d)).filter((w) => w !== null);
 }
 
 // src/services/appleMailManager.ts
@@ -79142,6 +79133,8 @@ function canonicalNumericId(raw) {
   return Number.isFinite(n) ? String(n) : trimmed;
 }
 var SELF_MOVE_NOTE = "Destination is the source mailbox, so no message should leave it. What Mail does to the count when a message is re-filed into the mailbox it already occupies is unspecified, so there is no expected delta to compare against: this mailbox is reported without a comparison and is never warned about.";
+var COUNT_UNMOVED_NOTE = `Mail's count did not move. This is the ordinary reading on a store that flags deletions instead of removing them (Gmail label mailboxes and IMAP accounts with "move deleted messages to Trash" off), where the message stays put and the operation still fully succeeded. It can also mean Mail's count simply had not caught up yet. The per-id outcomes are what report success; this number is not, so do not retry on the strength of it.`;
+var COUNT_PARTIAL_NOTE = `Mail's count moved by less than this operation accounted for. That is a LOWER BOUND on what left, not a count of what left: Mail has been observed reporting a stale count for a delete it had already performed (issue #155), and new mail arriving mid-operation reads the same way. No claim is made either way. To confirm where the messages went, match them at the destination by "date received" plus sender \u2014 NOT by the numeric ids you passed, which are renumbered by the move and do not survive it.`;
 function snapshotKey(entry) {
   return `${entry.id}\0${entry.messageId}`;
 }
@@ -79679,10 +79672,24 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       const observed = readable ? m.before - m.after : null;
       const note = noteFor(m.account, m.mailbox);
       let status;
-      if (!readable || m.expected === null) status = "unknown";
-      else if (observed === m.expected) status = "match";
-      else if ((observed ?? 0) > m.expected) status = "over";
-      else status = "under";
+      let unknownReason;
+      if (!readable) {
+        status = "unknown";
+        unknownReason = "count-unreadable";
+      } else if (m.expected === null) {
+        status = "unknown";
+        unknownReason = "no-expectation";
+      } else if (observed === m.expected) {
+        status = "match";
+      } else if ((observed ?? 0) > m.expected) {
+        status = "over";
+      } else if (observed === 0) {
+        status = "unknown";
+        unknownReason = "count-did-not-move";
+      } else {
+        status = "unknown";
+        unknownReason = "count-partial";
+      }
       return {
         account: m.account,
         mailbox: m.mailbox,
@@ -79691,11 +79698,11 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         expected: m.expected,
         observed,
         status,
+        ...unknownReason ? { unknownReason } : {},
         ...note ? { note } : {},
-        ...status === "unknown" && readable === false ? { note: note ?? "Mail did not report a message count for this mailbox" } : {},
-        ...status === "under" && !note ? {
-          note: "Fewer messages left the mailbox than were operated on. This is normal on a store that flags deletions instead of removing them (and when new mail arrives mid-operation), so it is reported but not warned about."
-        } : {}
+        ...unknownReason === "count-unreadable" ? { note: note ?? "Mail did not report a message count for this mailbox" } : {},
+        ...unknownReason === "count-did-not-move" && !note ? { note: COUNT_UNMOVED_NOTE } : {},
+        ...unknownReason === "count-partial" && !note ? { note: COUNT_PARTIAL_NOTE } : {}
       };
     });
     const preImages = [];
@@ -85303,7 +85310,10 @@ var COUNT_DELTA_OUTPUT_SCHEMA = external_exports.array(
     // `status: "unknown"`, and never with a warning.
     expected: external_exports.number().nullable().optional(),
     observed: external_exports.number().nullable().optional(),
-    status: external_exports.enum(["match", "over", "under", "unknown"]).optional(),
+    status: external_exports.enum(["match", "over", "unknown"]).optional(),
+    // Declared explicitly: the SDK stamps additionalProperties:false on a bare
+    // zod shape, so an undeclared key makes the CLIENT reject the result.
+    unknownReason: external_exports.enum(["count-unreadable", "no-expectation", "count-did-not-move", "count-partial"]).optional(),
     note: external_exports.string().optional()
   })
 ).optional();

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.10.33",
+  "version": "2.11.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.10.33"
+        "apple-mail-mcp@2.11.0"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.10.33",
+  "version": "2.11.0",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,7 +236,12 @@ const COUNT_DELTA_OUTPUT_SCHEMA = z
       // `status: "unknown"`, and never with a warning.
       expected: z.number().nullable().optional(),
       observed: z.number().nullable().optional(),
-      status: z.enum(["match", "over", "under", "unknown"]).optional(),
+      status: z.enum(["match", "over", "unknown"]).optional(),
+      // Declared explicitly: the SDK stamps additionalProperties:false on a bare
+      // zod shape, so an undeclared key makes the CLIENT reject the result.
+      unknownReason: z
+        .enum(["count-unreadable", "no-expectation", "count-did-not-move", "count-partial"])
+        .optional(),
       note: z.string().optional(),
     })
   )

--- a/src/services/appleMailManager.forensics.test.ts
+++ b/src/services/appleMailManager.forensics.test.ts
@@ -52,6 +52,14 @@ const h = vi.hoisted(() => ({
   collateral: [] as string[],
   /** When true, the store "succeeds" without the message leaving the mailbox. */
   flagOnlyDelete: false,
+  /**
+   * Mail's after-COUNT reads this many higher than the mailbox really holds,
+   * while the message list is correct — the #155 staleness as @scottstern0325
+   * measured it (the deletes had happened; the count had not caught up).
+   */
+  staleAfterCountBy: 0,
+  /** Mail refuses to report a count at all: `_cb`/`_ca` stay at -1. */
+  suppressCount: false,
   /** id → the error text Mail raises for it instead of performing the op. */
   errorOn: {} as Record<string, string>,
   /** id → the "account/mailbox, " list Mail builds when an id is ambiguous. */
@@ -270,7 +278,12 @@ function simulateDestructive(script: string): string {
 
   emitSnapshot("after", h.mailbox);
   if (wantsCount) {
-    out += `${RECON_TAG}${FIELD_SEP}${acct}${FIELD_SEP}${mbox}${FIELD_SEP}${before.length}${FIELD_SEP}${h.mailbox.length}${FIELD_SEP}${RECORD_SEP}`;
+    // The count is a SEPARATE instrument from the listing above, and #155 is
+    // exactly the case where they disagree — so the simulator has to be able to
+    // report a stale count over a correct list.
+    const beforeCount = h.suppressCount ? -1 : before.length;
+    const afterCount = h.suppressCount ? -1 : h.mailbox.length + h.staleAfterCountBy;
+    out += `${RECON_TAG}${FIELD_SEP}${acct}${FIELD_SEP}${mbox}${FIELD_SEP}${beforeCount}${FIELD_SEP}${afterCount}${FIELD_SEP}${RECORD_SEP}`;
   }
   return out;
 }
@@ -283,9 +296,6 @@ import {
   AUDIT_SNAPSHOT_CHUNK_ENV,
   reconciliationWarnings,
   writeDestructiveAudit,
-  falseOkWarning,
-  type CountDelta,
-  type CollateralDiff,
 } from "@/services/auditLog.js";
 
 let tmp: string;
@@ -315,6 +325,8 @@ beforeEach(() => {
   h.bulkReadCeiling = null;
   h.failSliceAlways = { before: [], after: [] };
   h.failSliceOnce = [];
+  h.staleAfterCountBy = 0;
+  h.suppressCount = false;
   tmp = mkdtempSync(join(tmpdir(), "amcp-audit-"));
   delete process.env[AUDIT_LOG_ENV];
   delete process.env[AUDIT_SUBJECTS_ENV];
@@ -405,13 +417,23 @@ describe("effect reconciliation (always on, no audit log configured)", () => {
     expect(warnings[0]).toContain("issues/155");
   });
 
-  it("does NOT cry wolf when fewer messages leave than expected", () => {
+  it("does NOT cry wolf when the count does not move", () => {
     // A store that flags deletions instead of removing them — the operation
     // genuinely succeeded and the count did not move. Reported, never warned.
+    // Deliberately run with the audit log ON: the pre-2.11.0 version of this
+    // test ran with it deleted, so it produced no collateral, could not reach
+    // falseOkWarning's gates, and passed for a reason unrelated to its title
+    // while that warning fired on this very shape in the field.
+    process.env[AUDIT_LOG_ENV] = auditFile();
     h.flagOnlyDelete = true;
-    mgr.batchDeleteMessages(["75811", "75812"]);
+    mgr.batchDeleteMessages(["75811", "75812"], { account: h.account, mailbox: h.mailboxName });
     const report = mgr.consumeLastForensics()!;
-    expect(report.countDeltas[0]).toMatchObject({ expected: 2, observed: 0, status: "under" });
+    expect(report.countDeltas[0]).toMatchObject({
+      expected: 2,
+      observed: 0,
+      status: "unknown",
+      unknownReason: "count-did-not-move",
+    });
     expect(report.countDeltas[0].note).toMatch(/flags deletions instead of removing them/);
     expect(reconciliationWarnings(report)).toEqual([]);
   });
@@ -1009,9 +1031,11 @@ describe("collateral identification (opt-in, gated on the audit log)", () => {
       expect(c.unobserved).toBeUndefined();
     });
 
-    it("never lets a partial snapshot raise the false-ok warning", () => {
+    it("raises nothing at all on a partial snapshot over a flat count", () => {
       // A flag-only account whose snapshot merely had a hole must not be told
-      // its delete silently did nothing.
+      // anything is wrong. This used to be about falseOkWarning specifically;
+      // since 2.11.0 that warning is gone, so the assertion is the stronger
+      // one — no warning of any kind, and a status that does not assert.
       process.env[AUDIT_LOG_ENV] = auditFile();
       process.env[AUDIT_SNAPSHOT_CHUNK_ENV] = "100";
       seed(many(250));
@@ -1019,7 +1043,12 @@ describe("collateral identification (opt-in, gated on the audit log)", () => {
       h.failSliceAlways = { before: [], after: ["101-200"] };
       mgr.batchDeleteMessages(["90000"], { account: h.account, mailbox: h.mailboxName });
       const report = mgr.consumeLastForensics()!;
-      expect(report.countDeltas[0]).toMatchObject({ observed: 0, expected: 1, status: "under" });
+      expect(report.countDeltas[0]).toMatchObject({
+        observed: 0,
+        expected: 1,
+        status: "unknown",
+        unknownReason: "count-did-not-move",
+      });
       expect(report.collateral[0].snapshot).toBe("partial");
       expect(reconciliationWarnings(report)).toEqual([]);
     });
@@ -1063,66 +1092,99 @@ describe("#155 acceptance: N ids passed, N+2 messages disappear", () => {
   });
 });
 
-describe("false-ok detection (#155)", () => {
-  const delta = (o: Partial<CountDelta> = {}): CountDelta => ({
-    account: "iCloud",
-    mailbox: "INBOX",
-    before: 29,
-    after: 29,
-    expected: 4,
-    observed: 0,
-    status: "under",
-    ...o,
-  });
-  const clean = (o: Partial<CollateralDiff> = {}): CollateralDiff => ({
-    account: "iCloud",
-    mailbox: "INBOX",
-    snapshot: "ok",
-    disappeared: [],
-    unrequested: [],
-    appeared: [],
-    ...o,
+describe("count staleness — the #155 retraction (2.11.0)", () => {
+  // @scottstern0325 located the messages from two `observed: 0` batches IN
+  // TRASH, matched by `date received` + sender against the audit-log pre-image.
+  // The deletes had happened; Mail's count had not caught up. So a short count
+  // reading is not evidence about the operation, and the warning built on it
+  // (falseOkWarning, 2.10.30) was firing on stores that worked correctly.
+
+  it("does NOT warn a flag-only store that its delete did nothing — WITH the audit log on", () => {
+    // The retraction guard. This is the shape falseOkWarning fired on: count
+    // flat, snapshot readable, nothing disappeared, every id reported ok. The
+    // pre-2.11.0 guard for this ran with the audit log DELETED, so it produced
+    // no collateral and passed for a reason unrelated to its title — it could
+    // never have caught the bug it was named after.
+    process.env[AUDIT_LOG_ENV] = auditFile();
+    h.flagOnlyDelete = true;
+    mgr.batchDeleteMessages(["75811", "75812"], { account: h.account, mailbox: h.mailboxName });
+    const report = mgr.consumeLastForensics()!;
+    const [c] = report.collateral;
+    expect(c.snapshot).toBe("ok");
+    expect(c.disappeared).toEqual([]);
+    expect(reconciliationWarnings(report)).toEqual([]);
   });
 
-  it("warns when everything reported ok but nothing observably happened", () => {
-    // scottstern0325's exact record from #155, on iCloud against 2.10.17.
-    const w = falseOkWarning(delta(), clean());
-    expect(w).toMatch(/Reported success with no observed effect/);
-    expect(w).toContain("issues/155");
-  });
-
-  it("stays silent when the snapshot could not be taken", () => {
-    // The flag-only account and a total no-op are genuinely indistinguishable
-    // here, so warning would cry wolf on ordinary deletes.
-    expect(falseOkWarning(delta(), clean({ snapshot: "unavailable" }))).toBeNull();
-    expect(falseOkWarning(delta(), clean({ snapshot: "skipped" }))).toBeNull();
-    expect(falseOkWarning(delta(), undefined)).toBeNull();
-  });
-
-  it("stays silent when messages did leave the mailbox", () => {
-    expect(
-      falseOkWarning(delta(), clean({ disappeared: [{ id: "1", messageId: "<a@b>" }] }))
-    ).toBeNull();
-  });
-
-  it("stays silent on a PARTIAL under, where flag-only and partial failure look alike", () => {
-    expect(falseOkWarning(delta({ after: 26, observed: 3 }), clean())).toBeNull();
-  });
-
-  it("stays silent on match, over and unknown", () => {
-    expect(falseOkWarning(delta({ status: "match", observed: 4, after: 25 }), clean())).toBeNull();
-    expect(falseOkWarning(delta({ status: "over", observed: 6, after: 23 }), clean())).toBeNull();
-    expect(falseOkWarning(delta({ status: "unknown", expected: null }), clean())).toBeNull();
-  });
-
-  it("is surfaced by reconciliationWarnings alongside the over warning", () => {
-    const warnings = reconciliationWarnings({
-      countDeltas: [delta()],
-      preImages: [],
-      outcomes: [],
-      collateral: [clean()],
+  it("classifies a flat count as count-did-not-move, and says it is ordinary", () => {
+    h.flagOnlyDelete = true;
+    mgr.batchDeleteMessages(["75811", "75812"]);
+    const [d] = mgr.consumeLastForensics()!.countDeltas;
+    expect(d).toMatchObject({
+      expected: 2,
+      observed: 0,
+      status: "unknown",
+      unknownReason: "count-did-not-move",
     });
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toMatch(/Reported success with no observed effect/);
+    // Must keep reassuring a store that flags deletions, and must NOT send the
+    // reader hunting a destination that does not exist for it.
+    expect(d.note).toMatch(/flags deletions instead of removing them/);
+    expect(d.note).not.toMatch(/date received/);
+    expect(d.note).toMatch(/do not retry/i);
+  });
+
+  it("classifies a short-but-nonzero count as count-partial, a shape flag-only cannot make", () => {
+    // Scott's "expected 16, observed 1" reading. Silent under the old warning
+    // (it required observed === 0) while being the most badly wrong of the four.
+    h.collateral = []; // only the requested ones leave
+    h.flagOnlyDelete = false;
+    seed(SAMPLE);
+    h.staleAfterCountBy = 1; // both left; Mail's count is one behind
+    mgr.batchDeleteMessages(["75811", "75812"]);
+    const [d] = mgr.consumeLastForensics()!.countDeltas;
+    expect(d).toMatchObject({
+      expected: 2,
+      observed: 1,
+      status: "unknown",
+      unknownReason: "count-partial",
+    });
+    expect(d.note).toMatch(/LOWER BOUND/);
+    // The #152 correction: ids renumber on the move, so the pre-image ids are
+    // not a usable key at the destination.
+    expect(d.note).toMatch(/date received/);
+    expect(d.note).toMatch(/renumbered by the move/);
+  });
+
+  it("never reports the retired `under` status", () => {
+    // Deleted rather than deprecated so the compiler enumerates every consumer.
+    for (const flagOnly of [true, false]) {
+      seed(SAMPLE);
+      h.flagOnlyDelete = flagOnly;
+      mgr.batchDeleteMessages(["75811", "75812"]);
+      for (const d of mgr.consumeLastForensics()!.countDeltas) {
+        expect(d.status).not.toBe("under");
+      }
+    }
+  });
+
+  it("still warns on `over` — the one surviving assertion", () => {
+    h.collateral = ["75814", "75815"];
+    mgr.batchDeleteMessages(["75811", "75812"]);
+    const report = mgr.consumeLastForensics()!;
+    expect(report.countDeltas[0].status).toBe("over");
+    expect(reconciliationWarnings(report)).toHaveLength(1);
+  });
+
+  it("keeps count-unreadable distinct, with its own note", () => {
+    h.suppressCount = true;
+    mgr.batchDeleteMessages(["75811"]);
+    const [d] = mgr.consumeLastForensics()!.countDeltas;
+    expect(d).toMatchObject({
+      before: null,
+      after: null,
+      observed: null,
+      status: "unknown",
+      unknownReason: "count-unreadable",
+    });
+    expect(d.note).toMatch(/did not report a message count/);
   });
 });

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -718,6 +718,43 @@ const SELF_MOVE_NOTE =
   "comparison and is never warned about.";
 
 /**
+ * The `note` when the count did not move AT ALL (`unknownReason:
+ * "count-did-not-move"`).
+ *
+ * This is the ordinary reading on a store that flags deletions instead of
+ * removing them, and it must keep saying so plainly. Two things it deliberately
+ * does NOT do, both of which a previous version got wrong (#155):
+ *
+ *   - it does not tell the reader to go check a destination. On a flag-only
+ *     store the message was never moved, so there is nothing to find, and its
+ *     absence reads as "the delete failed" when the delete succeeded;
+ *   - it does not suggest retrying. The operation reported success per id, and
+ *     a retry on the strength of a count is how one deletes twice.
+ */
+const COUNT_UNMOVED_NOTE =
+  "Mail's count did not move. This is the ordinary reading on a store that flags deletions " +
+  'instead of removing them (Gmail label mailboxes and IMAP accounts with "move deleted ' +
+  'messages to Trash" off), where the message stays put and the operation still fully ' +
+  "succeeded. It can also mean Mail's count simply had not caught up yet. The per-id outcomes " +
+  "are what report success; this number is not, so do not retry on the strength of it.";
+
+/**
+ * The `note` when the count moved but by less than the operation accounted for
+ * (`unknownReason: "count-partial"`).
+ *
+ * A flag-only store cannot produce this shape — its count does not move at all —
+ * so unlike COUNT_UNMOVED_NOTE this one can talk about a lag without being wrong
+ * on the commonest benign store.
+ */
+const COUNT_PARTIAL_NOTE =
+  "Mail's count moved by less than this operation accounted for. That is a LOWER BOUND on " +
+  "what left, not a count of what left: Mail has been observed reporting a stale count for a " +
+  "delete it had already performed (issue #155), and new mail arriving mid-operation reads the " +
+  "same way. No claim is made either way. To confirm where the messages went, match them at " +
+  'the destination by "date received" plus sender — NOT by the numeric ids you passed, which ' +
+  "are renumbered by the move and do not survive it.";
+
+/**
  * Same key discipline for a snapshot entry's (numeric id, Message-ID) identity —
  * including writing the separator as an escape rather than a raw byte. The id
  * half is already canonicalised by `parseSnapshot`, so both phases of a
@@ -1454,13 +1491,32 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       const observed = readable ? m.before - m.after : null;
       const note = noteFor(m.account, m.mailbox);
       let status: CountDelta["status"];
-      // Two independent reasons there is nothing to compare: Mail would not
-      // report a count, or no expected delta can be justified. Either one ends
-      // in `unknown`, which never warns.
-      if (!readable || m.expected === null) status = "unknown";
-      else if (observed === m.expected) status = "match";
-      else if ((observed ?? 0) > m.expected) status = "over";
-      else status = "under";
+      let unknownReason: CountDelta["unknownReason"];
+      // Four disjoint ways there is nothing this server will assert. They are
+      // NOT interchangeable to a reader, so each carries its own reason and its
+      // own note — see the #155 retraction on CountDelta.
+      if (!readable) {
+        status = "unknown";
+        unknownReason = "count-unreadable";
+      } else if (m.expected === null) {
+        status = "unknown";
+        unknownReason = "no-expectation";
+      } else if (observed === m.expected) {
+        status = "match";
+      } else if ((observed ?? 0) > m.expected) {
+        status = "over";
+      } else if (observed === 0) {
+        // The count did not move at all. On a store that flags deletions
+        // instead of removing them this is the ORDINARY reading for an
+        // operation that fully succeeded, so it must keep saying so.
+        status = "unknown";
+        unknownReason = "count-did-not-move";
+      } else {
+        // It moved, but short. A flag-only store cannot produce this, which is
+        // the whole reason it is worth telling apart from the case above.
+        status = "unknown";
+        unknownReason = "count-partial";
+      }
       return {
         account: m.account,
         mailbox: m.mailbox,
@@ -1469,18 +1525,13 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         expected: m.expected,
         observed,
         status,
+        ...(unknownReason ? { unknownReason } : {}),
         ...(note ? { note } : {}),
-        ...(status === "unknown" && readable === false
+        ...(unknownReason === "count-unreadable"
           ? { note: note ?? "Mail did not report a message count for this mailbox" }
           : {}),
-        ...(status === "under" && !note
-          ? {
-              note:
-                "Fewer messages left the mailbox than were operated on. This is normal on a store " +
-                "that flags deletions instead of removing them (and when new mail arrives " +
-                "mid-operation), so it is reported but not warned about.",
-            }
-          : {}),
+        ...(unknownReason === "count-did-not-move" && !note ? { note: COUNT_UNMOVED_NOTE } : {}),
+        ...(unknownReason === "count-partial" && !note ? { note: COUNT_PARTIAL_NOTE } : {}),
       };
     });
 
@@ -1500,8 +1551,10 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     }
 
     // Collateral: subtract the after-snapshot from the before-snapshot per
-    // mailbox. Keyed on RFC Message-ID, which is stable and store-independent;
-    // the numeric id rides along for correlation with the caller's id list.
+    // mailbox. Keyed on the (numeric id, RFC Message-ID) PAIR — see
+    // `snapshotKey`. Both phases read the same source mailbox before and after,
+    // so neither half of the key moves under a message that stayed put; the
+    // numeric id also correlates the entry with the caller's id list.
     const collateral: CollateralDiff[] = [];
     const byMailbox = new Map<
       string,

--- a/src/services/auditLog.ts
+++ b/src/services/auditLog.ts
@@ -139,15 +139,28 @@ export function auditSnapshotChunk(): number {
  *               This is the #155 signature and the data-loss direction, but it
  *               is a SIGNAL, not a proof — see `countDeltaWarning`. It is the
  *               only status that raises a warning in the tool response.
- * - `under`   — FEWER left than expected. This has legitimate causes on real
- *               stores (see `note`), so it is reported but never warned about.
- * - `unknown` — no comparison was possible: either the count could not be read
- *               (`before`/`after` null), or the expected delta is not
- *               predictable for this operation (`expected` null — a move whose
- *               destination IS the source mailbox is the one case, see `note`).
- *               Said plainly rather than guessed, and never warned about: a
- *               warning computed against a number nobody can justify is exactly
- *               the false alarm this instrumentation must not produce.
+ * - `unknown` — no comparison this server is willing to assert. `unknownReason`
+ *               says which of four disjoint situations produced it. Never
+ *               warned about: a warning computed against a number nobody can
+ *               justify is exactly the false alarm this must not produce.
+ *
+ * ## Where `under` went (removed 2026-08-16, #155)
+ *
+ * There used to be an `under` status meaning "fewer left than expected", framed
+ * as routine. Field evidence from @scottstern0325 on iCloud retired it: for two
+ * `observed: 0` batches the messages were located **in Trash**, matched by
+ * `date received` + sender against the audit-log pre-image. The deletes had
+ * happened. Mail's count had not caught up.
+ *
+ * So a short reading does not mean fewer messages left. It means **Mail's count
+ * says fewer left**, and that count has been observed lagging a delete it had
+ * already performed. Reporting it as a comparison result dressed the lag up as
+ * a finding. The four readings in that report — 0 of 4, 0 of 1 (a single-id
+ * delete), 15 of 16, and 14 of 15 — differ by amounts unrelated to batch size,
+ * which is what a lag looks like and not what a store-behaviour rule looks like.
+ *
+ * The vocabulary is deleted rather than deprecated so the compiler enumerates
+ * every consumer; a dead status string gets re-implemented by the next author.
  */
 export interface CountDelta {
   /** Account holding the affected mailbox ("" when Mail would not say). */
@@ -164,9 +177,36 @@ export interface CountDelta {
    * always pairs with `status: "unknown"`.
    */
   expected: number | null;
-  /** `before - after`; null when either count is unavailable. */
+  /**
+   * `before - after` — the movement of Mail's COUNT, and a LOWER BOUND on how
+   * many messages left. Null when either count is unavailable.
+   *
+   * Not "how many messages left". Mail has been observed reporting an unchanged
+   * count for a delete it had already performed (#155), so a value below
+   * `expected` is as consistent with a lagging count as with an incomplete
+   * operation, and this server will not claim to know which.
+   */
   observed: number | null;
-  status: "match" | "over" | "under" | "unknown";
+  status: "match" | "over" | "unknown";
+  /**
+   * Which situation produced `status: "unknown"`. Four disjoint cases, kept
+   * separate because they are NOT interchangeable to a reader:
+   *
+   * - `count-unreadable`     — Mail would not report a count at all
+   *                            (`before`/`after` null).
+   * - `no-expectation`       — no expected delta is predictable, so no
+   *                            comparison exists (a move whose destination IS
+   *                            the source mailbox).
+   * - `count-did-not-move`   — the count did not move at all. On a store that
+   *                            flags deletions instead of removing them this is
+   *                            the ORDINARY, CORRECT reading, and the note says
+   *                            so. Do not treat it as a problem signal.
+   * - `count-partial`        — the count moved, but by less than the operation
+   *                            accounted for. A flag-only store cannot produce
+   *                            this (its count does not move at all), which is
+   *                            what makes it worth distinguishing.
+   */
+  unknownReason?: "count-unreadable" | "no-expectation" | "count-did-not-move" | "count-partial";
   /** Why the numbers are what they are, when that needs saying. */
   note?: string;
 }
@@ -232,7 +272,15 @@ export interface CollateralDiff {
    *
    * An absent array therefore means "not computable", never "empty". Consumers
    * must not read `disappeared?.length ?? 0` as "nothing disappeared" — check
-   * `snapshot === "ok"` first, which is what `falseOkWarning` does.
+   * `snapshot === "ok"` first.
+   *
+   * ⚠️ And `snapshot === "ok"` is necessary, not sufficient. The enumeration's
+   * range is bounded by Mail's own message count (see `snapshotFragment`), and
+   * #155 established that count can lag the mutation. A count that reads LOW
+   * truncates the enumeration silently — the unread tail is never requested, so
+   * it never registers as a failed slice — and messages past the bound would
+   * then look like they disappeared. Tracked as its own defect; until it is
+   * fixed, treat a `disappeared` entry as a lead, not a proof.
    */
   snapshot: "ok" | "partial" | "skipped" | "unavailable";
   skipReason?: string;
@@ -373,64 +421,12 @@ export function countDeltaWarning(d: CountDelta): string | null {
 }
 
 /**
- * The one `under` reading that is NOT routine: a total no-op reported as success.
+ * Every warning a report has to raise, in mailbox order.
  *
- * The blanket `under` suppression above is justified by accounts that flag
- * `\Deleted` without removing the message, so the source count never drops. That
- * argument holds for the *shape* of the account, not for every reading — and it
- * suppressed a real defect (#155, reported on iCloud against 2.10.17):
- *
- * ```json
- * {"outcomes":[{"id":"68196","status":"ok"}, ...4 ids all "ok"],
- *  "countDeltas":[{"before":29,"after":29,"expected":4,"observed":0,"status":"under"}],
- *  "collateral":[{"snapshot":"ok","disappeared":[],"unrequested":[],"appeared":[]}]}
- * ```
- *
- * Four successes reported for an operation in which, by this server's own
- * measurement, nothing happened.
- *
- * The discriminator is the collateral snapshot. A flag-only account removes
- * nothing observably — but so does a total no-op, and the two are
- * indistinguishable *only when the snapshot could not be taken*. Here it was
- * taken, it read the mailbox fine, and it says nothing left. Requiring
- * `snapshot === "ok"` and an empty `disappeared` is what keeps this from firing
- * on the ordinary flag-only delete the blanket suppression exists to protect.
- *
- * Deliberately narrow: `observed === 0` only. A partial under (3 of 4 removed)
- * stays unwarned, because that is exactly where a flag-only account and a
- * partial failure DO look alike.
- *
- * `snapshot === "ok"` also excludes a PARTIAL snapshot (#176), and must keep
- * doing so. A partial snapshot's `disappeared` is either absent or an
- * undercount, so "nothing left the mailbox" is precisely the claim it cannot
- * support — warning off it would fire on a flag-only account whose snapshot
- * merely had a hole in it.
+ * `over` is the only surviving assertion. `falseOkWarning` was removed in
+ * 2.11.0 — see the note on `countDeltaWarning` for why its discriminator did
+ * not hold.
  */
-export function falseOkWarning(d: CountDelta, collateral?: CollateralDiff): string | null {
-  if (d.status !== "under" || d.expected === null) return null;
-  if (d.observed !== 0 || d.expected <= 0) return null;
-  if (!collateral || collateral.snapshot !== "ok") return null;
-  if ((collateral.disappeared?.length ?? 0) !== 0) return null;
-
-  const where = d.account ? `"${d.mailbox}" in account "${d.account}"` : `"${d.mailbox}"`;
-  return (
-    `⚠️ Reported success with no observed effect in ${where}: ${d.expected} message(s) were ` +
-    `operated on and reported ok, but the mailbox count did not move (${d.before} → ${d.after}) ` +
-    `and the collateral snapshot — which read this mailbox successfully — shows no message left ` +
-    `it. Either the operation silently did nothing, or Mail's count and listing are both stale ` +
-    `and the messages did move. Check the destination (Trash for a delete) before assuming ` +
-    `either: if they are there, this is a measurement-timing bug; if they are still in the ` +
-    `source mailbox minutes later, the operation failed while reporting success. Please report ` +
-    `at https://github.com/sweetrb/apple-mail-mcp/issues/155 with ` +
-    `${AUDIT_LOG_ENV}=/path/to/audit.ndjson set.`
-  );
-}
-
-/** Every warning a report has to raise, in mailbox order. */
 export function reconciliationWarnings(report: DestructiveOpReport): string[] {
-  const collateralFor = (d: CountDelta) =>
-    report.collateral.find((c) => c.account === d.account && c.mailbox === d.mailbox);
-  return report.countDeltas
-    .flatMap((d) => [countDeltaWarning(d), falseOkWarning(d, collateralFor(d))])
-    .filter((w): w is string => w !== null);
+  return report.countDeltas.map((d) => countDeltaWarning(d)).filter((w): w is string => w !== null);
 }


### PR DESCRIPTION
Refs #155, #152. Ships as **2.11.0** — `countDelta.status` loses a value, so this is a breaking output change.

## What changed the answer

@scottstern0325 ran the Trash check that has been the outstanding discriminator on #155 since 2.10.30, and it went the **opposite** way from what that release assumed. For two batches reporting `observed: 0`, the messages were **in iCloud Trash** — matched by `date received` + sender against the audit-log pre-image, at contiguous Trash ids in batch order. The deletes happened. Mail's count had not caught up.

That retires the reasoning behind both things this PR removes.

## 1. `falseOkWarning` is deleted

2.10.30 justified it like this (`auditLog.ts`): *"The discriminator is the collateral snapshot… a flag-only account and a total no-op are indistinguishable only when the snapshot could not be taken. Here it was taken, it read the mailbox fine, and it says nothing left."*

**The snapshot is not a second opinion.** It and the count are consecutive Apple Events in the same script — `countFragment("_ca")` then `snapshotFragment("after", …, "_ca")` at `appleMailManager.ts:3843`, with nothing between them. The record that motivated the warning had *both* instruments stale at once: it reported `disappeared: []` for a mailbox those four messages had already left. Worth noting that record came from 2.10.17, where the snapshot was an *unbounded* whole-mailbox enumeration (`git show v2.10.17:src/services/appleMailManager.ts`) — free to disagree with the count, and it didn't.

So the warning fired on stores that had done exactly what they were asked. **Reproduced, not inferred** — flag-only account, audit log on, two successful deletes:

```
⚠️ Reported success with no observed effect in "INBOX" in account "me@example.com":
2 message(s) were operated on and reported ok, but the mailbox count did not move (5 → 5)…
```

That is a live `alarms-must-not-cry-wolf` violation for every user who had opted into the audit log.

**The guard that was supposed to prevent it could never have caught it.** `"does NOT cry wolf when fewer messages leave than expected"` ran with `APPLE_MAIL_MCP_AUDIT_LOG` deleted by `beforeEach`, so no SNAP records were produced, `collateralFor` was `undefined`, and the warning short-circuited before its gates. It passed for a reason unrelated to its title — a textbook `guards-must-fail-on-the-bug-they-target` failure sitting in the file. It now runs with the log on.

## 2. `status: "under"` is removed

It asserted "fewer messages left than expected". What it observed was "**Mail's count says** fewer left", from an instrument now known to lag. Scott's four readings — 0 of 4, 0 of 1 (a **single-id** delete), 15 of 16, 14 of 15 — have a shortfall unrelated to batch size, which is what a lag looks like, not a store-behaviour rule.

Deleted rather than deprecated so the compiler enumerates every consumer.

Replaced by `unknown` + `unknownReason`, four disjoint cases. **The split that matters:**

| `unknownReason` | Note says |
|---|---|
| `count-did-not-move` | ordinary on a flag-only store; **does not** say "check the destination" |
| `count-partial` | lower bound, may be a lag; **does** say how to confirm at the destination |

A flag-only store cannot produce `count-partial` (its count doesn't move at all), which is exactly why they're worth telling apart. An earlier draft used one note for both, and it would have told every flag-only account, on every delete, forever, to go hunt Trash for a message that was never moved there — where the absence reads as "the delete failed". That would have been a *worse* alarm than the one being removed, and un-gated.

## 3. #152: pre-image ids don't survive the move

Per Scott, ids renumber on the move to Trash. `list-messages` returns no Message-ID (`src/tools/respond.ts:17-29`), so `date received` + sender is the only key a default user actually has — which is what he had to hand-match. The note now says that instead of leaving the reader to infer that the ids they were handed will work.

## Deliberately not included: an in-script settle

The obvious fix is to make the count fresher. Three independent adversarial reviews of that design killed it:

- It re-reads **only when the reading is short**, and the reported `after` becomes the last read — so it can only push `observed` **up**, directly into `countDeltaWarning`, the sole surviving always-on alarm. Concrete: flag-only Gmail INBOX, `delete-message`, a server-side filter archives 2 arrivals during the wait → `observed: 2 > expected: 1` → **`over` fires**, on an operation that today is silent. New false-alarm exposure concentrated on precisely the population this release protects.
- The after-snapshot's read range is bounded by `_ca`, so settling `_ca` **truncates the enumeration** and lands innocent survivors in `disappeared` and then `unrequested` — documented as *"IS the #155 symptom, with names attached"*. It would manufacture the smoking gun, with victims named.
- One fixed delay yields one bit per event, not a distribution, so it cannot size the very time constant it exists to measure.

Sizing a wait needs a measurement nobody has taken. Scott offered to take it — see the issue reply.

## Verification

- **All 7 changed/new guards shown failing against 2.10.33 first**, including the flag-only cry-wolf.
- `lint` / `typecheck` / `format:check` clean; **631 tests pass**.
- Committed `build/index.js` rebuilt and verified in sync.
- The simulator gained `staleAfterCountBy` (count reads high while the listing is correct — the #155 shape) and `suppressCount`, so the count and the listing can now disagree in tests. They could not before, which is part of why this went unnoticed.
- No AppleScript generation changed, so nothing here needs live-Mail execution.

## Also documented, not fixed

`"snapshot": "ok"` is necessary but **not sufficient**: the enumeration is bounded by Mail's count, so a count reading *low* truncates it silently — the unread tail is never requested, never registers as a failed slice, status stays `"ok"` — and messages past the bound look like they disappeared. That narrows the guarantee 2.10.33 stated. Filing separately rather than bolting on a probe whose clamp-or-raise semantics are backend-dependent and would be gated on one account.