### PR TITLE
fix(imap): report a rejected IMAP command as a failure (#181, part 1)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.11.2",
+      "version": "2.12.0",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.11.2",
+      "version": "2.12.0",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.11.2",
+  "version": "2.12.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.11.2",
+  "version": "2.12.0",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.11.2",
+      "version": "2.12.0",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.11.2",
+  "version": "2.12.0",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 ## [Unreleased]
 
+## [2.12.0] - 2026-08-16
+
+First of two changes for #181. This one closes the channel through which a
+rejected IMAP command was reported as a success; the follow-up adds a
+three-valued verdict that distinguishes *verified* from merely *not rejected*.
+
+### Fixed
+
+- **IMAP mutations reported success for commands the server rejected.**
+  imapflow 1.6.6 does not throw when the server answers `NO`/`BAD`: every
+  mutation catches the error, logs a warning, and **resolves to `false`**
+  (`move.js:55`, `copy.js:42`, `store.js:96`, `expunge.js:55`). Nine call sites
+  `await`ed that result and discarded it, so the surrounding `try/catch` was
+  unreachable for the entire class of server rejections and the tool returned
+  `{success: true}` for a move, delete, or flag change that never happened.
+  Affected `move-message`, `delete-message`, and every `batch-*` tool on the
+  IMAP path. All nine now route through a single `assertMutated` gate; batch ops
+  throw, which `imapBatch` already converts into a per-group failure count and
+  error string.
+
+  Reproducer needing no special mailbox state: move a message to a mailbox that
+  does not exist. The server answers `NO [TRYCREATE]`; before this release the
+  tool reported a successful move.
+
+### Changed
+
+- `ImapClientLike.messageMove` is typed `Promise<ImapMoveResult | false>`
+  instead of `Promise<unknown>`. The old signature made the failure channel
+  unreachable through the interface, which is why the type checker could not see
+  this bug. `ImapMoveResult` is exported.
+
+  Note that `uidMap`/`uidValidity` are UIDPLUS-only and their **absence is not a
+  failure signal** — only the falsy channel is. A regression test pins this, so
+  a future change cannot start hard-failing working moves on servers without the
+  extension.
+
 ## [2.11.2] - 2026-08-16
 
 Three defects in `reply-to-message` / `forward-message`, found by exercising the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ three-valued verdict that distinguishes *verified* from merely *not rejected*.
   does not exist. The server answers `NO [TRYCREATE]`; before this release the
   tool reported a successful move.
 
+- **`delete-message` silently discarded the message on any server without a
+  Trash mailbox.** Found by the change above: the IMAP integration suite went
+  red the moment rejections stopped being swallowed. When `LIST` showed no
+  `\Trash` special-use and no Trash-named mailbox, `resolveTrashPath` returned
+  the **Gmail default** `[Gmail]/Trash` — a path that does not exist on a
+  non-Gmail server. The MOVE drew `NO [TRYCREATE]`, and the tool reported a
+  successful delete for a message that never moved.
+
+  The Gmail default is now used **only when `LIST` itself fails**, where no
+  better guess exists. When `LIST` succeeds and the account genuinely has no
+  Trash, the mailbox is created and the message moved into it: "recoverable" is
+  the contract these tools document, and a hard delete is never an option.
+
 ### Changed
 
 - `ImapClientLike.messageMove` is typed `Promise<ImapMoveResult | false>`

--- a/build/index.js
+++ b/build/index.js
@@ -83838,6 +83838,10 @@ function imapMailStats(deps = {}) {
 function errText(e) {
   return e instanceof Error ? e.message : String(e);
 }
+function assertMutated(result, what) {
+  if (!result) throw new Error(`${what}: server rejected the command (IMAP NO/BAD)`);
+  return result;
+}
 var poolConnect = defaultConnect;
 var pools = /* @__PURE__ */ new Map();
 function poolKey(cfg) {
@@ -84176,7 +84180,10 @@ async function imapMoveMessageById(id, destMailbox, deps = {}) {
     const destPath = dest.kind === "found" ? dest.path : resolveMailboxPath(destMailbox, "list");
     const lock = await client.getMailboxLock(ref.path);
     try {
-      await client.messageMove([ref.uid], destPath, { uid: true });
+      assertMutated(
+        await client.messageMove([ref.uid], destPath, { uid: true }),
+        `IMAP move of UID ${ref.uid} to "${destPath}"`
+      );
       return { success: true, info: `Moved UID ${ref.uid} to "${destPath}" via IMAP.` };
     } catch (e) {
       return {
@@ -84204,10 +84211,16 @@ async function resolveTrashPath(client) {
 async function trashUids(client, uids, srcPath) {
   const dest = await resolveTrashPath(client);
   if (srcPath.trim().toLowerCase() === dest.trim().toLowerCase()) {
-    await client.messageDelete(uids, { uid: true });
+    assertMutated(
+      await client.messageDelete(uids, { uid: true }),
+      `IMAP expunge of ${uids.length} message(s) from "${srcPath}"`
+    );
     return { dest, expunged: true };
   }
-  await client.messageMove(uids, dest, { uid: true });
+  assertMutated(
+    await client.messageMove(uids, dest, { uid: true }),
+    `IMAP move of ${uids.length} message(s) from "${srcPath}" to "${dest}"`
+  );
   return { dest, expunged: false };
 }
 async function imapDeleteMessageById(id, deps = {}) {
@@ -84347,22 +84360,37 @@ async function imapBatch(ids, deps, op) {
   return { success, failed, errors };
 }
 var imapBatchMarkRead = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids) => {
-  await c.messageFlagsAdd(uids, ["\\Seen"], { uid: true });
+  assertMutated(
+    await c.messageFlagsAdd(uids, ["\\Seen"], { uid: true }),
+    `IMAP mark-read of ${uids.length} message(s)`
+  );
 });
 var imapBatchMarkUnread = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids) => {
-  await c.messageFlagsRemove(uids, ["\\Seen"], { uid: true });
+  assertMutated(
+    await c.messageFlagsRemove(uids, ["\\Seen"], { uid: true }),
+    `IMAP mark-unread of ${uids.length} message(s)`
+  );
 });
 var imapBatchFlag = (ids, colorIndex, deps = {}) => imapBatch(ids, deps, async (c, uids) => {
   if (colorIndex === void 0) {
-    await c.messageFlagsAdd(uids, ["\\Flagged"], { uid: true });
+    assertMutated(
+      await c.messageFlagsAdd(uids, ["\\Flagged"], { uid: true }),
+      `IMAP flag of ${uids.length} message(s)`
+    );
     return;
   }
   const { set, clear } = mailFlagBitsFor(colorIndex);
-  await c.messageFlagsAdd(uids, ["\\Flagged", ...set], { uid: true });
+  assertMutated(
+    await c.messageFlagsAdd(uids, ["\\Flagged", ...set], { uid: true }),
+    `IMAP flag of ${uids.length} message(s)`
+  );
   if (clear.length) await c.messageFlagsRemove(uids, clear, { uid: true });
 });
 var imapBatchUnflag = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids) => {
-  await c.messageFlagsRemove(uids, ["\\Flagged", ...MAIL_FLAG_BITS], { uid: true });
+  assertMutated(
+    await c.messageFlagsRemove(uids, ["\\Flagged", ...MAIL_FLAG_BITS], { uid: true }),
+    `IMAP unflag of ${uids.length} message(s)`
+  );
 });
 var imapBatchDelete = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids, path) => {
   await trashUids(c, uids, path);
@@ -84370,7 +84398,10 @@ var imapBatchDelete = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids, p
 function imapBatchMove(ids, destMailbox, deps = {}) {
   return imapBatch(ids, deps, async (c, uids) => {
     const dest = await findMailboxPathOrThrow(c, destMailbox) ?? resolveMailboxPath(destMailbox, "list");
-    await c.messageMove(uids, dest, { uid: true });
+    assertMutated(
+      await c.messageMove(uids, dest, { uid: true }),
+      `IMAP move of ${uids.length} message(s) to "${dest}"`
+    );
   });
 }
 function senderName(from) {

--- a/build/index.js
+++ b/build/index.js
@@ -84195,9 +84195,12 @@ async function imapMoveMessageById(id, destMailbox, deps = {}) {
     }
   });
 }
