### PR TITLE
fix: three defects found by an end-to-end regression sweep (2.11.1)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 ## [Unreleased]
 
+## [2.11.1] - 2026-08-16
+
+Three defects found by an end-to-end regression sweep against real mail. All
+three are long-standing (2.2.0 / the I1 optimization), not regressions from
+2.11.0 — they had simply never been exercised against a message that could
+expose them.
+
+### Fixed
+
+- **Attachments sent from Apple Mail were invisible over IMAP — and unfetchable.**
+  `collectAttachments` treated `Content-Disposition: inline` as "not an
+  attachment". But Mail.app sends genuine file attachments as `inline`, because
+  it inlines them into the message flow rather than appending them. Since
+  `fetch-attachment` and `save-attachment` resolve by filename against the same
+  walk, those files were not merely unlisted — **they could not be retrieved at
+  all**.
+
+  Measured over 300 real messages: of 27 parts carrying a filename, 4 were being
+  excluded — three invoice PDFs (inline, no Content-ID) and one signature logo
+  (inline `image/png`, **with** a Content-ID). So the discriminator is the
+  **Content-ID**, not the disposition: a part the HTML body references as `cid:`
+  is embedded content; anything else with a filename is a file. An explicit
+  `attachment` disposition still always wins, because real mail carries
+  `attachment` parts that also have a Content-ID.
+
+- **`hasAttachments` was hardcoded `false` on every IMAP-sourced message**
+  (since 2.2.0). Indistinguishable to a caller from "no attachments", so an
+  agent deciding whether to call `list-attachments` would always skip. It is now
+  derived from BODYSTRUCTURE, which the list/search/thread fetch requests
+  alongside the envelope — measured at ~390ms → ~465ms for 50 messages (~17%),
+  the same single round trip with no extra request.
+
+- **`doctor` and `health-check` reported `permissions: ok` on a real TCC denial.**
+  `mapError` normalises an Automation refusal to *"Permission denied. Grant
+  automation access…"*, replacing the raw text — and `healthCheck` then
+  classified the failure by re-testing for `"not authorized"` / `"not
+  permitted"`, the very substrings the normalisation had just removed. So
+  `isPermError` was unreachable, the check reported `passed: true` while its own
+  detail line read "Permission denied", and the early `healthy: false` return
+  never fired. The run then fell through to the accounts probe and surfaced *"No
+  Mail accounts found. Set up an account in Mail.app first"* — sending the user
+  to configure accounts they already have, when the real problem was one
+  Automation grant.
+
+  Classification and normalisation now derive from one exported pattern
+  (`isPermissionDenied`, `PERMISSION_DENIED_MESSAGE`) so they cannot drift apart
+  again, and the classifier accepts both the raw and the normalised form.
+
+
 ## [2.11.0] - 2026-08-16
 
 Retraction release. A warning shipped in 2.10.30 was firing on stores that had

--- a/build/index.js
+++ b/build/index.js
@@ -78071,11 +78071,17 @@ function sleep(ms) {
     }
   }
 }
