### PR TITLE
fix(audit): a stale-low count no longer fabricates collateral findings (#179)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 ## [Unreleased]
 
+## [2.13.1] - 2026-08-16
+
+Closes #179 — a regression introduced by the snapshot chunking in #177 (2.10.33).
+v2.10.32 read `id of messages of mb` unbounded; the chunking fix added
+`repeat while _sLo <= _ca`, and that bound is the count.
+
+### Fixed
+
+- **A lagging mailbox count could make the collateral snapshot name messages
+  that never moved.** `snapshotFragment` bounds its enumeration by the count
+  Mail just reported. #155 established that the count can lag the mailbox, and
+  the two are read as consecutive Apple Events in one script with nothing
+  between them — they are co-stale, not independent instruments. When the count
+  read **low**, every position past the bound was **never requested**, and only
+  a *failed* slice enters `_sMiss`, so an unrequested tail left no trace: the
+  status stayed `ok` and the record claimed a complete observation.
+
+  Those messages were then present in `before`, absent from `after`, and landed
+  in `disappeared` — and, if the caller never named them, in `unrequested`,
+  which the audit log documents as *"IS the #155 symptom, with names attached"*.
+  That is precisely the fabricated finding the #176 contract promises is
+  impossible: an innocent message put in front of someone mid-incident as
+  evidence of data loss.
+
+  The snapshot now probes exactly **one** position past the bound. One rather
+  than a slice, because an out-of-range *range* raises as a whole, so an
+  over-requested slice cannot distinguish "nothing there" from "the count was
+  low by more than a chunk". A message found there means the count was low; the
+  unread tail is recorded as a hole, which makes the snapshot `partial` under
+  the **existing** rules and withholds exactly the halves a truncation would
+  poison. No new status and no new gating.
+
+  The probe cannot fire spuriously: when the count is accurate the probed
+  position does not exist, and a specifier that *clamps* instead of raising
+  hands back an id this enumeration already recorded, which is ignored. Whether
+  Mail's `messages i thru j` clamps or raises is still not established across
+  backends, so both are handled rather than assumed.
+
+### Internal
+
+- The forensics simulator now derives its slice range from the **count the
+  generated script emitted** rather than from the fake mailbox's real length,
+  and models an out-of-range slice raising (with a knob for the clamping
+  semantics). Without this the bug above was not expressible in a test at all —
+  a guard for it would have passed vacuously against broken code, the same trap
+  the retracted `falseOkWarning` fell into.
+
 ## [2.13.0] - 2026-08-16
 
 Second and final change for #181, and the one that closes it. 2.12.0 stopped a

--- a/build/index.js
+++ b/build/index.js
@@ -79503,6 +79503,35 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             end if
             set _sLo to _sHi + 1
           end repeat
+          -- #179: the loop above is bounded by the count Mail JUST reported,
+          -- and that count can lag the mailbox (#155). Positions past the bound
+          -- are never requested, so \u2014 unlike a slice that failed \u2014 they leave
+          -- no trace in _sMiss, and the record would claim a complete
+          -- observation while every message past the bound looks like it
+          -- disappeared. That is a FABRICATED finding with names attached,
+          -- which is worse than the gap it papers over.
+          --
+          -- Probe exactly ONE position past the bound. One, not a slice: an
+          -- out-of-range RANGE raises as a whole, so an over-requested slice
+          -- could not distinguish "nothing there" from "count was low by more
+          -- than a chunk". If a message is there, the count was low and the
+          -- unread tail is recorded as a hole, which makes this snapshot
+          -- PARTIAL under the existing rules and withholds the halves a
+          -- truncation would poison.
+          try
+            set _sOverId to ((id of message (${countVar} + 1) of ${mbVar}) as string)
+            -- A specifier that CLAMPS rather than raising hands back the LAST
+            -- message instead of failing. That is not evidence of a truncation,
+            -- so only an id this enumeration did not already record counts.
+            set _sSeen to false
+            repeat with _sP in _sPairs
+              if (contents of _sP) starts with (_sOverId & "${SNAP_PAIR}") then set _sSeen to true
+            end repeat
+            if not _sSeen then
+              if _sMiss is not "" then set _sMiss to _sMiss & ","
+              set _sMiss to _sMiss & ((${countVar} + 1) as string) & "-end"
+            end if
+          end try
           if _sMiss is not "" then
             if (count of _sPairs) is 0 then
               set _sStatus to "unavailable"

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.13.0"
+        "apple-mail-mcp@2.13.1"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleMailManager.forensics.test.ts
+++ b/src/services/appleMailManager.forensics.test.ts
@@ -60,6 +60,15 @@ const h = vi.hoisted(() => ({
   staleAfterCountBy: 0,
   /** Mail refuses to report a count at all: `_cb`/`_ca` stay at -1. */
   suppressCount: false,
+  /**
+   * What `messages i thru j of mb` does when `j` exceeds the mailbox's real
+   * length. AppleScript RAISES on an out-of-range element range (`items 2 thru
+   * 5 of {1,2,3}` → -1728), so the default is `false` = the slice fails whole.
+   * Whether Mail's `messages` specifier behaves the same across every backend
+   * (iCloud/IMAP vs Exchange vs POP vs On-My-Mac) is NOT settled — #179 —
+   * so the other semantics is modelled rather than assumed away.
+   */
+  outOfRangeSliceClamps: false,
   /** id → the error text Mail raises for it instead of performing the op. */
   errorOn: {} as Record<string, string>,
   /** id → the "account/mailbox, " list Mail builds when an id is ambiguous. */
@@ -201,23 +210,49 @@ function simulateDestructive(script: string): string {
     const m = /repeat with _sTry from 1 to (\d+)/.exec(script);
     return m ? Number(m[1]) : 1;
   })();
+  /** Whether the script probes one position past the count bound (#179). */
+  const probesPastBound = script.includes("set _sOverId to");
 
-  const emitSnapshot = (phase: "before" | "after", state: FakeMsg[]): void => {
+  /**
+   * `reportedCount` is the count the generated script just put in `_cb`/`_ca`
+   * — NOT the mailbox's real length. (#179)
+   *
+   * `snapshotFragment` bounds its slice loop by that count (`repeat while
+   * _sLo <= _cb`), so when Mail's count lags the listing the two disagree and
+   * the enumeration is cut short. The simulator used to slice by
+   * `state.length`, i.e. by the truth, which made it structurally incapable of
+   * reproducing that: a test for the truncation would have passed vacuously
+   * against broken code. Deriving the range from the emitted count is what
+   * makes the bug expressible here at all.
+   */
+  const emitSnapshot = (
+    phase: "before" | "after",
+    state: FakeMsg[],
+    reportedCount: number
+  ): void => {
     if (snapMax === null) return;
-    if (state.length > snapMax) {
+    // `_cb < 0` is Mail declining to answer the count at all.
+    if (reportedCount < 0) {
+      out +=
+        `${SNAP_TAG}${FIELD_SEP}${acct}${FIELD_SEP}${mbox}${FIELD_SEP}${phase}${FIELD_SEP}unavailable` +
+        `${FIELD_SEP}${FIELD_SEP}${RECORD_SEP}`;
+      return;
+    }
+    if (reportedCount > snapMax) {
       out +=
         `${SNAP_TAG}${FIELD_SEP}${acct}${FIELD_SEP}${mbox}${FIELD_SEP}${phase}${FIELD_SEP}skipped${FIELD_SEP}` +
-        `mailbox holds ${state.length} messages, above APPLE_MAIL_MCP_AUDIT_SNAPSHOT_MAX=${snapMax}${RECORD_SEP}`;
+        `mailbox holds ${reportedCount} messages, above APPLE_MAIL_MCP_AUDIT_SNAPSHOT_MAX=${snapMax}${RECORD_SEP}`;
       return;
     }
     // Exactly the requests the script issues: one whole-mailbox read when it
-    // names no chunk size, otherwise consecutive slices of that size.
+    // names no chunk size, otherwise consecutive slices of that size — both
+    // bounded by the REPORTED count, as the script's own loop is.
     const slices: [number, number][] = [];
     if (snapChunk === null) {
-      if (state.length > 0) slices.push([1, state.length]);
+      if (reportedCount > 0) slices.push([1, reportedCount]);
     } else {
-      for (let lo = 1; lo <= state.length; lo += snapChunk) {
-        slices.push([lo, Math.min(lo + snapChunk - 1, state.length)]);
+      for (let lo = 1; lo <= reportedCount; lo += snapChunk) {
+        slices.push([lo, Math.min(lo + snapChunk - 1, reportedCount)]);
       }
     }
     const observed: FakeMsg[] = [];
@@ -228,8 +263,27 @@ function simulateDestructive(script: string): string {
       const always = h.failSliceAlways[phase].includes(range);
       // Answered on a retry — only if the script actually retries.
       const transient = h.failSliceOnce.includes(range) && snapAttempts < 2;
-      if (tooBig || always || transient) missed.push(range);
+      // A stale-HIGH count asks for positions past the end of the mailbox.
+      // AppleScript RAISES on an out-of-range element range (`items 2 thru 5 of
+      // {1,2,3}` → -1728) rather than clamping, so such a slice fails as a
+      // whole and is recorded as a hole. `outOfRangeSliceClamps` models the
+      // other possible semantics, which is not settled for Mail's `messages i
+      // thru j` specifier across backends (#179).
+      const outOfRange = hi > state.length;
+      const raises = outOfRange && !h.outOfRangeSliceClamps;
+      if (tooBig || always || transient || raises) missed.push(range);
       else observed.push(...state.slice(lo - 1, hi));
+    }
+    // The #179 overrun probe, answered only when the generated script actually
+    // issues it — the simulator serves the requests the script makes, so this
+    // stays absent (and the truncation stays invisible) against a script
+    // without the probe.
+    if (probesPastBound && state.length > reportedCount) {
+      const probed = state[reportedCount];
+      // The script only counts an id it has not already recorded, so a clamping
+      // specifier handing back the last message is not read as a truncation.
+      const already = observed.some((m) => m.id === probed.id);
+      if (!already) missed.push(`${reportedCount + 1}-end`);
     }
     const status = missed.length === 0 ? "ok" : observed.length === 0 ? "unavailable" : "partial";
     const payload = observed
@@ -240,7 +294,11 @@ function simulateDestructive(script: string): string {
       `${FIELD_SEP}${payload}${FIELD_SEP}${missed.join(",")}${RECORD_SEP}`;
   };
 
-  emitSnapshot("before", before);
+  // The count and the snapshot are consecutive Apple Events in ONE script with
+  // nothing between them, so the snapshot is bounded by the count the script
+  // just took — they are co-stale, not independent instruments (#155, #179).
+  const beforeCount = h.suppressCount ? -1 : before.length;
+  emitSnapshot("before", before, beforeCount);
 
   for (const t of targets) {
     // An id Mail finds in several mailboxes: refused, naming the candidates it
@@ -276,13 +334,13 @@ function simulateDestructive(script: string): string {
     h.mailbox = h.mailbox.filter((m) => !h.collateral.includes(m.id));
   }
 
-  emitSnapshot("after", h.mailbox);
+  // `staleAfterCountBy` now bounds the after-SNAPSHOT as well as the after-COUNT,
+  // which is the point: they are read by the same script against the same
+  // lagging state. A stale-LOW count truncates the enumeration (#179); a
+  // stale-HIGH count over-requests and the out-of-range slice fails.
+  const afterCount = h.suppressCount ? -1 : h.mailbox.length + h.staleAfterCountBy;
+  emitSnapshot("after", h.mailbox, afterCount);
   if (wantsCount) {
-    // The count is a SEPARATE instrument from the listing above, and #155 is
-    // exactly the case where they disagree — so the simulator has to be able to
-    // report a stale count over a correct list.
-    const beforeCount = h.suppressCount ? -1 : before.length;
-    const afterCount = h.suppressCount ? -1 : h.mailbox.length + h.staleAfterCountBy;
     out += `${RECON_TAG}${FIELD_SEP}${acct}${FIELD_SEP}${mbox}${FIELD_SEP}${beforeCount}${FIELD_SEP}${afterCount}${FIELD_SEP}${RECORD_SEP}`;
   }
   return out;
@@ -327,6 +385,7 @@ beforeEach(() => {
   h.failSliceOnce = [];
   h.staleAfterCountBy = 0;
   h.suppressCount = false;
+  h.outOfRangeSliceClamps = false;
   tmp = mkdtempSync(join(tmpdir(), "amcp-audit-"));
   delete process.env[AUDIT_LOG_ENV];
   delete process.env[AUDIT_SUBJECTS_ENV];
@@ -809,6 +868,34 @@ describe("collateral identification (opt-in, gated on the audit log)", () => {
       { id: "75814", messageId: "d@example.com" },
     ]);
     expect(c.unrequested).toEqual([{ id: "75814", messageId: "d@example.com" }]);
+  });
+
+  // =========================================================================
+  // #179 — the snapshot loop is bounded by the COUNT, and Mail's count can lag.
+  // A stale-LOW count truncates the after-enumeration; positions past the bound
+  // are never requested, so only a FAILED slice enters _sMiss and an unrequested
+  // tail leaves no trace at all. Every message past the bound is then present in
+  // `before`, absent from `after`, and lands in `disappeared` -> `unrequested`,
+  // which the audit log documents as "IS the #155 symptom, with names attached".
+  // That is the fabricated finding the #176 contract promises is impossible.
+  // =========================================================================
+  it("does not fabricate `unrequested` when a stale-LOW count truncates the after-snapshot", () => {
+    process.env[AUDIT_LOG_ENV] = auditFile();
+    // One message really leaves. Mail's after-count reads 2 when 4 remain, so
+    // the loop asks only for positions 1-2 and never sees 75814 / 75815.
+    h.staleAfterCountBy = -2;
+    mgr.batchDeleteMessages(["75811"], { account: h.account, mailbox: h.mailboxName });
+    const report = mgr.consumeLastForensics()!;
+    const [c] = report.collateral;
+
+    // 75814 and 75815 never moved. Naming either as collateral would put an
+    // innocent message in front of someone mid-incident as evidence of data
+    // loss. The snapshot must not claim a complete observation it did not make.
+    expect(c.unrequested ?? []).toEqual([]);
+    expect(c.disappeared ?? []).not.toContainEqual({ id: "75814", messageId: "d@example.com" });
+    expect(c.disappeared ?? []).not.toContainEqual({ id: "75815", messageId: "e@example.com" });
+    // "ok" asserts both snapshots were read IN FULL, which is false here.
+    expect(c.snapshot).not.toBe("ok");
   });
 
   it("RECORDS the skip when the mailbox is above the ceiling", () => {

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -1242,6 +1242,35 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             end if
             set _sLo to _sHi + 1
           end repeat
+          -- #179: the loop above is bounded by the count Mail JUST reported,
+          -- and that count can lag the mailbox (#155). Positions past the bound
+          -- are never requested, so — unlike a slice that failed — they leave
+          -- no trace in _sMiss, and the record would claim a complete
+          -- observation while every message past the bound looks like it
+          -- disappeared. That is a FABRICATED finding with names attached,
+          -- which is worse than the gap it papers over.
+          --
+          -- Probe exactly ONE position past the bound. One, not a slice: an
+          -- out-of-range RANGE raises as a whole, so an over-requested slice
+          -- could not distinguish "nothing there" from "count was low by more
+          -- than a chunk". If a message is there, the count was low and the
+          -- unread tail is recorded as a hole, which makes this snapshot
+          -- PARTIAL under the existing rules and withholds the halves a
+          -- truncation would poison.
+          try
+            set _sOverId to ((id of message (${countVar} + 1) of ${mbVar}) as string)
+            -- A specifier that CLAMPS rather than raising hands back the LAST
+            -- message instead of failing. That is not evidence of a truncation,
+            -- so only an id this enumeration did not already record counts.
+            set _sSeen to false
+            repeat with _sP in _sPairs
+              if (contents of _sP) starts with (_sOverId & "${SNAP_PAIR}") then set _sSeen to true
+            end repeat
+            if not _sSeen then
+              if _sMiss is not "" then set _sMiss to _sMiss & ","
+              set _sMiss to _sMiss & ((${countVar} + 1) as string) & "-end"
+            end if
+          end try
           if _sMiss is not "" then
             if (count of _sPairs) is 0 then
               set _sStatus to "unavailable"


### PR DESCRIPTION
**Closes #179.** Combines the two planned steps — the simulator fidelity work is the prerequisite for the guard, and merging it alone would add no test, so they ship together.

## The defect

`snapshotFragment` bounds its enumeration by the count Mail just reported:

```applescript
repeat while _sLo <= _ca
```

#155 established that the count can lag the mailbox, and the count and the snapshot are **consecutive Apple Events in one script with nothing between them** — co-stale, not independent instruments.

When the count reads **low**, positions past the bound are **never requested**. Only a *failed* slice enters `_sMiss`, so an unrequested tail leaves no trace: `_sStatus` stays `ok`, `holes.length === 0`, and the record claims a complete observation. Those messages are then present in `before`, absent from `after`, and land in `disappeared` — and if the caller never named them, in `unrequested`, which the audit log documents as *"IS the #155 symptom, with names attached"*.

That is exactly the fabricated finding the #176 contract promises is impossible: an innocent message put in front of someone mid-incident as evidence of data loss.

Regression from #177 (2.10.33) — v2.10.32 read `id of messages of mb` unbounded.

## The fix

Probe exactly **one** position past the bound. One rather than a slice, because an out-of-range *range* raises as a whole, so an over-requested slice cannot distinguish "nothing there" from "the count was low by more than a chunk".

A message found there means the count was low; the unread tail is recorded as a hole, which makes the snapshot `partial` under the **existing** rules and withholds exactly the halves a truncation would poison. **No new status, no new gating** — it reuses the #176 contract rather than inventing semantics beside it.

The probe cannot fire spuriously:
- with an accurate count the probed position does not exist and the `try` swallows the raise;
- a specifier that **clamps** instead of raising hands back an id this enumeration already recorded, which is ignored.

Whether Mail's `messages i thru j` clamps or raises is *still* not established across backends (iCloud/IMAP vs Exchange vs POP vs On-My-Mac), so both are handled rather than assumed — which was the reason #178 declined to fix this.

## The simulator had to be fixed first

`emitSnapshot` sliced by the fake mailbox's **real length** rather than by the count the generated script emitted, so the bug was **not expressible in a test at all** — a guard for it would have passed vacuously against broken code. That is the same trap the retracted `falseOkWarning` fell into, and #179 called it out explicitly as a prerequisite.

It now derives its range from the emitted count and models an out-of-range slice **raising**, with an `outOfRangeSliceClamps` knob for the other semantics. `staleAfterCountBy` consequently bounds the after-*snapshot* as well as the after-*count*, which is the point.

## Verification

Guard checked in **both** directions:

| | result |
|---|---|
| unfixed script + new simulator | **RED** — `unrequested` = `[75814, 75815]`, two messages that never moved, with `snapshot: "ok"` |
| fixed script | **GREEN** |

Exactly one test flips; the other 48 forensics tests are unchanged in both directions.

Generated AppleScript validated with `osacompile` (exit 0) — the probe renders correctly in both phases (`_cb` before, `_ca` after).

Suite: 665 passed / 46 files. `typecheck` clean, `lint` 0 errors, `format:check` clean.

Closes #179