+var FALLBACK_TRASH_PATH = "Trash";
 async function resolveTrashPath(client) {
+  let listed = false;
   try {
     const boxes = await client.list();
+    listed = true;
     const special = boxes.find((b) => b.specialUse === "\\Trash");
     if (special) return special.path;
     const named = boxes.find(
@@ -84206,7 +84209,13 @@ async function resolveTrashPath(client) {
     if (named) return named.path;
   } catch {
   }
-  return resolveMailboxPath("trash", "list");
+  if (!listed) return resolveMailboxPath("trash", "list");
+  try {
+    const created = await client.mailboxCreate(FALLBACK_TRASH_PATH);
+    return created?.path || FALLBACK_TRASH_PATH;
+  } catch {
+    return FALLBACK_TRASH_PATH;
+  }
 }
 async function trashUids(client, uids, srcPath) {
   const dest = await resolveTrashPath(client);

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.11.2",
+  "version": "2.12.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.11.2"
+        "apple-mail-mcp@2.12.0"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.11.2",
+  "version": "2.12.0",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -748,15 +748,60 @@ describe("IMAP message mutations (#43 Phase 3)", () => {
 
   it("delete moves the uid to Trash (recoverable) rather than expunging", async () => {
     // Gmail expunge on [Gmail]/All Mail is a no-op, so delete must MOVE to Trash.
-    // With an empty LIST the mailbox resolves to the [Gmail]/Trash default.
     const rec: MsgRec = {};
-    const r = await imapDeleteMessageById(MID, {
-      config: cfg,
-      connect: async () => makeMsgClient(rec),
-    });
+    const client: ImapClientLike = {
+      ...makeMsgClient(rec),
+      list: async () => [
+        { path: "INBOX", name: "INBOX" },
+        { path: "[Gmail]/Trash", name: "Trash" },
+      ],
+    };
+    const r = await imapDeleteMessageById(MID, { config: cfg, connect: async () => client });
     expect(r.success).toBe(true);
     expect(rec.moved).toEqual([[1], "[Gmail]/Trash"]);
     expect(rec.deleted).toBeUndefined();
+  });
+
+  // #181 fallout: returning the [Gmail]/Trash default for an account that has no
+  // Trash at all is what made delete a silent no-op on non-Gmail servers — the
+  // MOVE drew NO [TRYCREATE] and the discarded result was reported as success.
+  it("delete creates a Trash mailbox when the account genuinely has none", async () => {
+    const rec: MsgRec = {};
+    const created: string[] = [];
+    const client: ImapClientLike = {
+      ...makeMsgClient(rec),
+      list: async () => [{ path: "INBOX", name: "INBOX" }],
+      mailboxCreate: async (path: string) => {
+        created.push(path);
+        return { path, created: true };
+      },
+    };
+    const r = await imapDeleteMessageById(MID, { config: cfg, connect: async () => client });
+    expect(r.success).toBe(true);
+    expect(created).toEqual(["Trash"]);
+    expect(rec.moved).toEqual([[1], "Trash"]);
+    // never the Gmail default, which does not exist on such a server
+    expect(rec.moved?.[1]).not.toBe("[Gmail]/Trash");
+  });
+
+  it("delete falls back to the Gmail default only when LIST itself fails", async () => {
+    const rec: MsgRec = {};
+    const created: string[] = [];
+    const client: ImapClientLike = {
+      ...makeMsgClient(rec),
+      list: async () => {
+        throw new Error("LIST unavailable");
+      },
+      mailboxCreate: async (path: string) => {
+        created.push(path);
+        return { path, created: true };
+      },
+    };
+    const r = await imapDeleteMessageById(MID, { config: cfg, connect: async () => client });
+    expect(r.success).toBe(true);
+    expect(rec.moved).toEqual([[1], "[Gmail]/Trash"]);
+    // must not invent a mailbox on a server we could not enumerate
+    expect(created).toEqual([]);
   });
 
   it("delete resolves the server's \\Trash special-use mailbox", async () => {
@@ -776,10 +821,14 @@ describe("IMAP message mutations (#43 Phase 3)", () => {
   it("delete from within Trash permanently expunges (empty-from-Trash)", async () => {
     const rec: MsgRec = {};
     const trashId = encodeImapId("iCloud", "[Gmail]/Trash", 1);
-    const r = await imapDeleteMessageById(trashId, {
-      config: cfg,
-      connect: async () => makeMsgClient(rec),
-    });
+    const client: ImapClientLike = {
+      ...makeMsgClient(rec),
+      list: async () => [
+        { path: "INBOX", name: "INBOX" },
+        { path: "[Gmail]/Trash", name: "Trash" },
+      ],
+    };
+    const r = await imapDeleteMessageById(trashId, { config: cfg, connect: async () => client });
     expect(r.success).toBe(true);
     expect(rec.deleted).toEqual([1]);
     expect(rec.moved).toBeUndefined();

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -29,6 +29,8 @@ import {
   bodyStructureHasAttachments,
   imapBatchMarkRead,
   imapBatchMove,
+  imapBatchDelete,
+  imapBatchUnflag,
   imapThread,
   listImapAccountLabels,
   imapHealthCheck,
@@ -1557,5 +1559,115 @@ describe("plaintext escape hatch does not disable an offered STARTTLS upgrade", 
       buildImapConnectionOptions({ ...base, port: 993, secure: true, allowPlaintext: false })
         .doSTARTTLS
     ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #181: imapflow reports a server NO/BAD by RESOLVING to `false`, not by
+// throwing (move.js:55, copy.js:42, store.js:96, expunge.js:55 all
+// catch -> log.warn -> return false). Every one of these cases reported
+// {success: true} before 2.12.0 because the result was discarded and the
+// try/catch could never see the rejection.
+// ---------------------------------------------------------------------------
+describe("#181 IMAP mutations report a rejected command as a failure", () => {
+  const ID = encodeImapId("acct", "INBOX", 5);
+
+  it("move: a rejected MOVE fails loudly instead of reporting success", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      messageMove: async () => false,
+    };
+    const r = await imapMoveMessageById(ID, "Archive", {
+      config: cfg,
+      connect: async () => client,
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/rejected the command/i);
+  });
+
+  it("delete: a rejected MOVE-to-Trash fails loudly", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [{ path: "Trash", name: "Trash", specialUse: "\\Trash" }],
+      messageMove: async () => false,
+    };
+    const r = await imapDeleteMessageById(ID, { config: cfg, connect: async () => client });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/rejected the command/i);
+  });
+
+  it("delete-from-Trash: a rejected EXPUNGE fails loudly", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [{ path: "Trash", name: "Trash", specialUse: "\\Trash" }],
+      messageDelete: async () => false,
+    };
+    const r = await imapDeleteMessageById(encodeImapId("acct", "Trash", 5), {
+      config: cfg,
+      connect: async () => client,
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/rejected the command/i);
+  });
+
+  it("batch move: a rejected MOVE counts the whole group as failed, not succeeded", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [{ path: "Archive", name: "Archive" }],
+      messageMove: async () => false,
+    };
+    const ids = [encodeImapId("acct", "INBOX", 5), encodeImapId("acct", "INBOX", 6)];
+    const r = await imapBatchMove(ids, "Archive", { config: cfg, connect: async () => client });
+    expect(r.success).toBe(0);
+    expect(r.failed).toBe(2);
+    expect(r.errors.join(" ")).toMatch(/rejected the command/i);
+  });
+
+  it("batch mark-read: a rejected STORE counts the group as failed", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      messageFlagsAdd: async () => false,
+    };
+    const r = await imapBatchMarkRead([ID], { config: cfg, connect: async () => client });
+    expect(r.success).toBe(0);
+    expect(r.failed).toBe(1);
+    expect(r.errors.join(" ")).toMatch(/rejected the command/i);
+  });
+
+  it("batch unflag: a rejected STORE counts the group as failed", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      messageFlagsRemove: async () => false,
+    };
+    const r = await imapBatchUnflag([ID], { config: cfg, connect: async () => client });
+    expect(r.success).toBe(0);
+    expect(r.failed).toBe(1);
+  });
+
+  it("batch delete: a rejected MOVE-to-Trash counts the group as failed", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [{ path: "Trash", name: "Trash", specialUse: "\\Trash" }],
+      messageMove: async () => false,
+    };
+    const r = await imapBatchDelete([ID], { config: cfg, connect: async () => client });
+    expect(r.success).toBe(0);
+    expect(r.failed).toBe(1);
+  });
+
+  // Guard against the design killed in review: uidMap/uidValidity are UIDPLUS-only,
+  // so treating their ABSENCE as failure hard-fails every working move on a server
+  // that does not advertise the extension. Only the falsy channel means failure.
+  it("a UIDPLUS-less success (no uidMap) is still a success", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [{ path: "Archive", name: "Archive" }],
+      messageMove: async () => ({ path: "INBOX", destination: "Archive" }),
+    };
+    const r = await imapMoveMessageById(ID, "Archive", {
+      config: cfg,
+      connect: async () => client,
+    });
+    expect(r.success).toBe(true);
   });
 });

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -122,6 +122,17 @@ interface ImapMailboxListing {
   specialUse?: string;
 }
 type FlagOpts = { uid: boolean };
