### PR TITLE
feat(imap): report whether an accepted mutation's effect was observed (#181, part 2)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 ## [Unreleased]
 
+## [2.13.0] - 2026-08-16
+
+Second and final change for #181, and the one that closes it. 2.12.0 stopped a
+**rejected** command being reported as a success; this makes an **accepted** one
+say whether its effect was actually observed.
+
+### Added
+
+- **`verification` on `delete-message` and `move-message` for `imap:` ids.** The
+  AppleScript destructive path has carried an effect-reconciliation layer
+  (`countDelta`, the collateral snapshot) since #155, built precisely because
+  "the command did not throw" is not evidence that anything happened. The IMAP
+  path had none of it — and since reads route to IMAP whenever an account is
+  IMAP-configured, the layer was off for essentially all real traffic.
+
+  `structuredContent.verification` is three-valued in effect:
+
+  | verdict | meaning |
+  |---|---|
+  | `verified` | the effect was observed — UIDPLUS `COPYUID` named the new UID in the destination, or the UID is gone from the source |
+  | `unverified` | the server accepted the command and nothing could confirm the effect; `why` says what stopped it |
+  | *(failure)* | `success: false` — the server rejected the command outright (2.12.0) |
+
+  `unverified` is **not a failure** and is not rendered as one. Reporting it is
+  the point: an absent verification must never read as a successful one, which
+  is the rule already adopted for the collateral diff in #176/#178.
+
+  A message still present in the source after an accepted move is reported
+  `unverified` rather than failed, deliberately — a Gmail label store can
+  legitimately keep a message in an all-mail view after a move, and hard-failing
+  a working move is the strictly worse error.
+
+  The originally reported case — a Gmail draft whose `move-message` returned
+  `ok: true` while the message stayed in `[Gmail]/Drafts` and the destination
+  stayed empty — now returns `unverified` with the contradiction named.
+
+### Changed
+
+- `routeMessage` merges an operation's `verification` into `structuredContent`,
+  so every IMAP-routed single-message tool reports it uniformly. Tools surfacing
+  it declare `verification` in their `outputSchema`: a bare zod shape implies
+  `additionalProperties: false`, and the client rejects undeclared keys.
+
 ## [2.12.0] - 2026-08-16
 
 First of two changes for #181. This one closes the channel through which a

--- a/README.md
+++ b/README.md
@@ -1430,9 +1430,33 @@ Three more honesty rules:
   than list positions — and `expected` stays comparable with the mailbox instead
   of double-counting a duplicate into a false `over`.
 
-`imap:` ids are not reconciled. An IMAP UID names exactly one message in exactly
-one mailbox, so the mis-targeting class this exists for cannot occur there; a
-batch of only `imap:` ids returns no `countDelta` rather than a fabricated one.
+`imap:` ids are not reconciled by `countDelta`. An IMAP UID names exactly one
+message in exactly one mailbox, so the mis-targeting class this exists for cannot
+occur there; a batch of only `imap:` ids returns no `countDelta` rather than a
+fabricated one.
+
+They carry their own post-condition check instead. `delete-message` and
+`move-message` on an `imap:` id return a **`verification`** object in
+`structuredContent`:
+
+```jsonc
+"verification": {
+  "verdict": "verified",
+  "how": "COPYUID: UID 5 arrived in \"Archive\" as UID 91"
+}
+```
+
+| `verdict` | Meaning |
+|---|---|
+| `verified` | The effect was **observed** — either the server's UIDPLUS `COPYUID` named the message's new UID in the destination, or the UID is no longer in the source mailbox. |
+| `unverified` | The server **accepted** the command and nothing could confirm the effect. Populates `why`. |
+
+`unverified` is **not a failure** and must not be rendered as one — it means
+"accepted, no observation either way". It is reported rather than hidden because
+an absent verification must never read as a successful one, the same rule the
+collateral diff follows. A message that is still in the source mailbox after an
+accepted move is reported `unverified` rather than failed, because a Gmail label
+store can legitimately keep a message visible in an all-mail view after a move.
 
 ### `APPLE_MAIL_MCP_AUDIT_LOG` — opt-in forensic log
 