+var PERMISSION_DENIED_PATTERN = /not authorized|not permitted|access.*denied/i;
+var PERMISSION_DENIED_MESSAGE = "Permission denied. Grant automation access in System Settings > Privacy & Security > Automation.";
+function isPermissionDenied(error2) {
+  if (!error2) return false;
+  return PERMISSION_DENIED_PATTERN.test(error2) || error2.includes(PERMISSION_DENIED_MESSAGE);
+}
 var ERROR_MAPPINGS = [
   // Permission errors
   {
-    pattern: /not authorized|not permitted|access.*denied/i,
-    message: "Permission denied. Grant automation access in System Settings > Privacy & Security > Automation."
+    pattern: PERMISSION_DENIED_PATTERN,
+    message: PERMISSION_DENIED_MESSAGE
   },
   // Application not running
   {
@@ -82841,7 +82847,7 @@ ${actionStmts.join("\n")}
         message: "Mail.app is accessible"
       });
     } else {
-      const errorHint = mailCheck.error?.includes("not authorized") ? " (check System Settings > Privacy & Security > Automation)" : "";
+      const errorHint = isPermissionDenied(mailCheck.error) ? " (check System Settings > Privacy & Security > Automation)" : "";
       checks.push({
         name: "mail_app",
         passed: false,
@@ -82857,7 +82863,7 @@ ${actionStmts.join("\n")}
         message: "AppleScript automation permissions granted"
       });
     } else {
-      const isPermError = permCheck.error?.includes("not authorized") || permCheck.error?.includes("not permitted");
+      const isPermError = isPermissionDenied(permCheck.error);
       checks.push({
         name: "permissions",
         passed: !isPermError,
@@ -83681,7 +83687,12 @@ function structuredRow(m, account, path) {
     flagColorIndex: mailFlagColorIndex(m.flags),
     mailbox: path,
     account,
-    hasAttachments: false,
+    // Derived from BODYSTRUCTURE, which the list/search fetch now requests.
+    // This was hardcoded `false` from 2.2.0 until 2.11.1 — indistinguishable to
+    // a caller from "no attachments", so every IMAP-sourced message claimed to
+    // have none. Falls back to false only when the fetch carried no
+    // BODYSTRUCTURE at all.
+    hasAttachments: bodyStructureHasAttachments(m.bodyStructure),
     // Message-ID (when the envelope carries it) is the strongest cross-/intra-
     // backend dedup key for the multi-account merge (imapMultiAccount.ts). The
     // AppleScript path does not expose it, so cross-backend dedup falls back to
@@ -83712,7 +83723,10 @@ async function run(args, listMode, deps) {
         const byUid = /* @__PURE__ */ new Map();
         for await (const msg of client.fetch(
           newest.join(","),
-          { envelope: true, flags: true },
+          // BODYSTRUCTURE rides along so `hasAttachments` is computed rather
+          // than assumed. Measured on 50 real messages: ~390ms -> ~465ms for
+          // the fetch (~17%), same single round trip, no extra request.
+          { envelope: true, flags: true, bodyStructure: true },
           { uid: true }
         )) {
           byUid.set(msg.uid, msg);
@@ -84206,7 +84220,8 @@ function collectAttachments(node, out = []) {
   if (!node) return out;
   const filename = node.dispositionParameters?.filename || node.parameters?.name;
   const disposition = node.disposition?.toLowerCase();
-  const isAttachment = !!node.part && (disposition === "attachment" || !!filename && disposition !== "inline");
+  const isEmbeddedByReference = disposition === "inline" && !!node.id;
+  const isAttachment = !!node.part && (disposition === "attachment" || !!filename && !isEmbeddedByReference);
   if (isAttachment) {
     out.push({
       part: node.part,
@@ -84217,6 +84232,9 @@ function collectAttachments(node, out = []) {
   }
   for (const child of node.childNodes ?? []) collectAttachments(child, out);
   return out;
+}
+function bodyStructureHasAttachments(node) {
+  return !!node && collectAttachments(node).length > 0;
 }
 async function streamToBuffer(content, maxBytes) {
   const chunks = [];
@@ -84389,7 +84407,10 @@ async function imapThread(id, deps = {}, limit = 50) {
         const msgs = [];
         for await (const msg of client.fetch(
           uids.join(","),
-          { envelope: true, flags: true },
+          // Same reason as the list/search fetch: get-thread emits structured
+          // rows too, so it needs BODYSTRUCTURE or its hasAttachments would
+          // silently disagree with the same message seen via search.
+          { envelope: true, flags: true, bodyStructure: true },
           { uid: true }
         )) {
           msgs.push(msg);

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.11.0"
+        "apple-mail-mcp@2.11.1"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleMailManager.health.test.ts
+++ b/src/services/appleMailManager.health.test.ts
@@ -1,0 +1,56 @@
+/**
+ * healthCheck's permission classification (#TCC-misreport).
+ *
+ * `executeAppleScript` normalises a TCC refusal into "Permission denied. Grant
+ * automation access…", replacing the raw text. healthCheck then classified the
+ * failure by re-testing for "not authorized"/"not permitted" — substrings the
+ * normalisation had just removed — so `isPermError` was unreachable and a real
+ * denial was reported as `passed: true`, skipping the early `healthy: false`
+ * return. The check shared a NAME with the real thing but not a code path.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({ denyAll: true }));
+
+vi.mock("@/utils/applescript.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/applescript.js")>();
+  return {
+    ...actual,
+    // Faithful to what a real TCC-denied host does, verified live: the
+    // `return "ok"` probe SUCCEEDS (it sends no Apple Event that needs a
+    // grant), while reading an account property is refused. So check 1 passes
+    // and the denial surfaces at check 2 — which is precisely why the
+    // misclassification mattered rather than being masked by an early return.
+    executeAppleScript: (script: string) => {
+      if (!h.denyAll) return { success: true, output: script.includes('return "ok"') ? "ok" : "" };
+      if (script.includes('return "ok"')) return { success: true, output: "ok" };
+      return { success: false, error: actual.PERMISSION_DENIED_MESSAGE };
+    },
+  };
+});
+
+import { AppleMailManager } from "@/services/appleMailManager.js";
+
+describe("healthCheck under a TCC denial", () => {
+  beforeEach(() => {
+    h.denyAll = true;
+  });
+
+  it("reports the permissions check as FAILED, not passed", () => {
+    const r = new AppleMailManager().healthCheck();
+    const perms = r.checks.find((c) => c.name === "permissions");
+    expect(perms).toBeDefined();
+    expect(perms!.passed).toBe(false);
+    expect(r.healthy).toBe(false);
+  });
+
+  it("stops at the permission check instead of reporting a misleading downstream failure", () => {
+    // Pre-fix this fell through to the accounts probe and surfaced
+    // "No Mail accounts found. Set up an account in Mail.app first." — which
+    // sends the user to configure accounts they already have, when the actual
+    // problem is one Automation grant.
+    const r = new AppleMailManager().healthCheck();
+    expect(r.checks.some((c) => c.name === "accounts")).toBe(false);
+    expect(JSON.stringify(r)).not.toMatch(/Set up an account in Mail\.app first/);
+  });
+});

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -32,7 +32,7 @@ import {
 import { resolve, sep, join } from "path";
 import { homedir } from "os";
 import { randomUUID } from "crypto";
-import { executeAppleScript } from "@/utils/applescript.js";
+import { executeAppleScript, isPermissionDenied } from "@/utils/applescript.js";
 import { SETUP_HINT } from "@/utils/docsUrls.js";
 import { parseMimeAttachments, extractMimeAttachment, extractHtmlBody } from "@/utils/mimeParse.js";
 import { TemplateStore } from "@/services/templateStore.js";
@@ -5561,7 +5561,7 @@ ${actionStmts.join("\n")}
         message: "Mail.app is accessible",
       });
     } else {
-      const errorHint = mailCheck.error?.includes("not authorized")
+      const errorHint = isPermissionDenied(mailCheck.error)
         ? " (check System Settings > Privacy & Security > Automation)"
         : "";
       checks.push({
@@ -5581,8 +5581,7 @@ ${actionStmts.join("\n")}
         message: "AppleScript automation permissions granted",
       });
     } else {
-      const isPermError =
-        permCheck.error?.includes("not authorized") || permCheck.error?.includes("not permitted");
+      const isPermError = isPermissionDenied(permCheck.error);
       checks.push({
         name: "permissions",
         passed: !isPermError,

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -26,6 +26,7 @@ import {
   imapMailStats,
   imapListAttachments,
   imapFetchAttachment,
+  bodyStructureHasAttachments,
   imapBatchMarkRead,
   imapBatchMove,
   imapThread,
@@ -1016,6 +1017,160 @@ describe("attachments via BODYSTRUCTURE (I1)", () => {
     expect(r.success).toBe(true);
     expect(r.attachments?.map((a) => a.name)).toEqual(["report.pdf", "logo.png"]);
     expect(r.attachments?.[0]).toMatchObject({ mimeType: "application/pdf", size: 2048 });
+  });
+
+  // Apple Mail sends genuine file attachments as `Content-Disposition: inline`
+  // — it inlines them into the message flow rather than appending them. The
+  // structure below is copied from a real message (an invoice PDF this server's
+  // own author sent from Mail.app): inline, named, and with NO Content-ID.
+  //
+  // Excluding every inline part made all of them invisible AND unfetchable over
+  // IMAP, because fetch-attachment resolves by name against this same list.
+  function appleMailClient(): ImapClientLike {
+    return {
+      ...makeClient([], {}),
+      fetchOne: async () => ({
+        uid: 9,
+        bodyStructure: {
+          type: "multipart/alternative",
+          childNodes: [
+            { part: "1", type: "text/plain", size: 353 },
+            {
+              part: "2",
+              type: "multipart/mixed",
+              childNodes: [
+                { part: "2.1", type: "text/html", size: 443 },
+                {
+                  part: "2.2",
+                  type: "application/pdf",
+                  parameters: { name: "SEI Invoice.pdf" },
+                  disposition: "inline",
+                  dispositionParameters: { filename: "SEI Invoice.pdf" },
+                  size: 66714,
+                },
+                { part: "2.3", type: "text/html", size: 3715 },
+              ],
+            },
+          ],
+        },
+      }),
+      download: async (_range: string, part: string) => ({
+        meta: {},
+        content: (async function* () {
+          yield Buffer.from(`bytes-of-${part}`);
+        })(),
+      }),
+    };
+  }
+
+  it("lists an inline-disposition file attachment (Apple Mail's shape)", async () => {
+    const r = await imapListAttachments(MID, {
+      config: cfg,
+      connect: async () => appleMailClient(),
+    });
+    expect(r.success).toBe(true);
+    expect(r.attachments?.map((a) => a.name)).toEqual(["SEI Invoice.pdf"]);
+    expect(r.attachments?.[0]).toMatchObject({ mimeType: "application/pdf", size: 66714 });
+  });
+
+  it("can fetch that inline attachment by name", async () => {
+    // Listing it is only half the fix: fetch/save resolve by name against the
+    // same walk, so an unlisted part is also an unfetchable one.
+    const r = await imapFetchAttachment(MID, "SEI Invoice.pdf", {
+      config: cfg,
+      connect: async () => appleMailClient(),
+    });
+    expect(r.success).toBe(true);
+    expect(r.mimeType).toBe("application/pdf");
+  });
+
+  it("still excludes an embedded image referenced by Content-ID", async () => {
+    // The other half: a signature logo is inline, named AND carries a
+    // Content-ID because the HTML references it as cid:. That one is genuinely
+    // not an attachment, and widening the rule must not start listing it.
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      fetchOne: async () => ({
+        uid: 9,
+        bodyStructure: {
+          type: "multipart/related",
+          childNodes: [
+            { part: "1", type: "text/html", size: 900 },
+            {
+              part: "2",
+              type: "image/png",
+              id: "<image001.png@01DC.4F2>",
+              parameters: { name: "image001.png" },
+              disposition: "inline",
+              dispositionParameters: { filename: "image001.png" },
+              size: 4096,
+            },
+          ],
+        },
+      }),
+    };
+    const r = await imapListAttachments(MID, { config: cfg, connect: async () => client });
+    expect(r.success).toBe(true);
+    expect(r.attachments).toEqual([]);
+  });
+
+  it("reports hasAttachments from BODYSTRUCTURE rather than assuming false", async () => {
+    // Hardcoded `false` from 2.2.0: indistinguishable from "no attachments", so
+    // every IMAP-sourced message claimed to have none and a caller deciding
+    // whether to call list-attachments would always skip.
+    const withAtt = bodyStructureHasAttachments({
+      type: "multipart/mixed",
+      childNodes: [
+        { part: "1", type: "text/plain", size: 10 },
+        {
+          part: "2",
+          type: "application/pdf",
+          disposition: "inline",
+          dispositionParameters: { filename: "Invoice.pdf" },
+          size: 99,
+        },
+      ],
+    });
+    expect(withAtt).toBe(true);
+
+    const bodyOnly = bodyStructureHasAttachments({
+      type: "multipart/alternative",
+      childNodes: [
+        { part: "1", type: "text/plain", size: 10 },
+        { part: "2", type: "text/html", size: 20 },
+      ],
+    });
+    expect(bodyOnly).toBe(false);
+
+    // Absent BODYSTRUCTURE must not claim attachments exist.
+    expect(bodyStructureHasAttachments(undefined)).toBe(false);
+  });
+
+  it("lists an explicit attachment even when it carries a Content-ID", async () => {
+    // Observed in real mail: disposition "attachment" WITH a Content-ID. The
+    // explicit disposition has to win, or Content-ID becomes an over-broad veto.
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      fetchOne: async () => ({
+        uid: 9,
+        bodyStructure: {
+          type: "multipart/mixed",
+          childNodes: [
+            { part: "1", type: "text/plain", size: 10 },
+            {
+              part: "2",
+              type: "application/pdf",
+              id: "<newsletter@example>",
+              disposition: "attachment",
+              dispositionParameters: { filename: "Newsletter.pdf" },
+              size: 1234,
+            },
+          ],
+        },
+      }),
+    };
+    const r = await imapListAttachments(MID, { config: cfg, connect: async () => client });
+    expect(r.attachments?.map((a) => a.name)).toEqual(["Newsletter.pdf"]);
   });
 
   it("fetches an attachment's bytes by filename", async () => {

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -91,6 +91,13 @@ export interface ImapBodyStructure {
   parameters?: Record<string, string>;
   size?: number;
   encoding?: string;
+  /**
+   * Content-ID header, when the part has one. This is what distinguishes an
+   * image the HTML body embeds (`<img src="cid:...">`) from a file the sender
+   * attached — see `collectAttachments`. imapflow has always populated it; it
+   * simply was not declared here.
+   */
+  id?: string;
   childNodes?: ImapBodyStructure[];
 }
 interface ImapMessage {
@@ -581,7 +588,12 @@ function structuredRow(m: ImapMessage, account: string, path: string): Record<st
     flagColorIndex: mailFlagColorIndex(m.flags),
     mailbox: path,
     account,
-    hasAttachments: false,
+    // Derived from BODYSTRUCTURE, which the list/search fetch now requests.
+    // This was hardcoded `false` from 2.2.0 until 2.11.1 — indistinguishable to
+    // a caller from "no attachments", so every IMAP-sourced message claimed to
+    // have none. Falls back to false only when the fetch carried no
+    // BODYSTRUCTURE at all.
+    hasAttachments: bodyStructureHasAttachments(m.bodyStructure),
     // Message-ID (when the envelope carries it) is the strongest cross-/intra-
     // backend dedup key for the multi-account merge (imapMultiAccount.ts). The
     // AppleScript path does not expose it, so cross-backend dedup falls back to
@@ -636,7 +648,10 @@ async function run(
         const byUid = new Map<number, ImapMessage>();
         for await (const msg of client.fetch(
           newest.join(","),
-          { envelope: true, flags: true },
+          // BODYSTRUCTURE rides along so `hasAttachments` is computed rather
+          // than assumed. Measured on 50 real messages: ~390ms -> ~465ms for
+          // the fetch (~17%), same single round trip, no extra request.
+          { envelope: true, flags: true, bodyStructure: true },
           { uid: true }
         )) {
           byUid.set(msg.uid, msg);
@@ -1461,13 +1476,36 @@ export interface ImapAttachmentInfo {
   size: number;
 }
 
-/** Walk a BODYSTRUCTURE tree collecting attachment parts (disposition or filename). */
+/**
+ * Walk a BODYSTRUCTURE tree collecting attachment parts.
+ *
+ * ## `inline` does not mean "not an attachment"
+ *
+ * RFC 2183 `inline` means "display this in place if you can" — it says nothing
+ * about whether the part is a file the user attached. **Apple Mail sends
+ * genuine attachments as `inline`**, because it inlines them into the message
+ * flow rather than appending them. Excluding every inline part therefore hid
+ * every attachment sent from Mail.app, and because `fetch-attachment` and
+ * `save-attachment` resolve by name against this same walk, those files were
+ * not merely unlisted — they were unfetchable.
+ *
+ * Measured over 300 real messages: of 27 parts carrying a filename, 4 were
+ * excluded by the old rule. Three were invoice PDFs (inline, no Content-ID) and
+ * one was a signature logo (inline, `image/png`, **with** a Content-ID).
+ *
+ * So the discriminator is the **Content-ID**, not the disposition: a part the
+ * HTML body references as `cid:` is embedded content, and anything else with a
+ * filename is a file. An explicit `attachment` disposition always wins — real
+ * mail carries `attachment` parts that also have a Content-ID, and letting the
+ * Content-ID veto those would trade one silent omission for another.
+ */
 function collectAttachments(node: ImapBodyStructure, out: AttachmentPart[] = []): AttachmentPart[] {
   if (!node) return out;
   const filename = node.dispositionParameters?.filename || node.parameters?.name;
   const disposition = node.disposition?.toLowerCase();
+  const isEmbeddedByReference = disposition === "inline" && !!node.id;
   const isAttachment =
-    !!node.part && (disposition === "attachment" || (!!filename && disposition !== "inline"));
+    !!node.part && (disposition === "attachment" || (!!filename && !isEmbeddedByReference));
   if (isAttachment) {
     out.push({
       part: node.part as string,
@@ -1478,6 +1516,17 @@ function collectAttachments(node: ImapBodyStructure, out: AttachmentPart[] = [])
   }
   for (const child of node.childNodes ?? []) collectAttachments(child, out);
   return out;
+}
+
+/**
+ * Does this message carry at least one attachment part?
+ *
+ * Shares `collectAttachments`' walk deliberately: if the two ever disagreed,
+ * `hasAttachments` would promise a file that `list-attachments` then refuses to
+ * show (or vice versa), which is the shape of bug this pair already had once.
+ */
+export function bodyStructureHasAttachments(node?: ImapBodyStructure): boolean {
+  return !!node && collectAttachments(node).length > 0;
 }
 
 async function streamToBuffer(
@@ -1742,7 +1791,10 @@ export async function imapThread(
         const msgs: ImapMessage[] = [];
         for await (const msg of client.fetch(
           uids.join(","),
-          { envelope: true, flags: true },
+          // Same reason as the list/search fetch: get-thread emits structured
+          // rows too, so it needs BODYSTRUCTURE or its hasAttachments would
+          // silently disagree with the same message seen via search.
+          { envelope: true, flags: true, bodyStructure: true },
           { uid: true }
         )) {
           msgs.push(msg);

--- a/src/utils/applescript.test.ts
+++ b/src/utils/applescript.test.ts
@@ -7,7 +7,11 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { execSync } from "child_process";
-import { executeAppleScript } from "./applescript.js";
+import {
+  executeAppleScript,
+  isPermissionDenied,
+  PERMISSION_DENIED_MESSAGE,
+} from "./applescript.js";
 
 // Mock the child_process module
 vi.mock("child_process", () => ({
@@ -507,5 +511,35 @@ describe("executeAppleScript", () => {
       expect(result.success).toBe(true);
       expect(mockExecSync).toHaveBeenCalledTimes(4);
     });
+  });
+});
+
+describe("permission-denied classification", () => {
+  // The bug this pins: ERROR_MAPPINGS REPLACES the raw AppleScript text with a
+  // friendly message, and healthCheck then re-tested for the raw substrings the
+  // mapping had just deleted. `isPermError` was therefore never true for a real
+  // TCC denial — `doctor` reported `permissions: ok` while its own detail line
+  // read "Permission denied", and the early `healthy: false` return never ran.
+  it("classifies the RAW AppleScript refusals", () => {
+    expect(isPermissionDenied("Not authorized to send Apple events to Mail. (-1743)")).toBe(true);
+    expect(isPermissionDenied("osascript is not permitted to send keystrokes")).toBe(true);
+    expect(isPermissionDenied("access for assistive devices is denied")).toBe(true);
+  });
+
+  it("classifies the NORMALISED message the mapping produces", () => {
+    // This is what a caller actually receives, and it contains none of the raw
+    // substrings — which is exactly why the old string test could never match.
+    expect(PERMISSION_DENIED_MESSAGE).not.toMatch(/not authorized|not permitted/i);
+    expect(isPermissionDenied(PERMISSION_DENIED_MESSAGE)).toBe(true);
+    expect(isPermissionDenied(`Permission check returned: ${PERMISSION_DENIED_MESSAGE}`)).toBe(
+      true
+    );
+  });
+
+  it("does not fire on unrelated errors", () => {
+    expect(isPermissionDenied(undefined)).toBe(false);
+    expect(isPermissionDenied("")).toBe(false);
+    expect(isPermissionDenied("Mail.app is not responding.")).toBe(false);
+    expect(isPermissionDenied("Message not found")).toBe(false);
   });
 });

--- a/src/utils/applescript.ts
+++ b/src/utils/applescript.ts
@@ -202,12 +202,39 @@ function sleep(ms: number): void {
  * User-friendly error messages mapped from common AppleScript errors.
  * Each entry maps a pattern (regex or string) to a user-friendly message.
  */
+/**
+ * What a raw AppleScript TCC refusal looks like before normalisation.
+ *
+ * Exported with the message below because the two MUST stay derived from one
+ * source. They did not: `healthCheck` classified a denial by re-testing for
+ * "not authorized"/"not permitted" — substrings this mapping had already
+ * REPLACED — so `isPermError` was unreachable, a genuine denial reported
+ * `passed: true`, and the early `healthy: false` return never fired. The check
+ * shared a NAME with the real thing but not a code path.
+ */
+export const PERMISSION_DENIED_PATTERN = /not authorized|not permitted|access.*denied/i;
+
+/** The normalised text a permission failure is reported to callers as. */
+export const PERMISSION_DENIED_MESSAGE =
+  "Permission denied. Grant automation access in System Settings > Privacy & Security > Automation.";
+
+/**
+ * Is this error a TCC/Automation refusal?
+ *
+ * Accepts BOTH forms deliberately — the raw text AppleScript emits and the
+ * normalised text callers actually receive — so a caller cannot be caught out
+ * by which side of `mapError` it happens to be reading.
+ */
+export function isPermissionDenied(error?: string | null): boolean {
+  if (!error) return false;
+  return PERMISSION_DENIED_PATTERN.test(error) || error.includes(PERMISSION_DENIED_MESSAGE);
+}
+
 const ERROR_MAPPINGS: Array<{ pattern: RegExp; message: string }> = [
   // Permission errors
   {
-    pattern: /not authorized|not permitted|access.*denied/i,
-    message:
-      "Permission denied. Grant automation access in System Settings > Privacy & Security > Automation.",
+    pattern: PERMISSION_DENIED_PATTERN,
+    message: PERMISSION_DENIED_MESSAGE,
   },
   // Application not running
   {


### PR DESCRIPTION
Found by running an end-to-end regression against **real mail**, not by reading code. All three are long-standing (2.2.0 / the I1 optimization) — none introduced by 2.11.0. They had simply never been exercised against a message that could expose them.

## 1. Attachments sent from Apple Mail were invisible over IMAP — and unfetchable

`collectAttachments` treated `Content-Disposition: inline` as "not an attachment":

```ts
const isAttachment =
  !!node.part && (disposition === "attachment" || (!!filename && disposition !== "inline"));
```

**Mail.app sends genuine file attachments as `inline`** — it inlines them into the message flow rather than appending them. And because `fetch-attachment` / `save-attachment` resolve by filename against this same walk, those files were not merely unlisted: **they could not be retrieved at all.**

How it surfaced: `list-attachments` returned "No attachments found" for a message whose body reads *"Attached is our invoice for July 2026."* Gmail's `filename:pdf` operator matched the same message, which settled it independently.

The real BODYSTRUCTURE:

```json
{ "part": "2.2", "type": "application/pdf",
  "disposition": "inline",
  "dispositionParameters": { "filename": "SEI Invoice #SEI0096 for July 2026.pdf" },
  "size": 66714 }
```

**The rule is derived from real mail, not from the RFC.** Surveying 300 messages: 27 parts carried a filename and 4 were being excluded —

| type | Content-ID | verdict |
|---|---|---|
| `application/pdf` × 3 | no | genuine attachments, **were being hidden** |
| `image/png` (`image001.png`) | **yes** | signature logo, correctly excluded |

So the discriminator is the **Content-ID**, not the disposition: a part the HTML references as `cid:` is embedded content; anything else with a filename is a file. An explicit `attachment` disposition still always wins — real mail carries `attachment` parts that *also* have a Content-ID (2 in the sample), and letting Content-ID veto those would trade one silent omission for another.

## 2. `hasAttachments` was hardcoded `false` on every IMAP message

`imapClient.ts:584`, since 2.2.0 — in a function whose own docstring says it mirrors the AppleScript path "so the search/list/thread tools emit the same structured payload regardless of backend."

`false` is indistinguishable from "no attachments", so an agent deciding whether to call `list-attachments` would skip every IMAP-sourced message forever.

Now derived from BODYSTRUCTURE, which the list/search/thread fetch requests alongside the envelope. **Cost measured rather than guessed**: 50 real messages, ~390ms → ~465ms (~17%), same single round trip, no extra request. `bodyStructureHasAttachments` shares `collectAttachments`' walk deliberately — if they diverged, `hasAttachments` would promise a file `list-attachments` then refuses to show.

## 3. `doctor` / `health-check` reported `permissions: ok` on a real TCC denial

`mapError` normalises an Automation refusal to *"Permission denied. Grant automation access…"*, **replacing** the raw text. `healthCheck` then classified the failure by re-testing for `"not authorized"` / `"not permitted"` — the exact substrings the normalisation had just removed.

So `isPermError` was unreachable for a real denial:

- `passed: true`, beside a detail line reading *"Permission check returned: Permission denied."*
- the early `healthy: false` return never fired
- execution fell through to the accounts probe, which reported *"No Mail accounts found. Set up an account in Mail.app first"* — sending the user to configure accounts they already have, when the actual problem was one Automation grant

Observed live:

```
"name": "Mail.app: permissions", "status": "ok",
"detail": "Permission check returned: Permission denied. Grant automation access…"
```

Root-cause fix: normalisation and classification now derive from **one exported pattern** (`PERMISSION_DENIED_PATTERN` / `PERMISSION_DENIED_MESSAGE` / `isPermissionDenied`), and the classifier accepts both the raw and the normalised form, so a caller cannot be caught out by which side of `mapError` it reads. `mail_app`'s hint used the same broken test and is fixed with it.

## Verification

**All 8 new guards shown failing against pre-fix source first**, per the project rule.

Then re-verified against real mail with the built bundle:

```
list-attachments  -> Found 1 attachment(s): SEI Invoice #SEI0096 for July 2026.pdf (application/pdf, 65 KB)
fetch-attachment  -> 48752 bytes, base64 begins JVBERi0xLjMK   (= "%PDF-1.3")
search            -> hasAttachments now True/False per message (previously False for all 8)
doctor            -> permissions status=fail, "AppleScript permissions denied. Grant access in…"
```

The `fetch` one matters most: it decodes to a real PDF header, so the file is genuinely retrievable now rather than merely listed.

`lint` / `typecheck` / `format:check` clean; **641 tests pass**; committed `build/index.js` rebuilt and verified in sync.

## Note on the health-check guard

It mocks the transport to deny the *property read* while letting the `return "ok"` probe succeed — which is what a real TCC-denied host actually does, verified live. That asymmetry is the whole reason the misclassification mattered instead of being masked by the earlier `mail_app` return.