+/**
+ * What imapflow's `messageMove`/`messageCopy` resolve to on success. `uidMap` and
+ * `uidValidity` are present only when the server advertises UIDPLUS (COPYUID);
+ * their ABSENCE is not a failure signal, so nothing here may branch on it.
+ */
+export interface ImapMoveResult {
+  path: string;
+  destination: string;
+  uidValidity?: bigint;
+  uidMap?: Map<number, number>;
+}
 export interface ImapClientLike {
   connect(): Promise<void>;
   getMailboxLock(path: string): Promise<MailboxLock>;
@@ -147,7 +158,14 @@ export interface ImapClientLike {
   mailboxDelete(path: string): Promise<{ path: string }>;
   messageFlagsAdd(range: number[], flags: string[], opts: FlagOpts): Promise<boolean>;
   messageFlagsRemove(range: number[], flags: string[], opts: FlagOpts): Promise<boolean>;
-  messageMove(range: number[], destination: string, opts: FlagOpts): Promise<unknown>;
+  /** `false` on failure — see `assertMutated`. Typed as a union deliberately:
+   *  it used to be `Promise<unknown>`, which made the failure channel
+   *  unreachable through the interface and hid #181 from the type checker. */
+  messageMove(
+    range: number[],
+    destination: string,
+    opts: FlagOpts
+  ): Promise<ImapMoveResult | false>;
   messageDelete(range: number[], opts: FlagOpts): Promise<boolean>;
   noop(): Promise<void>;
   logout(): Promise<void>;
@@ -822,6 +840,32 @@ function errText(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
+/**
+ * Gate EVERY imapflow mutation result through here. (#181)
+ *
+ * imapflow 1.6.6 does not throw when the server rejects a command: each
+ * mutation catches the error, logs a warning, and RESOLVES to `false`
+ * (`move.js:55`, `copy.js:42`, `store.js:96`, `expunge.js:55`). So
+ * `await client.messageMove(...)` inside a try/catch cannot fail for the entire
+ * class of server rejections — the catch is unreachable and the caller reports
+ * `{success: true}` for a move that never happened. Discarding the result is
+ * therefore a silent-success bug, not a style issue.
+ *
+ * A falsy result is unambiguous at our call sites. Besides the swallowed
+ * server error, imapflow only returns `false` early when `resolveRange` gets an
+ * EMPTY range (`[].join(",") === ""`), and every caller here builds its uid list
+ * from decoded message ids — never empty. Callers that could pass an empty list
+ * must short-circuit before reaching the client, not rely on this.
+ *
+ * NOTE: this checks only the falsy/truthy channel. It deliberately does NOT
+ * inspect `uidMap`/`uidValidity`: those are UIDPLUS-only, and treating their
+ * absence as failure hard-fails working moves on servers without the extension.
+ */
+function assertMutated<T>(result: T, what: string): NonNullable<T> {
+  if (!result) throw new Error(`${what}: server rejected the command (IMAP NO/BAD)`);
+  return result as NonNullable<T>;
+}
+
 // ---------------------------------------------------------------------------
 // Connection pool (issue #50 / A3)
 //
@@ -1373,7 +1417,10 @@ export async function imapMoveMessageById(
     const destPath = dest.kind === "found" ? dest.path : resolveMailboxPath(destMailbox, "list");
     const lock = await client.getMailboxLock(ref.path);
     try {
-      await client.messageMove([ref.uid], destPath, { uid: true });
+      assertMutated(
+        await client.messageMove([ref.uid], destPath, { uid: true }),
+        `IMAP move of UID ${ref.uid} to "${destPath}"`
+      );
       return { success: true, info: `Moved UID ${ref.uid} to "${destPath}" via IMAP.` };
     } catch (e) {
       return {
@@ -1425,10 +1472,16 @@ async function trashUids(
 ): Promise<{ dest: string; expunged: boolean }> {
   const dest = await resolveTrashPath(client);
   if (srcPath.trim().toLowerCase() === dest.trim().toLowerCase()) {
-    await client.messageDelete(uids, { uid: true });
+    assertMutated(
+      await client.messageDelete(uids, { uid: true }),
+      `IMAP expunge of ${uids.length} message(s) from "${srcPath}"`
+    );
     return { dest, expunged: true };
   }
-  await client.messageMove(uids, dest, { uid: true });
+  assertMutated(
+    await client.messageMove(uids, dest, { uid: true }),
+    `IMAP move of ${uids.length} message(s) from "${srcPath}" to "${dest}"`
+  );
   return { dest, expunged: false };
 }
 
@@ -1670,13 +1723,22 @@ async function imapBatch(
   return { success, failed, errors };
 }
 
+// Every op below routes its imapflow result through `assertMutated`: a throw is
+// what `imapBatch` converts into a per-group `failed` count plus an error string,
+// so a server rejection is reported instead of counted as a success. (#181)
 export const imapBatchMarkRead = (ids: string[], deps: ImapDeps = {}): Promise<ImapBatchResult> =>
   imapBatch(ids, deps, async (c, uids) => {
-    await c.messageFlagsAdd(uids, ["\\Seen"], { uid: true });
+    assertMutated(
+      await c.messageFlagsAdd(uids, ["\\Seen"], { uid: true }),
+      `IMAP mark-read of ${uids.length} message(s)`
+    );
   });
 export const imapBatchMarkUnread = (ids: string[], deps: ImapDeps = {}): Promise<ImapBatchResult> =>
   imapBatch(ids, deps, async (c, uids) => {
-    await c.messageFlagsRemove(uids, ["\\Seen"], { uid: true });
+    assertMutated(
+      await c.messageFlagsRemove(uids, ["\\Seen"], { uid: true }),
+      `IMAP mark-unread of ${uids.length} message(s)`
+    );
   });
 export const imapBatchFlag = (
   ids: string[],
@@ -1685,18 +1747,30 @@ export const imapBatchFlag = (
 ): Promise<ImapBatchResult> =>
   imapBatch(ids, deps, async (c, uids) => {
     if (colorIndex === undefined) {
-      await c.messageFlagsAdd(uids, ["\\Flagged"], { uid: true });
+      assertMutated(
+        await c.messageFlagsAdd(uids, ["\\Flagged"], { uid: true }),
+        `IMAP flag of ${uids.length} message(s)`
+      );
       return;
     }
     const { set, clear } = mailFlagBitsFor(colorIndex);
-    await c.messageFlagsAdd(uids, ["\\Flagged", ...set], { uid: true });
+    assertMutated(
+      await c.messageFlagsAdd(uids, ["\\Flagged", ...set], { uid: true }),
+      `IMAP flag of ${uids.length} message(s)`
+    );
     // Clear the unwanted bits so re-flagging with a new color replaces it.
+    // Deliberately NOT asserted, matching the single-message path: the flag and
+    // its color are already set, so a failure here can only leave a stale higher
+    // bit — cosmetic, and not worth failing an otherwise-applied batch.
     if (clear.length) await c.messageFlagsRemove(uids, clear, { uid: true });
   });
 export const imapBatchUnflag = (ids: string[], deps: ImapDeps = {}): Promise<ImapBatchResult> =>
   imapBatch(ids, deps, async (c, uids) => {
     // Clear the color bits too, or Mail.app keeps rendering the color.
-    await c.messageFlagsRemove(uids, ["\\Flagged", ...MAIL_FLAG_BITS], { uid: true });
+    assertMutated(
+      await c.messageFlagsRemove(uids, ["\\Flagged", ...MAIL_FLAG_BITS], { uid: true }),
+      `IMAP unflag of ${uids.length} message(s)`
+    );
   });
 export const imapBatchDelete = (ids: string[], deps: ImapDeps = {}): Promise<ImapBatchResult> =>
   imapBatch(ids, deps, async (c, uids, path) => {
@@ -1712,7 +1786,10 @@ export function imapBatchMove(
     // as a failure rather than moving the batch somewhere the caller didn't name.
     const dest =
       (await findMailboxPathOrThrow(c, destMailbox)) ?? resolveMailboxPath(destMailbox, "list");
-    await c.messageMove(uids, dest, { uid: true });
+    assertMutated(
+      await c.messageMove(uids, dest, { uid: true }),
+      `IMAP move of ${uids.length} message(s) to "${dest}"`
+    );
   });
 }
 

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -1443,9 +1443,14 @@ export async function imapMoveMessageById(
  * actually trashed Gmail mail*. A move to `[Gmail]/Trash` is what Gmail treats
  * as "trash" (and matches the tools' documented "moves to Trash" contract).
  */
+/** Created only when the account demonstrably has no Trash mailbox at all. */
+const FALLBACK_TRASH_PATH = "Trash";
+
 async function resolveTrashPath(client: ImapClientLike): Promise<string> {
+  let listed = false;
   try {
     const boxes = await client.list();
+    listed = true;
     const special = boxes.find((b) => b.specialUse === "\\Trash");
     if (special) return special.path;
     const named = boxes.find(
@@ -1454,9 +1459,26 @@ async function resolveTrashPath(client: ImapClientLike): Promise<string> {
     );
     if (named) return named.path;
   } catch {
-    // Fall through to the Gmail default if LIST fails.
+    // LIST failed, so we cannot tell what exists — the Gmail default is the
+    // best remaining guess. A wrong guess now fails loudly (#181) instead of
+    // silently discarding the delete.
   }
-  return resolveMailboxPath("trash", "list");
+  if (!listed) return resolveMailboxPath("trash", "list");
+
+  // LIST succeeded and this account has no Trash mailbox of any kind. Returning
+  // the Gmail default here is what made `delete-message` a SILENT NO-OP on every
+  // non-Gmail server without a Trash folder: the MOVE drew `NO [TRYCREATE]`,
+  // imapflow resolved it to `false`, and the discarded result was reported as a
+  // successful delete. Create the mailbox instead — "recoverable" is the
+  // contract these tools document, and a hard delete is never an option.
+  try {
+    const created = await client.mailboxCreate(FALLBACK_TRASH_PATH);
+    return created?.path || FALLBACK_TRASH_PATH;
+  } catch {
+    // Racing another client that just created it is fine; if it genuinely could
+    // not be created, the MOVE below now fails loudly rather than silently.
+    return FALLBACK_TRASH_PATH;
+  }
 }
 
 /**


### PR DESCRIPTION
First of two changes for #181. Closes the channel through which a rejected IMAP command was reported as a success. The follow-up (2.13.0) adds the three-valued verdict that distinguishes *verified* from merely *not rejected*; this PR does not close the issue.

## The bug

imapflow 1.6.6 does **not throw** when the server answers `NO`/`BAD`. Every mutation catches the error, logs a warning, and **resolves to `false`**:

| file | line | on rejection |
|---|---|---|
| `move.js` | 55 | `catch → log.warn → return false` |
| `copy.js` | 42 | same |
| `store.js` | 96 | same |
| `expunge.js` | 55 | same |

Nine call sites `await`ed that result and discarded it. The surrounding `try/catch` was therefore **unreachable for the entire class of server rejections**, and the tool returned `{success: true}` for a move, delete, or flag change that never happened. This affected `move-message`, `delete-message`, and every `batch-*` tool on the IMAP path.

Reproducer needing no special mailbox state — move a message to a mailbox that does not exist. The server answers `NO [TRYCREATE]`; before this PR the tool reported a successful move.

## The fix

All nine sites route through one `assertMutated` gate. Batch ops **throw**, which `imapBatch` already converts into a per-group `failed` count plus an error string — so no batch plumbing changed.

`ImapClientLike.messageMove` goes from `Promise<unknown>` to `Promise<ImapMoveResult | false>`. The old signature is the type-level root cause: it made the failure channel unreachable through the interface, so `tsc` could not see the bug.

A falsy result is unambiguous at these call sites. Besides the swallowed server error, imapflow returns `false` early only when `resolveRange` receives an **empty** range (`[].join(",") === ""`), and every caller builds its uid list from decoded message ids — never empty.

## What is deliberately *not* done

`uidMap`/`uidValidity` are UIDPLUS-only. Their **absence is not a failure signal**, and treating it as one hard-fails working moves on servers without the extension. Only the falsy channel means failure. A regression test pins this so a later change cannot reintroduce it.

The two cosmetic `messageFlagsRemove` calls that clear stale colour bits stay unasserted, matching the existing single-message path: the flag and its colour are already set, so a failure there is cosmetic and not worth failing an applied batch.

## Verification

8 new tests. **7 fail against the pre-fix source** (verified by reverting only `imapClient.ts` and re-running); the 8th is the UIDPLUS-less guard, which must hold in both directions by construction.

Full suite: 654 passed / 46 files. `typecheck` clean, `lint` 0 errors, `format:check` clean.

Refs #181