### PR TITLE
fix: reply/forward left a live compose window instead of saving a draft (2.11.2)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.11.1",
+      "version": "2.11.2",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.11.1",
+      "version": "2.11.2",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.11.1",
+      "version": "2.11.2",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 ## [Unreleased]
 
+## [2.11.2] - 2026-08-16
+
+Three defects in `reply-to-message` / `forward-message`, found by exercising the
+full tool surface against real mail. The first is a safety fix.
+
+### Fixed
+
+- **`send: false` did not save a draft — it left a live compose window.** The
+  generated AppleScript created the outgoing message and set its content, then
+  stopped: there was no `save`. Mail.app was left holding an unsaved compose
+  window — pre-addressed, pre-filled and one click from sending — while the tool
+  reported `ok: true` and the docs promised "save as draft". During the
+  regression run that window was addressed to a **third party**. `send: false`
+  is the review-before-sending option, so a live compose window is the one
+  outcome it must never produce. Both paths now `save`.
+
+- **`imap:` ids silently never matched.** The id schema accepts them and every
+  read tool returns them when IMAP is configured, but `findMessageScript`
+  interpolates `Number(id)`, so an `imap:` id became `whose id is NaN` and
+  matched nothing — surfacing as an unexplained "not found". Reply and forward
+  now resolve an `imap:` id to its numeric Mail.app id first, via the same RFC
+  Message-ID lookup `resolve-message-id` uses.
+
+- **Failures reported a bare message that hid the reason.** Mail's own error was
+  logged to stderr and replaced with `Failed to reply to message "<id>"`, so a
+  caller could not tell an ambiguous id (which names its candidate mailboxes and
+  says to re-list) from a missing one from a transport error. Both tools now
+  return Mail's text. This mattered most for ids present in several mailboxes —
+  the normal case on a Gmail store, where a message is in INBOX and All Mail at
+  once.
+
+### Changed
+
+- `replyToMessage` / `forwardMessage` return `{ success, error? }` instead of a
+  bare `boolean`, so the reason survives to the tool layer.
+
+
 ## [2.11.1] - 2026-08-16
 
 Three defects found by an end-to-end regression sweep against real mail. All

--- a/build/index.js
+++ b/build/index.js
@@ -80955,20 +80955,15 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
   replyToMessage(id, body, replyAll = false, send = true) {
     const safeBody = escapeForAppleScriptBody(body);
     const replyAllClause = replyAll ? " with reply to all" : "";
-    const sendAction = send ? "send theReply" : "";
+    const finalAction = send ? "send theReply" : "save theReply";
     const script = this.findMessageScript(
       id,
       `
           set theReply to reply msg without opening window${replyAllClause}
           set content of theReply to "${safeBody}"
-          ${sendAction}`
+          ${finalAction}`
     );
-    const result = executeAppleScript(script, { timeoutMs: 6e4 });
-    if (!result.success || result.output.startsWith("error:")) {
-      console.error(`Failed to reply to message: ${result.error || result.output}`);
-      return false;
-    }
-    return true;
+    return this.runComposeScript(script, "reply to");
   }
   /**
    * Forward a message.
@@ -80981,7 +80976,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
    */
   forwardMessage(id, to, body, send = true) {
     const safeBody = body ? escapeForAppleScriptBody(body) : "";
-    const sendAction = send ? "send theForward" : "";
+    const finalAction = send ? "send theForward" : "save theForward";
     let recipientCommands = "";
     for (const addr of to) {
       recipientCommands += `make new to recipient at end of to recipients of theForward with properties {address:"${escapeForAppleScript(addr)}"}
@@ -80993,14 +80988,9 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           set theForward to forward msg without opening window
           ${recipientCommands}
           ${safeBody ? `set content of theForward to "${safeBody}"` : ""}
-          ${sendAction}`
+          ${finalAction}`
     );
-    const result = executeAppleScript(script, { timeoutMs: 6e4 });
-    if (!result.success || result.output.startsWith("error:")) {
-      console.error(`Failed to forward message: ${result.error || result.output}`);
-      return false;
-    }
-    return true;
+    return this.runComposeScript(script, "forward");
   }
   /**
    * Helper to find and operate on a message by ID, scoped to the mailbox the id
@@ -81025,6 +81015,25 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
    * it immediately, so this is also where the previous operation's forensic
    * report is invalidated — see `beginMutation()`.
    */