--- a/README.md
+++ b/README.md
@@ -1439,10 +1439,12 @@ They carry their own post-condition check instead. `delete-message` and
 `move-message` on an `imap:` id return a **`verification`** object in
 `structuredContent`:
 
-```jsonc
-"verification": {
-  "verdict": "verified",
-  "how": "COPYUID: UID 5 arrived in \"Archive\" as UID 91"
+```json
+{
+  "verification": {
+    "verdict": "verified",
+    "how": "COPYUID: UID 5 arrived in \"Archive\" as UID 91"
+  }
 }
 ```
 

--- a/build/index.js
+++ b/build/index.js
@@ -83842,6 +83842,27 @@ function assertMutated(result, what) {
   if (!result) throw new Error(`${what}: server rejected the command (IMAP NO/BAD)`);
   return result;
 }
+async function verifyMoved(client, moved, uid, srcPath, destPath) {
+  const newUid = moved.uidMap?.get(uid);
+  if (newUid !== void 0) {
+    return {
+      verdict: "verified",
+      how: `COPYUID: UID ${uid} arrived in "${destPath}" as UID ${newUid}`
+    };
+  }
+  try {
+    const stillThere = await client.fetchOne(String(uid), { uid: true }, { uid: true });
+    if (!stillThere) {
+      return { verdict: "verified", how: `UID ${uid} is no longer present in "${srcPath}"` };
+    }
+    return {
+      verdict: "unverified",
+      why: `the server accepted the MOVE, but UID ${uid} is still present in "${srcPath}" and this server does not advertise UIDPLUS, so arrival in "${destPath}" could not be confirmed. A Gmail label store can legitimately keep a message in an all-mail view after a move, so this is not reported as a failure`
+    };
+  } catch (e) {
+    return { verdict: "unverified", why: `the post-move check could not run: ${errText(e)}` };
+  }
+}
 var poolConnect = defaultConnect;
 var pools = /* @__PURE__ */ new Map();
 function poolKey(cfg) {
@@ -84180,11 +84201,16 @@ async function imapMoveMessageById(id, destMailbox, deps = {}) {
     const destPath = dest.kind === "found" ? dest.path : resolveMailboxPath(destMailbox, "list");
     const lock = await client.getMailboxLock(ref.path);
     try {
-      assertMutated(
+      const moved = assertMutated(
         await client.messageMove([ref.uid], destPath, { uid: true }),
         `IMAP move of UID ${ref.uid} to "${destPath}"`
       );
-      return { success: true, info: `Moved UID ${ref.uid} to "${destPath}" via IMAP.` };
+      const verification = await verifyMoved(client, moved, ref.uid, ref.path, destPath);
+      return {
+        success: true,
+        info: verification.verdict === "verified" ? `Moved UID ${ref.uid} to "${destPath}" via IMAP (verified: ${verification.how}).` : `Moved UID ${ref.uid} to "${destPath}" via IMAP \u2014 UNVERIFIED: ${verification.why}.`,
+        verification
+      };
     } catch (e) {
       return {
         success: false,
@@ -84226,21 +84252,38 @@ async function trashUids(client, uids, srcPath) {
     );
     return { dest, expunged: true };
   }
-  assertMutated(
+  const moved = assertMutated(
     await client.messageMove(uids, dest, { uid: true }),
     `IMAP move of ${uids.length} message(s) from "${srcPath}" to "${dest}"`
   );
-  return { dest, expunged: false };
+  return { dest, expunged: false, moved };
+}
+async function verifyExpunged(client, uid, path) {
+  try {
+    const stillThere = await client.fetchOne(String(uid), { uid: true }, { uid: true });
+    if (!stillThere) {
+      return { verdict: "verified", how: `UID ${uid} is no longer present in "${path}"` };
+    }
+    return {
+      verdict: "unverified",
+      why: `the server accepted the EXPUNGE but UID ${uid} is still present in "${path}"`
+    };
+  } catch (e) {
+    return { verdict: "unverified", why: `the post-delete check could not run: ${errText(e)}` };
+  }
 }
 async function imapDeleteMessageById(id, deps = {}) {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
   return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
     try {
-      const { dest, expunged } = await trashUids(client, [ref.uid], ref.path);
+      const { dest, expunged, moved } = await trashUids(client, [ref.uid], ref.path);
+      const verification = expunged || !moved ? await verifyExpunged(client, ref.uid, ref.path) : await verifyMoved(client, moved, ref.uid, ref.path, dest);
+      const what = expunged ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP` : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP`;
       return {
         success: true,
-        info: expunged ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP.` : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`
+        info: verification.verdict === "verified" ? `${what} (verified: ${verification.how}).` : `${what} \u2014 UNVERIFIED: ${verification.why}.`,
+        verification
       };
     } catch (e) {
       return { success: false, error: `IMAP delete failed for UID ${ref.uid}: ${errText(e)}` };
@@ -84820,10 +84863,12 @@ function formatMergedRows(rows, showReadState = true) {
 async function routeMessage(id, opts) {
   if (decodeImapId(id)) {
     const r = await opts.imap();
-    return r.success ? successResponse(
+    if (!r.success) return errorResponse(r.error ?? opts.fail);
+    const structured = opts.structuredFromResult ? opts.structuredFromResult(r) : opts.structured;
+    return successResponse(
       r.info ?? opts.ok,
-      opts.structuredFromResult ? opts.structuredFromResult(r) : opts.structured
-    ) : errorResponse(r.error ?? opts.fail);
+      r.verification && structured ? { ...structured, verification: r.verification } : structured
+    );
   }
   return opts.apple();
 }
@@ -85387,6 +85432,13 @@ var COUNT_DELTA_OUTPUT_SCHEMA = external_exports.array(
     note: external_exports.string().optional()
   })
 ).optional();
+var VERIFICATION_OUTPUT_SCHEMA = external_exports.object({
+  verdict: external_exports.enum(["verified", "unverified"]),
+  /** Present on `verified`: what was observed. */
+  how: external_exports.string().optional(),
+  /** Present on `unverified`: why no observation was possible. */
+  why: external_exports.string().optional()
+}).optional();
 var CHECK_ITEM_SCHEMA = external_exports.object({}).passthrough();
 var require2 = createRequire(import.meta.url);
 var { version: version2 } = require2("../package.json");
@@ -86239,7 +86291,8 @@ registerTool(
     outputSchema: {
       ok: external_exports.boolean().optional(),
       id: external_exports.string().optional(),
-      countDelta: COUNT_DELTA_OUTPUT_SCHEMA
+      countDelta: COUNT_DELTA_OUTPUT_SCHEMA,
+      verification: VERIFICATION_OUTPUT_SCHEMA
     }
   },
   withErrorHandling(
@@ -86279,7 +86332,8 @@ registerTool(
       ok: external_exports.boolean().optional(),
       id: external_exports.string().optional(),
       mailbox: external_exports.string().optional(),
-      countDelta: COUNT_DELTA_OUTPUT_SCHEMA
+      countDelta: COUNT_DELTA_OUTPUT_SCHEMA,
+      verification: VERIFICATION_OUTPUT_SCHEMA
     }
   },
   withErrorHandling(

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.12.0"
+        "apple-mail-mcp@2.13.0"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,6 +247,26 @@ const COUNT_DELTA_OUTPUT_SCHEMA = z
   )
   .optional();
 
+/**
+ * Whether a mutation the server ACCEPTED was corroborated by observing its
+ * effect (#181). Distinct from `ok`: `ok` says the command was not rejected,
+ * this says whether anyone checked that it did anything.
+ *
+ * `unverified` is not a failure — it means "accepted, no observation either
+ * way" — and must never be rendered as one. Modelled as a flat object rather
+ * than a discriminated union so the emitted JSON Schema stays simple; exactly
+ * one of `how`/`why` is populated, matching the verdict.
+ */
+const VERIFICATION_OUTPUT_SCHEMA = z
+  .object({
+    verdict: z.enum(["verified", "unverified"]),
+    /** Present on `verified`: what was observed. */
+    how: z.string().optional(),
+    /** Present on `unverified`: why no observation was possible. */
+    why: z.string().optional(),
+  })
+  .optional();
+
 /** A health/doctor check item — loose to accept both health-check
  *  ({name, passed, message}) and doctor ({name, status, detail}) items. */
 const CHECK_ITEM_SCHEMA = z.object({}).passthrough();
@@ -1510,6 +1530,7 @@ registerTool(
       ok: z.boolean().optional(),
       id: z.string().optional(),
       countDelta: COUNT_DELTA_OUTPUT_SCHEMA,
+      verification: VERIFICATION_OUTPUT_SCHEMA,
     },
   },
   withErrorHandling(
@@ -1555,6 +1576,7 @@ registerTool(
       id: z.string().optional(),
       mailbox: z.string().optional(),
       countDelta: COUNT_DELTA_OUTPUT_SCHEMA,
+      verification: VERIFICATION_OUTPUT_SCHEMA,
     },
   },
   withErrorHandling(

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -1720,3 +1720,127 @@ describe("#181 IMAP mutations report a rejected command as a failure", () => {
     expect(r.success).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #181 part 2: an ACCEPTED mutation now reports whether its effect was
+// observed. Before 2.13.0 every one of these returned a bare {success:true},
+// so "confirmed" and "nobody looked" were indistinguishable — the asymmetry
+// with the AppleScript path (countDelta / collateral snapshot) that #181 is
+// about. `unverified` is NOT a failure and must never be rendered as one.
+// ---------------------------------------------------------------------------
+describe("#181 three-valued verification of accepted IMAP mutations", () => {
+  const ID = encodeImapId("acct", "INBOX", 5);
+
+  // The reported case: a Gmail draft whose move returned ok:true while the
+  // message demonstrably stayed in [Gmail]/Drafts and the destination stayed
+  // empty. This is the guard the issue asks for.
+  it("move: accepted but the message is still in the source reads as UNVERIFIED, not success", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [{ path: "Archive", name: "Archive" }],
+      // no uidMap => server does not advertise UIDPLUS
+      messageMove: async () => ({ path: "INBOX", destination: "Archive" }),
+      // the message never left
+      fetchOne: async () => ({ uid: 5 }),
+    };
+    const r = await imapMoveMessageById(ID, "Archive", {
+      config: cfg,
+      connect: async () => client,
+    });
+    expect(r.success).toBe(true); // the server did accept it
+    expect(r.verification?.verdict).toBe("unverified");
+    expect(r.info).toMatch(/UNVERIFIED/);
+    // and it must not be dressed up as a confirmed move
+    expect(r.info).not.toMatch(/\(verified:/);
+  });
+
+  it("move: COPYUID from a UIDPLUS server verifies arrival directly", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [{ path: "Archive", name: "Archive" }],
+      messageMove: async () => ({
+        path: "INBOX",
+        destination: "Archive",
+        uidMap: new Map([[5, 91]]),
+      }),
+      // still present in source; COPYUID must win over the fallback probe
+      fetchOne: async () => ({ uid: 5 }),
+    };
+    const r = await imapMoveMessageById(ID, "Archive", {
+      config: cfg,
+      connect: async () => client,
+    });
+    expect(r.verification).toEqual({
+      verdict: "verified",
+      how: 'COPYUID: UID 5 arrived in "Archive" as UID 91',
+    });
+    expect(r.info).toMatch(/verified/);
+  });
+
+  it("move: without UIDPLUS, the uid leaving the source verifies the move", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [{ path: "Archive", name: "Archive" }],
+      messageMove: async () => ({ path: "INBOX", destination: "Archive" }),
+      fetchOne: async () => false, // gone from the source
+    };
+    const r = await imapMoveMessageById(ID, "Archive", {
+      config: cfg,
+      connect: async () => client,
+    });
+    expect(r.verification?.verdict).toBe("verified");
+    expect(r.verification).toMatchObject({ how: expect.stringMatching(/no longer present/) });
+  });
+
+  it("move: a probe that throws is unverified, never a failure", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [{ path: "Archive", name: "Archive" }],
+      messageMove: async () => ({ path: "INBOX", destination: "Archive" }),
+      fetchOne: async () => {
+        throw new Error("connection reset");
+      },
+    };
+    const r = await imapMoveMessageById(ID, "Archive", {
+      config: cfg,
+      connect: async () => client,
+    });
+    expect(r.success).toBe(true);
+    expect(r.verification?.verdict).toBe("unverified");
+    expect(r.verification).toMatchObject({ why: expect.stringMatching(/connection reset/) });
+  });
+
+  it("delete: the move to Trash is verified the same way", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [
+        { path: "INBOX", name: "INBOX" },
+        { path: "Trash", name: "Trash", specialUse: "\\Trash" },
+      ],
+      messageMove: async () => ({
+        path: "INBOX",
+        destination: "Trash",
+        uidMap: new Map([[5, 12]]),
+      }),
+    };
+    const r = await imapDeleteMessageById(ID, { config: cfg, connect: async () => client });
+    expect(r.success).toBe(true);
+    expect(r.verification?.verdict).toBe("verified");
+  });
+
+  it("delete-from-Trash: an accepted EXPUNGE that left the uid in place is unverified", async () => {
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [{ path: "Trash", name: "Trash", specialUse: "\\Trash" }],
+      messageDelete: async () => true,
+      fetchOne: async () => ({ uid: 5 }), // still there
+    };
+    const r = await imapDeleteMessageById(encodeImapId("acct", "Trash", 5), {
+      config: cfg,
+      connect: async () => client,
+    });
+    expect(r.success).toBe(true);
+    expect(r.verification?.verdict).toBe("unverified");
+    expect(r.verification).toMatchObject({ why: expect.stringMatching(/still present/) });
+  });
+});

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -830,10 +830,29 @@ export function imapMailStats(deps: ImapDeps = {}): Promise<ImapStats> {
 // configured; AppleScript remains the path for everything else.
 // ===========================================================================
 
+/**
+ * Whether the server's acceptance of a mutation was corroborated by observing
+ * the effect. (#181)
+ *
+ * Three-valued on purpose. `success: false` already covers a command the server
+ * REJECTED (#181 part 1). What this adds is the distinction the IMAP path was
+ * missing entirely: a command the server ACCEPTED whose effect was confirmed,
+ * versus one whose effect nobody looked at. Before 2.13.0 both returned a bare
+ * `{success: true}`, so an unverified mutation was indistinguishable from a
+ * verified one — the asymmetry #181 was filed for.
+ *
+ * `unverified` is NOT a failure and must never be rendered as one. It means
+ * exactly "the server accepted this and we have no observation either way".
+ */
+export type ImapVerification =
+  { verdict: "verified"; how: string } | { verdict: "unverified"; why: string };
+
 export interface ImapOpResult {
   success: boolean;
   error?: string;
   info?: string;
+  /** Absent on operations that perform no post-condition check at all. */
+  verification?: ImapVerification;
 }
 
 function errText(e: unknown): string {
@@ -861,9 +880,60 @@ function errText(e: unknown): string {
  * inspect `uidMap`/`uidValidity`: those are UIDPLUS-only, and treating their
  * absence as failure hard-fails working moves on servers without the extension.
  */
-function assertMutated<T>(result: T, what: string): NonNullable<T> {
+function assertMutated<T>(result: T, what: string): Exclude<T, false | null | undefined> {
   if (!result) throw new Error(`${what}: server rejected the command (IMAP NO/BAD)`);
-  return result as NonNullable<T>;
+  return result as Exclude<T, false | null | undefined>;
+}
+
+/**
+ * Corroborate a MOVE the server already accepted. (#181)
+ *
+ * The AppleScript path has a whole effect-reconciliation layer precisely because
+ * "the command did not throw" is not evidence that anything happened; the IMAP
+ * path had none of it, and since reads route to IMAP whenever an account is
+ * IMAP-configured, that meant the layer was off for essentially all real
+ * traffic.
+ *
+ * Deliberately never returns a failure. A contradicted post-condition is
+ * reported as `unverified` with the contradiction named, because a Gmail label
+ * store can legitimately keep a message visible in an all-mail view after a
+ * move — and hard-failing a working move is the strictly worse error. Callers
+ * that need certainty should read `verdict`, not infer it from `success`.
+ */
+async function verifyMoved(
+  client: ImapClientLike,
+  moved: ImapMoveResult,
+  uid: number,
+  srcPath: string,
+  destPath: string
+): Promise<ImapVerification> {
+  // Strongest evidence and it costs nothing: with UIDPLUS the server's own
+  // COPYUID response names the UID the message received in the destination.
+  const newUid = moved.uidMap?.get(uid);
+  if (newUid !== undefined) {
+    return {
+      verdict: "verified",
+      how: `COPYUID: UID ${uid} arrived in "${destPath}" as UID ${newUid}`,
+    };
+  }
+  // No UIDPLUS. The source mailbox is still selected here, so asking whether the
+  // UID is still in it is one FETCH and needs no extra capability.
+  try {
+    const stillThere = await client.fetchOne(String(uid), { uid: true }, { uid: true });
+    if (!stillThere) {
+      return { verdict: "verified", how: `UID ${uid} is no longer present in "${srcPath}"` };
+    }
+    return {
+      verdict: "unverified",
+      why:
+        `the server accepted the MOVE, but UID ${uid} is still present in "${srcPath}" and ` +
+        `this server does not advertise UIDPLUS, so arrival in "${destPath}" could not be ` +
+        `confirmed. A Gmail label store can legitimately keep a message in an all-mail view ` +
+        `after a move, so this is not reported as a failure`,
+    };
+  } catch (e) {
+    return { verdict: "unverified", why: `the post-move check could not run: ${errText(e)}` };
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1417,11 +1487,19 @@ export async function imapMoveMessageById(
     const destPath = dest.kind === "found" ? dest.path : resolveMailboxPath(destMailbox, "list");
     const lock = await client.getMailboxLock(ref.path);
     try {
-      assertMutated(
+      const moved = assertMutated(
         await client.messageMove([ref.uid], destPath, { uid: true }),
         `IMAP move of UID ${ref.uid} to "${destPath}"`
       );
-      return { success: true, info: `Moved UID ${ref.uid} to "${destPath}" via IMAP.` };
+      const verification = await verifyMoved(client, moved, ref.uid, ref.path, destPath);
+      return {
+        success: true,
+        info:
+          verification.verdict === "verified"
+            ? `Moved UID ${ref.uid} to "${destPath}" via IMAP (verified: ${verification.how}).`
+            : `Moved UID ${ref.uid} to "${destPath}" via IMAP — UNVERIFIED: ${verification.why}.`,
+        verification,
+      };
     } catch (e) {
       return {
         success: false,
@@ -1491,7 +1569,7 @@ async function trashUids(
   client: ImapClientLike,
   uids: number[],
   srcPath: string
-): Promise<{ dest: string; expunged: boolean }> {
+): Promise<{ dest: string; expunged: boolean; moved?: ImapMoveResult }> {
   const dest = await resolveTrashPath(client);
   if (srcPath.trim().toLowerCase() === dest.trim().toLowerCase()) {
     assertMutated(
@@ -1500,11 +1578,34 @@ async function trashUids(
     );
     return { dest, expunged: true };
   }
-  assertMutated(
+  const moved = assertMutated(
     await client.messageMove(uids, dest, { uid: true }),
     `IMAP move of ${uids.length} message(s) from "${srcPath}" to "${dest}"`
   );
-  return { dest, expunged: false };
+  return { dest, expunged: false, moved };
+}
+
+/**
+ * Corroborate an EXPUNGE the server already accepted. Same contract as
+ * `verifyMoved`: never a failure, only "confirmed" vs "nobody looked". (#181)
+ */
+async function verifyExpunged(
+  client: ImapClientLike,
+  uid: number,
+  path: string
+): Promise<ImapVerification> {
+  try {
+    const stillThere = await client.fetchOne(String(uid), { uid: true }, { uid: true });
+    if (!stillThere) {
+      return { verdict: "verified", how: `UID ${uid} is no longer present in "${path}"` };
+    }
+    return {
+      verdict: "unverified",
+      why: `the server accepted the EXPUNGE but UID ${uid} is still present in "${path}"`,
+    };
+  } catch (e) {
+    return { verdict: "unverified", why: `the post-delete check could not run: ${errText(e)}` };
+  }
 }
 
 export async function imapDeleteMessageById(
@@ -1515,12 +1616,21 @@ export async function imapDeleteMessageById(
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
   return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
     try {
-      const { dest, expunged } = await trashUids(client, [ref.uid], ref.path);
+      const { dest, expunged, moved } = await trashUids(client, [ref.uid], ref.path);
+      const verification =
+        expunged || !moved
+          ? await verifyExpunged(client, ref.uid, ref.path)
+          : await verifyMoved(client, moved, ref.uid, ref.path, dest);
+      const what = expunged
+        ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP`
+        : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP`;
       return {
         success: true,
-        info: expunged
-          ? `Permanently deleted UID ${ref.uid} from Trash ("${ref.path}") via IMAP.`
-          : `Moved UID ${ref.uid} to Trash ("${dest}") via IMAP.`,
+        info:
+          verification.verdict === "verified"
+            ? `${what} (verified: ${verification.how}).`
+            : `${what} — UNVERIFIED: ${verification.why}.`,
+        verification,
       };
     } catch (e) {
       return { success: false, error: `IMAP delete failed for UID ${ref.uid}: ${errText(e)}` };

--- a/src/services/messageRouter.test.ts
+++ b/src/services/messageRouter.test.ts
@@ -40,6 +40,39 @@ describe("routeMessage", () => {
     expect(res.content[0].text).toBe("boom");
   });
 
+  // #181: the verdict has to reach structuredContent, or a caller can only tell
+  // "confirmed" from "nobody looked" by parsing prose.
+  it("merges an IMAP verification verdict into structuredContent", async () => {
+    const res = await routeMessage(imapId, {
+      imap: async () => ({
+        success: true,
+        info: "moved",
+        verification: { verdict: "unverified" as const, why: "no UIDPLUS" },
+      }),
+      apple: () => ({ content: [{ type: "text", text: "apple" }] }),
+      ok: "ok",
+      fail: "fail",
+      structured: { ok: true, id: imapId, mailbox: "Archive" },
+    });
+    expect(res.structuredContent).toEqual({
+      ok: true,
+      id: imapId,
+      mailbox: "Archive",
+      verification: { verdict: "unverified", why: "no UIDPLUS" },
+    });
+  });
+
+  it("leaves structuredContent alone when the op reports no verification", async () => {
+    const res = await routeMessage(imapId, {
+      imap: async () => ({ success: true, info: "flagged" }),
+      apple: () => ({ content: [{ type: "text", text: "apple" }] }),
+      ok: "ok",
+      fail: "fail",
+      structured: { ok: true, id: imapId },
+    });
+    expect(res.structuredContent).toEqual({ ok: true, id: imapId });
+  });
+
   it("falls through to the AppleScript branch for numeric ids", async () => {
     let imapCalled = false;
     const res = await routeMessage("57820", {

--- a/src/services/messageRouter.ts
+++ b/src/services/messageRouter.ts
@@ -42,12 +42,17 @@ export async function routeMessage(
 ): Promise<ToolResponse> {
   if (decodeImapId(id)) {
     const r = await opts.imap();
-    return r.success
-      ? successResponse(
-          r.info ?? opts.ok,
-          opts.structuredFromResult ? opts.structuredFromResult(r) : opts.structured
-        )
-      : errorResponse(r.error ?? opts.fail);
+    if (!r.success) return errorResponse(r.error ?? opts.fail);
+    const structured = opts.structuredFromResult ? opts.structuredFromResult(r) : opts.structured;
+    // #181: carry the post-condition verdict through to structuredContent so a
+    // caller can tell "confirmed" from "the server accepted it and nobody
+    // looked" without parsing prose. Any tool surfacing this MUST declare
+    // `verification` in its outputSchema — a bare zod raw shape implies
+    // additionalProperties:false, and the client rejects undeclared keys.
+    return successResponse(
+      r.info ?? opts.ok,
+      r.verification && structured ? { ...structured, verification: r.verification } : structured
+    );
   }
   return opts.apple();
 }

--- a/test/imap.integration.test.ts
+++ b/test/imap.integration.test.ts
@@ -153,10 +153,18 @@ run("IMAP backend (GreenMail) integration", () => {
       await imapSearchMessages({ mailbox: "INBOX", subject: "Movable", limit: 1 }, deps)
     ).text;
     const id = firstImapId(search);
-    expect((await imapMoveMessageById(id, "Dest", deps)).success).toBe(true);
+    const moved = await imapMoveMessageById(id, "Dest", deps);
+    expect(moved.success).toBe(true);
+    // #181: a real move against a real server must come back CORROBORATED, not
+    // merely un-rejected. Whether that arrives via UIDPLUS COPYUID or via the
+    // uid leaving the source is the server's business, but "unverified" here
+    // would mean the post-condition check does not actually work end to end.
+    expect(moved.verification?.verdict).toBe("verified");
     const inDest = (await imapListMessages({ mailbox: "Dest", limit: 10 }, deps)).text;
     const destId = firstImapId(inDest);
-    expect((await imapDeleteMessageById(destId, deps)).success).toBe(true);
+    const deleted = await imapDeleteMessageById(destId, deps);
+    expect(deleted.success).toBe(true);
+    expect(deleted.verification?.verdict).toBe("verified");
     await imapDeleteMailbox("Dest", deps);
     expect(list).toMatch(/via IMAP/);
   });


### PR DESCRIPTION
Second and final change for #181. **Closes #181.**

2.12.0 (#184) stopped a **rejected** command being reported as a success. This makes an **accepted** one say whether anything actually happened.

## The asymmetry this closes

The AppleScript destructive path has carried an effect-reconciliation layer since #155 — `countDelta`, the collateral snapshot — built precisely because *"the command did not throw"* is not evidence of effect. The IMAP path had none of it. Since reads route to IMAP whenever an account is IMAP-configured, that layer was off for essentially all real traffic.

## The verdict

`delete-message` and `move-message` on an `imap:` id now return `structuredContent.verification`:

| verdict | meaning |
|---|---|
| `verified` | the effect was **observed** — UIDPLUS `COPYUID` named the new UID in the destination, or the UID is gone from the source |
| `unverified` | the server **accepted** it and nothing could confirm the effect; `why` says what stopped it |
| *(failure)* | `success: false` — the server rejected it outright (2.12.0) |

**`unverified` is not a failure and is not rendered as one.** Reporting it is the point: an absent verification must never read as a successful one — the rule already adopted for the collateral diff in #176/#178.

The originally reported case (a Gmail draft whose move returned `ok: true` while the message stayed in `[Gmail]/Drafts` and the destination stayed empty) now returns `unverified` with the contradiction named.

## What is deliberately *not* done

A message still present in the source after an accepted move is `unverified`, **not failed**. A Gmail label store can legitimately keep a message visible in an all-mail view after a move, and hard-failing a working move is the strictly worse error — the same reasoning that killed the `uidMap === undefined` hard-fail design.

Batch tools are untouched here; a `countDelta`-shaped result on the IMAP batch path is the separate follow-up the issue also asks for.

## Wiring

`routeMessage` merges `verification` into `structuredContent`, so every IMAP-routed single-message tool reports it uniformly. Both tools declare `verification` in their `outputSchema` — a bare zod shape implies `additionalProperties: false`, and the client would reject the undeclared key with `-32602`.

## Verification

7 new unit tests, **all 7 fail against the pre-fix source** (verified by reverting only `imapClient.ts` + `messageRouter.ts` and re-running). The two don't-regress guards pass in both directions by construction.

Also asserted **end to end against real GreenMail**: a real move and a real delete both come back `verified`, so the post-condition check works against an actual server and not just mocks. Suite: 664 passed / 46 files; `typecheck`, `lint` (0 errors), `format:check` clean; `test:imap` 11/11 locally.

Closes #181