+  /**
+   * Run a reply/forward compose script and surface Mail's OWN error text.
+   *
+   * These used to return a bare boolean and log the reason to stderr, so the
+   * tool layer could only say "Failed to reply to message X". That hid the two
+   * failures a caller can actually act on — an id present in several mailboxes
+   * (which names the candidates and tells you to re-list) and a missing id —
+   * behind one indistinguishable message.
+   */
+  runComposeScript(script, verb) {
+    const result = executeAppleScript(script, { timeoutMs: 6e4 });
+    if (!result.success || result.output.startsWith("error:")) {
+      const raw = result.error || result.output;
+      const error2 = raw.startsWith("error:") ? raw.slice("error:".length) : raw;
+      console.error(`Failed to ${verb} message: ${error2}`);
+      return { success: false, error: error2 };
+    }
+    return { success: true };
+  }
   findMessageScript(id, operation, instrument = false) {
     this.beginMutation();
     const loc = this.locationFor(id);
@@ -85940,6 +85949,23 @@ function resolveSmtpOrFallback() {
     return null;
   }
 }
+async function toNumericMailId(id) {
+  const ref = decodeImapId(id);
+  if (!ref) return { numericId: id };
+  const messageId = await imapFetchMessageId(id);
+  if (!messageId) {
+    return {
+      error: `could not read the RFC Message-ID for "${id}" over IMAP, which is what maps it to a Mail.app id. Pass the numeric id instead (see the resolve-message-id tool).`
+    };
+  }
+  const numericId = mailManager.findNumericIdByMessageId(messageId, ref.account);
+  if (!numericId) {
+    return {
+      error: `Mail.app has no message with Message-ID <${messageId}> in account "${ref.account}", so this IMAP message has no numeric id to reply to or forward. It may not have synced to Mail.app yet.`
+    };
+  }
+  return { numericId };
+}
 async function sendReplyViaSmtp(id, body, replyAll) {
   const cfg = resolveSmtpOrFallback();
   if (!cfg) return { sent: false, fallback: true };
@@ -85998,17 +86024,23 @@ registerTool(
   },
   withErrorHandling(async ({ id, body, replyAll, send }) => {
     if (send && isSmtpConfigured()) {
-      const outcome = await sendReplyViaSmtp(id, body, replyAll);
-      if (outcome.sent) {
+      const outcome2 = await sendReplyViaSmtp(id, body, replyAll);
+      if (outcome2.sent) {
         return successResponse("Reply sent", { ok: true, sent: true, id });
       }
-      if (!outcome.fallback) {
-        return errorResponse(`Failed to reply to message "${id}" via SMTP: ${outcome.error}`);
+      if (!outcome2.fallback) {
+        return errorResponse(`Failed to reply to message "${id}" via SMTP: ${outcome2.error}`);
       }
     }
-    const success = mailManager.replyToMessage(id, body, replyAll, send);
-    if (!success) {
-      return errorResponse(`Failed to reply to message "${id}"`);
+    const resolvedReply = await toNumericMailId(id);
+    if (!resolvedReply.numericId) {
+      return errorResponse(`Failed to reply to message "${id}": ${resolvedReply.error}`);
+    }
+    const outcome = mailManager.replyToMessage(resolvedReply.numericId, body, replyAll, send);
+    if (!outcome.success) {
+      return errorResponse(
+        outcome.error ? `Failed to reply to message "${id}": ${outcome.error}` : `Failed to reply to message "${id}"`
+      );
     }
     return successResponse(send ? "Reply sent" : "Reply saved as draft", {
       ok: true,
@@ -86036,8 +86068,8 @@ registerTool(
   },
   withErrorHandling(async ({ id, to, body, send }) => {
     if (send && isSmtpConfigured()) {
-      const outcome = await sendForwardViaSmtp(id, to, body);
-      if (outcome.sent) {
+      const outcome2 = await sendForwardViaSmtp(id, to, body);
+      if (outcome2.sent) {
         return successResponse(`Message forwarded to ${to.join(", ")}`, {
           ok: true,
           sent: true,
@@ -86045,13 +86077,19 @@ registerTool(
           id
         });
       }
-      if (!outcome.fallback) {
-        return errorResponse(`Failed to forward message "${id}" via SMTP: ${outcome.error}`);
+      if (!outcome2.fallback) {
+        return errorResponse(`Failed to forward message "${id}" via SMTP: ${outcome2.error}`);
       }
     }
-    const success = mailManager.forwardMessage(id, to, body, send);
-    if (!success) {
-      return errorResponse(`Failed to forward message "${id}"`);
+    const resolvedFwd = await toNumericMailId(id);
+    if (!resolvedFwd.numericId) {
+      return errorResponse(`Failed to forward message "${id}": ${resolvedFwd.error}`);
+    }
+    const outcome = mailManager.forwardMessage(resolvedFwd.numericId, to, body, send);
+    if (!outcome.success) {
+      return errorResponse(
+        outcome.error ? `Failed to forward message "${id}": ${outcome.error}` : `Failed to forward message "${id}"`
+      );
     }
     return successResponse(
       send ? `Message forwarded to ${to.join(", ")}` : "Forward saved as draft",

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.11.1"
+        "apple-mail-mcp@2.11.2"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1157,6 +1157,40 @@ function resolveSmtpOrFallback(): SmtpConfig | null {
 }
 
 /** Reply to a message over direct SMTP with RFC 5322 threading headers. */
+/**
+ * Reply and forward drive Mail.app's `reply`/`forward` verbs, which take a
+ * NUMERIC Mail.app id — `findMessageScript` interpolates `Number(id)`, so an
+ * `imap:` id became `whose id is NaN` and simply never matched.
+ *
+ * The id schema accepts both forms, so callers reasonably passed `imap:` ids
+ * (every read tool returns them when IMAP is configured) and got an
+ * unexplained "not found". Rather than reject, resolve: the same RFC
+ * Message-ID lookup `resolve-message-id` uses, done for the caller.
+ */
+async function toNumericMailId(id: string): Promise<{ numericId?: string; error?: string }> {
+  const ref = decodeImapId(id);
+  if (!ref) return { numericId: id }; // already numeric
+
+  const messageId = await imapFetchMessageId(id);
+  if (!messageId) {
+    return {
+      error:
+        `could not read the RFC Message-ID for "${id}" over IMAP, which is what maps it to a ` +
+        `Mail.app id. Pass the numeric id instead (see the resolve-message-id tool).`,
+    };
+  }
+  const numericId = mailManager.findNumericIdByMessageId(messageId, ref.account);
+  if (!numericId) {
+    return {
+      error:
+        `Mail.app has no message with Message-ID <${messageId}> in account "${ref.account}", so ` +
+        `this IMAP message has no numeric id to reply to or forward. It may not have synced to ` +
+        `Mail.app yet.`,
+    };
+  }
+  return { numericId };
+}
+
 async function sendReplyViaSmtp(
   id: string,
   body: string,
@@ -1253,10 +1287,20 @@ registerTool(
       }
     }
 
-    const success = mailManager.replyToMessage(id, body, replyAll, send);
+    const resolvedReply = await toNumericMailId(id);
+    if (!resolvedReply.numericId) {
+      return errorResponse(`Failed to reply to message "${id}": ${resolvedReply.error}`);
+    }
+    const outcome = mailManager.replyToMessage(resolvedReply.numericId, body, replyAll, send);
 
-    if (!success) {
-      return errorResponse(`Failed to reply to message "${id}"`);
+    if (!outcome.success) {
+      // Surface Mail's own reason. An ambiguous id names its candidate
+      // mailboxes and tells the caller to re-list; a bare failure did not.
+      return errorResponse(
+        outcome.error
+          ? `Failed to reply to message "${id}": ${outcome.error}`
+          : `Failed to reply to message "${id}"`
+      );
     }
 
     return successResponse(send ? "Reply sent" : "Reply saved as draft", {
@@ -1308,10 +1352,18 @@ registerTool(
       }
     }
 
-    const success = mailManager.forwardMessage(id, to, body, send);
+    const resolvedFwd = await toNumericMailId(id);
+    if (!resolvedFwd.numericId) {
+      return errorResponse(`Failed to forward message "${id}": ${resolvedFwd.error}`);
+    }
+    const outcome = mailManager.forwardMessage(resolvedFwd.numericId, to, body, send);
 
-    if (!success) {
-      return errorResponse(`Failed to forward message "${id}"`);
+    if (!outcome.success) {
+      return errorResponse(
+        outcome.error
+          ? `Failed to forward message "${id}": ${outcome.error}`
+          : `Failed to forward message "${id}"`
+      );
     }
 
     return successResponse(

--- a/src/services/appleMailManager.messageIdentity.test.ts
+++ b/src/services/appleMailManager.messageIdentity.test.ts
@@ -41,7 +41,7 @@ describe("by-id message identity", () => {
     h.output = "ok";
     mgr.noteMessageLocation("42", "work@example.com", "INBOX");
 
-    expect(mgr.replyToMessage("42", "Reply body", false, false)).toBe(true);
+    expect(mgr.replyToMessage("42", "Reply body", false, false)).toMatchObject({ success: true });
     let script = lastScript();
     expect(script).toContain('if (name of _a) is "work@example.com"');
     expect(script).toContain('if (name of _m) is "INBOX"');
@@ -50,7 +50,9 @@ describe("by-id message identity", () => {
     expect(script).not.toContain("messages of mb whose id is 42");
 
     h.calls.length = 0;
-    expect(mgr.forwardMessage("42", ["recipient@example.com"], undefined, false)).toBe(true);
+    expect(mgr.forwardMessage("42", ["recipient@example.com"], undefined, false)).toMatchObject({
+      success: true,
+    });
     script = lastScript();
     expect(script).toContain("messages of _tmb whose id is 42");
     expect(script).toContain("forward msg without opening window");
@@ -138,5 +140,74 @@ describe("by-id message identity", () => {
       "error:Message not found\r\nFrom: sender@example.com\r\n\r\nbody"
     );
     expect(mgr.consumeLastMessageLookupError()).toBeUndefined();
+  });
+});
+
+describe("reply/forward draft safety", () => {
+  let mgr: AppleMailManager;
+
+  beforeEach(() => {
+    h.calls.length = 0;
+    h.output = "ok";
+    mgr = new AppleMailManager();
+    mgr.noteMessageLocation("42", "work@example.com", "INBOX");
+  });
+
+  // Found by an end-to-end regression run: `send: false` is documented as
+  // "save as draft", but the generated script only created the outgoing
+  // message and set its content — it never saved. Mail.app was left holding an
+  // unsaved compose window, pre-addressed and pre-filled, one click from
+  // sending, while the tool reported ok. During the run that window was
+  // addressed to a THIRD PARTY, which is why this is a safety fix and not a
+  // tidiness one.
+  it("SAVES the draft when send is false, for replies", () => {
+    mgr.replyToMessage("42", "body", false, false);
+    const script = lastScript();
+    expect(script).toContain("save theReply");
+    expect(script).not.toContain("send theReply");
+  });
+
+  it("SAVES the draft when send is false, for forwards", () => {
+    mgr.forwardMessage("42", ["someone@example.com"], "body", false);
+    const script = lastScript();
+    expect(script).toContain("save theForward");
+    expect(script).not.toContain("send theForward");
+  });
+
+  it("still sends, and does not save, when send is true", () => {
+    mgr.replyToMessage("42", "body", false, true);
+    let script = lastScript();
+    expect(script).toContain("send theReply");
+    expect(script).not.toContain("save theReply");
+
+    h.calls.length = 0;
+    mgr.forwardMessage("42", ["someone@example.com"], "body", true);
+    script = lastScript();
+    expect(script).toContain("send theForward");
+    expect(script).not.toContain("save theForward");
+  });
+
+  // The failure this hid: Mail's real reason ("present in more than one
+  // mailbox…", "Message not found") was logged to stderr and replaced with a
+  // bare "Failed to reply to message X", so a caller could not tell an
+  // ambiguous id from a missing one from a transport error.
+  it("returns Mail's actual error text instead of swallowing it", () => {
+    h.output =
+      "error:This message id is present in more than one mailbox (a/INBOX, a/All Mail); list or search that mailbox first";
+    const r = mgr.replyToMessage("42", "body", false, true);
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("present in more than one mailbox");
+
+    const f = mgr.forwardMessage("42", ["x@example.com"], "body", true);
+    expect(f.success).toBe(false);
+    expect(f.error).toContain("present in more than one mailbox");
+  });
+
+  it("reports success as a structured result", () => {
+    h.output = "ok";
+    expect(mgr.replyToMessage("42", "body", false, false)).toMatchObject({ success: true });
+    expect(mgr.forwardMessage("42", ["x@example.com"], "body", false)).toMatchObject({
+      success: true,
+    });
   });
 });

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -3099,27 +3099,31 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
    * @param send - If true, send immediately; if false, save as draft
    * @returns true if reply created/sent successfully
    */
-  replyToMessage(id: string, body: string, replyAll = false, send = true): boolean {
+  replyToMessage(
+    id: string,
+    body: string,
+    replyAll = false,
+    send = true
+  ): { success: boolean; error?: string } {
     const safeBody = escapeForAppleScriptBody(body);
     const replyAllClause = replyAll ? " with reply to all" : "";
-    const sendAction = send ? "send theReply" : "";
+    // `save` is NOT optional on the draft path. Without it the script creates
+    // the outgoing message, sets its content and abandons it, leaving Mail.app
+    // holding an unsaved compose window — pre-addressed, pre-filled, one click
+    // from sending — while this method reports success. `send: false` is the
+    // REVIEW-FIRST option, so leaving a live compose window is the one outcome
+    // it must never produce.
+    const finalAction = send ? "send theReply" : "save theReply";
 
     const script = this.findMessageScript(
       id,
       `
           set theReply to reply msg without opening window${replyAllClause}
           set content of theReply to "${safeBody}"
-          ${sendAction}`
+          ${finalAction}`
     );
 
-    const result = executeAppleScript(script, { timeoutMs: 60000 });
-
-    if (!result.success || result.output.startsWith("error:")) {
-      console.error(`Failed to reply to message: ${result.error || result.output}`);
-      return false;
-    }
-
-    return true;
+    return this.runComposeScript(script, "reply to");
   }
 
   /**
@@ -3131,9 +3135,16 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
    * @param send - If true, send immediately; if false, save as draft
    * @returns true if forward created/sent successfully
    */
-  forwardMessage(id: string, to: string[], body?: string, send = true): boolean {
+  forwardMessage(
+    id: string,
+    to: string[],
+    body?: string,
+    send = true
+  ): { success: boolean; error?: string } {
     const safeBody = body ? escapeForAppleScriptBody(body) : "";
-    const sendAction = send ? "send theForward" : "";
+    // See replyToMessage: the draft path MUST save, or Mail is left with a live
+    // compose window while this reports success.
+    const finalAction = send ? "send theForward" : "save theForward";
 
     // Build recipient additions
     let recipientCommands = "";
@@ -3147,17 +3158,10 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           set theForward to forward msg without opening window
           ${recipientCommands}
           ${safeBody ? `set content of theForward to "${safeBody}"` : ""}
-          ${sendAction}`
+          ${finalAction}`
     );
 
-    const result = executeAppleScript(script, { timeoutMs: 60000 });
-
-    if (!result.success || result.output.startsWith("error:")) {
-      console.error(`Failed to forward message: ${result.error || result.output}`);
-      return false;
-    }
-
-    return true;
+    return this.runComposeScript(script, "forward");
   }
 
   /**
@@ -3183,6 +3187,26 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
    * it immediately, so this is also where the previous operation's forensic
    * report is invalidated — see `beginMutation()`.
    */
+  /**
+   * Run a reply/forward compose script and surface Mail's OWN error text.
+   *
+   * These used to return a bare boolean and log the reason to stderr, so the
+   * tool layer could only say "Failed to reply to message X". That hid the two
+   * failures a caller can actually act on — an id present in several mailboxes
+   * (which names the candidates and tells you to re-list) and a missing id —
+   * behind one indistinguishable message.
+   */
+  private runComposeScript(script: string, verb: string): { success: boolean; error?: string } {
+    const result = executeAppleScript(script, { timeoutMs: 60000 });
+    if (!result.success || result.output.startsWith("error:")) {
+      const raw = result.error || result.output;
+      const error = raw.startsWith("error:") ? raw.slice("error:".length) : raw;
+      console.error(`Failed to ${verb} message: ${error}`);
+      return { success: false, error };
+    }
+    return { success: true };
+  }
+
   private findMessageScript(id: string, operation: string, instrument = false): string {
     this.beginMutation();
     const loc = this.locationFor(id);


### PR DESCRIPTION
Found by exercising the **full** tool surface against real mail — including the outbound tier that earlier runs had skipped. Three defects in `reply-to-message` / `forward-message`; the first is a safety fix.

## 1. `send: false` never saved a draft — it left a live compose window

```ts
const sendAction = send ? "send theReply" : "";   // <- empty
...
set theReply to reply msg without opening window
set content of theReply to "..."
${sendAction}                                     // <- nothing
```

`grep` confirms it: no `save theReply` or `save theForward` anywhere in the file. The script created the outgoing message, set its content, and abandoned it — leaving Mail.app holding an **unsaved compose window, pre-addressed and pre-filled, one click from sending**, while the tool returned `ok: true` and the description promised "save as draft".

This surfaced the worst possible way: mid-regression the operator reported *"I can see a draft email reply to Vultr support, both the compose window and the email in drafts"* — a live window addressed to a **third party**, which they had to close by hand. My own IMAP check had reported it clean, because the window was local Mail.app state that had never synced.

`send: false` is the *review-before-sending* option. A live compose window is the one outcome it must never produce. Both paths now `save`.

## 2. `imap:` ids silently never matched

The id schema is `^(\d+|imap:[A-Za-z0-9_-]+)$` — it accepts `imap:` ids, and every read tool returns them when IMAP is configured. But `findMessageScript` interpolates `Number(id)`, so an `imap:` id became `whose id is NaN`, matched nothing, and surfaced as an unexplained "not found".

Reply and forward now resolve `imap:` → numeric first, reusing the same RFC Message-ID lookup `resolve-message-id` performs. Rejecting would also have been defensible, but every read tool hands the caller an `imap:` id, so resolving is the behaviour that matches how the surface is actually used.

## 3. Failures reported a bare message that hid the reason

Mail's own error went to `console.error` and the caller got `Failed to reply to message "<id>"`. So an **ambiguous id** — which names its candidate mailboxes and tells you to re-list — was indistinguishable from a missing id or a transport failure.

That case is not exotic. On a Gmail store a message is in INBOX *and* All Mail (often *and* Important), so `get-message` correctly refuses:

```
Message id 79718 is present in more than one mailbox
(rob@…/All Mail, rob@…/Sent Mail, rob@…/INBOX); list or search that mailbox first
```

…while reply/forward, hitting the identical condition, said only "Failed". Both now return Mail's text.

## Caller fix worth calling out

`replyToMessage`/`forwardMessage` now return `{ success, error? }` rather than a bare `boolean`. The two tool-layer callers did `const success = …; if (!success)` — **an object is always truthy**, so leaving them would have silently disabled the error branch entirely, turning every failure into a reported success. `tsc` does not flag `if (!obj)`. Both updated.

## Verification

- **All 4 new guards shown failing against pre-fix source first**, on exactly these defects.
- `lint` / `typecheck` / `format:check` clean; **646 tests pass**; committed bundle rebuilt and in sync.
- The error-surfacing fix is confirmed against real mail — an `imap:` id that previously produced a bare "Failed" now returns a specific, actionable explanation.

**Stated plainly: the draft-saving behaviour is verified at script-generation level only** — the guards assert `save theReply`/`save theForward`, and both appear in the committed bundle — **not yet against a live Mail.app.** Confirming that needs a server restart onto this build, because a headless server has no Automation grant and cannot drive Mail's `reply` verb at all. Worth doing right after merge.