### PR TITLE
fix(list-mailboxes): a refused listing no longer reads as an empty one (#183)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.13.1",
+      "version": "2.13.2",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.13.1",
+      "version": "2.13.2",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.13.1",
+      "version": "2.13.2",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 ## [Unreleased]
 
+## [2.13.2] - 2026-08-16
+
+Partial progress on #183 — the half that needs no new AppleScript. **#183 stays
+open**: local "On My Mac" mailboxes are still not enumerated. What changes is
+that the server no longer *implies they do not exist*.
+
+### Fixed
+
+- **`list-mailboxes` reported a refused listing as an empty one.** `listMailboxes`
+  returns `[]` both when an account genuinely holds no mailboxes and when Mail
+  REFUSED the request — asking for something that is not an account raises
+  `Can't get account "X"` — and the tool called the unchecked variant, so both
+  came back as `{"mailboxes":[],"count":0}` and a successful "No mailboxes
+  found".
+
+  That told the caller the opposite of the truth, and it is the same
+  absent-vs-empty distinction enforced everywhere else here (an absent
+  collateral array means "not computable", never "empty"). A refused listing now
+  returns an **error** naming the accounts that do exist.
+
+  Asking for `account="On My Mac"` additionally explains that Mail's local store
+  is not an account at all — its mailboxes are not children of any account, so
+  no `account` argument can reach them — instead of implying the store is empty.
+
+- **The unscoped fan-out silently dropped sources it could not read.** An IMAP
+  account whose LIST threw, or an AppleScript account Mail refused, was logged to
+  stderr and omitted, leaving a short list that looked complete. Those are now
+  named: the result carries `partial: true` + `failedAccounts`, the text says the
+  list is incomplete, and a fan-out where *every* source failed is an error
+  rather than "No mailboxes found". Matches the contract `get-mail-stats` and
+  `get-unread-count` already follow.
+
 ## [2.13.1] - 2026-08-16
 
 Closes #179 — a regression introduced by the snapshot chunking in #177 (2.10.33).

--- a/build/index.js
+++ b/build/index.js
@@ -84652,6 +84652,25 @@ function withErrorHandling(handler, errorPrefix) {
   };
 }
 
+// src/tools/mailboxListing.ts
+var LOCAL_STORE_NAMES = ["on my mac", "on my computer", "local", "local folders"];
+function isLocalStoreName(name) {
+  return LOCAL_STORE_NAMES.includes(name.trim().toLowerCase());
+}
+function unlistableStoreError(account, error2, knownAccounts) {
+  const scope = account ? ` for "${account}"` : "";
+  const parts = [`Could not list mailboxes${scope}: ${error2 ?? "Mail declined the request"}`];
+  if (knownAccounts.length > 0) {
+    parts.push(`Accounts on this Mac: ${knownAccounts.join(", ")}.`);
+  }
+  if (account && isLocalStoreName(account)) {
+    parts.push(
+      `"${account}" is Mail's LOCAL store, not an account \u2014 its mailboxes are not children of any account, so they cannot be reached with an \`account\` argument. Enumerating them is not yet supported.`
+    );
+  }
+  return parts.join("\n\n");
+}
+
 // src/tools/batchResults.ts
 async function hybridBatchCounts(ids, appleFn, imapFn) {
   const distinctIds = [...new Set(ids)];
@@ -86693,13 +86712,17 @@ ${r.base64}`,
 registerTool(
   "list-mailboxes",
   {
-    description: "Use when: discovering the mailbox/folder names (and unread/message counts) available in an account, e.g. before moving messages or searching a specific mailbox.\nReturns: each mailbox's name with its unread (and, for IMAP, total message) count, plus a count.\nDo not use when: you want the messages inside a mailbox (use list-messages or search-messages) or the list of accounts (use list-accounts).",
+    description: "Use when: discovering the mailbox/folder names (and unread/message counts) available in an account, e.g. before moving messages or searching a specific mailbox.\nReturns: each mailbox's name with its unread (and, for IMAP, total message) count, plus a count. A source that could not be read is NAMED \u2014 the result carries `partial: true` + `failedAccounts` and the list is a floor, not the complete set \u2014 and a listing Mail refused outright (e.g. an account that does not exist) returns an ERROR naming the accounts that do exist, never an empty list.\nDo not use when: you want the messages inside a mailbox (use list-messages or search-messages) or the list of accounts (use list-accounts).\nNote: Mail's local \"On My Mac\" mailboxes are not part of any account and are not currently enumerated by this tool.",
     inputSchema: {
       account: external_exports.string().optional().describe("Account to list mailboxes from")
     },
     outputSchema: {
       mailboxes: external_exports.array(external_exports.object({}).passthrough()).optional(),
-      count: external_exports.number().optional()
+      count: external_exports.number().optional(),
+      // Declared explicitly: the SDK stamps additionalProperties:false on a bare
+      // zod shape, so an undeclared key makes the CLIENT reject the result.
+      partial: external_exports.boolean().optional(),
+      failedAccounts: external_exports.array(external_exports.string()).optional()
     }
   },
   withErrorHandling(async ({ account }) => {
@@ -86721,6 +86744,7 @@ ${list2}`, structured3);
       }
       const configs = resolveImapConfigs();
       const rows = [];
+      const failedAccounts = [];
       for (const config2 of configs) {
         try {
           const boxes = await imapListMailboxes({ config: config2 });
@@ -86734,11 +86758,18 @@ ${list2}`, structured3);
           }
         } catch (e) {
           console.error(`IMAP list-mailboxes failed for "${config2.accountLabel}": ${String(e)}`);
+          failedAccounts.push(config2.accountLabel);
         }
       }
       const { appleScriptOnly } = partitionAccountsForCounts(mailManager.listAccounts(), configs);
       for (const acct of appleScriptOnly) {
-        for (const mb of mailManager.listMailboxes(acct.name)) {
+        const checked = mailManager.listMailboxesChecked(acct.name);
+        if (checked.failed) {
+          console.error(`list-mailboxes failed for "${acct.name}": ${checked.error}`);
+          failedAccounts.push(acct.name);
+          continue;
+        }
+        for (const mb of checked.mailboxes) {
           rows.push({
             name: `${acct.name}/${mb.name}`,
             account: acct.name,
@@ -86747,13 +86778,34 @@ ${list2}`, structured3);
           });
         }
       }
-      const structured2 = { mailboxes: rows, count: rows.length };
-      if (rows.length === 0) return successResponse("No mailboxes found", structured2);
+      const partial2 = failedAccounts.length > 0;
+      const structured2 = {
+        mailboxes: rows,
+        count: rows.length,
+        ...partial2 ? { partial: partial2, failedAccounts } : {}
+      };
+      const caveat = partial2 ? `
+
+PARTIAL \u2014 could not read: ${failedAccounts.join(", ")}. This list is incomplete.` : "";
+      if (rows.length === 0) {
+        return partial2 ? errorResponse(
+          `Could not list mailboxes from any source. Failed: ${failedAccounts.join(", ")}.`
+        ) : successResponse("No mailboxes found", structured2);
+      }
       const list = rows.map((b) => `  - ${b.name} (${b.unreadCount} unread)`).join("\n");
       return successResponse(`Found ${rows.length} mailbox(es):
-${list}`, structured2);
+${list}${caveat}`, structured2);
     }
-    const mailboxes = mailManager.listMailboxes(account);
+    const { mailboxes, failed, error: error2 } = mailManager.listMailboxesChecked(account);
+    if (failed) {
+      return errorResponse(
+        unlistableStoreError(
+          account,
+          error2,
+          mailManager.listAccounts().map((a) => a.name)
+        )
+      );
+    }
     const structured = { mailboxes, count: mailboxes.length };
     if (mailboxes.length === 0) {
       return successResponse("No mailboxes found", structured);

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.13.1"
+        "apple-mail-mcp@2.13.2"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ import {
   currentCallTiming,
   messageSummary,
 } from "@/tools/respond.js";
+import { unlistableStoreError } from "@/tools/mailboxListing.js";
 import { hybridBatchCounts, batchResponse } from "@/tools/batchResults.js";
 import { runBatchDelete, runBatchMove } from "@/tools/batchMutations.js";
 import {
@@ -1991,13 +1992,17 @@ registerTool(
   "list-mailboxes",
   {
     description:
-      "Use when: discovering the mailbox/folder names (and unread/message counts) available in an account, e.g. before moving messages or searching a specific mailbox.\nReturns: each mailbox's name with its unread (and, for IMAP, total message) count, plus a count.\nDo not use when: you want the messages inside a mailbox (use list-messages or search-messages) or the list of accounts (use list-accounts).",
+      "Use when: discovering the mailbox/folder names (and unread/message counts) available in an account, e.g. before moving messages or searching a specific mailbox.\nReturns: each mailbox's name with its unread (and, for IMAP, total message) count, plus a count. A source that could not be read is NAMED — the result carries `partial: true` + `failedAccounts` and the list is a floor, not the complete set — and a listing Mail refused outright (e.g. an account that does not exist) returns an ERROR naming the accounts that do exist, never an empty list.\nDo not use when: you want the messages inside a mailbox (use list-messages or search-messages) or the list of accounts (use list-accounts).\nNote: Mail's local \"On My Mac\" mailboxes are not part of any account and are not currently enumerated by this tool.",
     inputSchema: {
       account: z.string().optional().describe("Account to list mailboxes from"),
     },
     outputSchema: {
       mailboxes: z.array(z.object({}).passthrough()).optional(),
       count: z.number().optional(),
+      // Declared explicitly: the SDK stamps additionalProperties:false on a bare
+      // zod shape, so an undeclared key makes the CLIENT reject the result.
+      partial: z.boolean().optional(),
+      failedAccounts: z.array(z.string()).optional(),
     },
   },
   withErrorHandling(async ({ account }) => {
@@ -2026,6 +2031,10 @@ registerTool(
       const configs = resolveImapConfigs();
       const rows: { name: string; account: string; unreadCount: number; messageCount: number }[] =
         [];
+      // #183: a source that could not be read is NAMED. Dropping it left the
+      // caller with a short list that looked complete — the same absent-vs-empty
+      // confusion, one level up. Matches get-mail-stats' partial/failedAccounts.
+      const failedAccounts: string[] = [];
       for (const config of configs) {
         try {
           const boxes = await imapListMailboxes({ config });
@@ -2041,12 +2050,19 @@ registerTool(
           }
         } catch (e) {
           console.error(`IMAP list-mailboxes failed for "${config.accountLabel}": ${String(e)}`);
+          failedAccounts.push(config.accountLabel);
         }
       }
       // AppleScript for the accounts IMAP doesn't cover (no double-listing).
       const { appleScriptOnly } = partitionAccountsForCounts(mailManager.listAccounts(), configs);
       for (const acct of appleScriptOnly) {
-        for (const mb of mailManager.listMailboxes(acct.name)) {
+        const checked = mailManager.listMailboxesChecked(acct.name);
+        if (checked.failed) {
+          console.error(`list-mailboxes failed for "${acct.name}": ${checked.error}`);
+          failedAccounts.push(acct.name);
+          continue;
+        }
+        for (const mb of checked.mailboxes) {
           rows.push({
             name: `${acct.name}/${mb.name}`,
             account: acct.name,
@@ -2055,13 +2071,45 @@ registerTool(
           });
         }
       }
-      const structured = { mailboxes: rows, count: rows.length };
-      if (rows.length === 0) return successResponse("No mailboxes found", structured);
+      const partial = failedAccounts.length > 0;
+      const structured = {
+        mailboxes: rows,
+        count: rows.length,
+        ...(partial ? { partial, failedAccounts } : {}),
+      };
+      // A partial list is a FLOOR, not an answer — say so rather than letting a
+      // short list read as the complete set.
+      const caveat = partial
+        ? `\n\nPARTIAL — could not read: ${failedAccounts.join(", ")}. This list is incomplete.`
+        : "";
+      if (rows.length === 0) {
+        return partial
+          ? errorResponse(
+              `Could not list mailboxes from any source. Failed: ${failedAccounts.join(", ")}.`
+            )
+          : successResponse("No mailboxes found", structured);
+      }
       const list = rows.map((b) => `  - ${b.name} (${b.unreadCount} unread)`).join("\n");
-      return successResponse(`Found ${rows.length} mailbox(es):\n${list}`, structured);
+      return successResponse(`Found ${rows.length} mailbox(es):\n${list}${caveat}`, structured);
     }
 
-    const mailboxes = mailManager.listMailboxes(account);
+    // #183: read through the CHECKED variant. `listMailboxes` returns `[]` both
+    // when an account genuinely has no mailboxes and when Mail REFUSED the
+    // request — an account that does not exist raises `Can't get account "X"`
+    // — so reporting the empty list as a success made "this store is not
+    // addressable" indistinguishable from "you have no mail". That is the
+    // absent-vs-empty confusion this codebase refuses to make everywhere else
+    // (the collateral diff withholds rather than reports an empty array).
+    const { mailboxes, failed, error } = mailManager.listMailboxesChecked(account);
+    if (failed) {
+      return errorResponse(
+        unlistableStoreError(
+          account,
+          error,
+          mailManager.listAccounts().map((a) => a.name)
+        )
+      );
+    }
     const structured = { mailboxes, count: mailboxes.length };
 
     if (mailboxes.length === 0) {

--- a/src/tools/mailboxListing.test.ts
+++ b/src/tools/mailboxListing.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  isLocalStoreName,
+  unlistableStoreError,
+  LOCAL_STORE_NAMES,
+} from "@/tools/mailboxListing.js";
+
+const ACCOUNTS = ["iCloud", "robert.b.sweet@gmail.com", "rob@superiortech.io"];
+
+describe("#183 a refused mailbox listing says so instead of reading as empty", () => {
+  it("names the failure rather than reporting nothing found", () => {
+    const msg = unlistableStoreError(
+      "Nonsense",
+      'Can\'t get account "Nonsense". (-1728)',
+      ACCOUNTS
+    );
+    expect(msg).toMatch(/Could not list mailboxes for "Nonsense"/);
+    expect(msg).toMatch(/-1728/);
+    // The whole point: it must not be phrased as an empty result.
+    expect(msg).not.toMatch(/No mailboxes found/i);
+  });
+
+  it("names the accounts that DO exist, so the caller can correct the argument", () => {
+    const msg = unlistableStoreError("Nonsense", "boom", ACCOUNTS);
+    for (const a of ACCOUNTS) expect(msg).toContain(a);
+  });
+
+  it("explains that the local store is not an account and cannot be reached this way", () => {
+    const msg = unlistableStoreError("On My Mac", "boom", ACCOUNTS);
+    expect(msg).toMatch(/is Mail's LOCAL store, not an account/);
+    expect(msg).toMatch(/not yet supported/);
+  });
+
+  it("does not claim a real account is the local store", () => {
+    const msg = unlistableStoreError("iCloud", "boom", ACCOUNTS);
+    expect(msg).not.toMatch(/LOCAL store/);
+  });
+
+  it("still explains itself when the account enumeration is also unavailable", () => {
+    const msg = unlistableStoreError("On My Mac", undefined, []);
+    expect(msg).toMatch(/Mail declined the request/);
+    expect(msg).not.toMatch(/Accounts on this Mac/);
+    expect(msg).toMatch(/LOCAL store/);
+  });
+
+  it("recognises the local store by its common names, case- and space-insensitively", () => {
+    for (const n of LOCAL_STORE_NAMES) {
+      expect(isLocalStoreName(n)).toBe(true);
+      expect(isLocalStoreName(`  ${n.toUpperCase()}  `)).toBe(true);
+    }
+    expect(isLocalStoreName("iCloud")).toBe(false);
+    expect(isLocalStoreName("On My Mac Archive")).toBe(false);
+  });
+});

--- a/src/tools/mailboxListing.ts
+++ b/src/tools/mailboxListing.ts
@@ -1,0 +1,53 @@
+/**
+ * Error text for a mailbox listing Mail refused. (#183)
+ *
+ * `listMailboxes` returns `[]` both when an account genuinely holds no
+ * mailboxes and when Mail REFUSED the request — asking for an account that does
+ * not exist raises `Can't get account "X"`. Reporting that empty list as a
+ * success told the caller the opposite of the truth: "you have no mailboxes"
+ * rather than "this store is not addressable".
+ *
+ * That is the same absent-vs-empty distinction the collateral diff enforces,
+ * where an absent array means "not computable" and never "empty".
+ *
+ * Kept here rather than in `index.ts` so it is testable: importing `index.ts`
+ * opens a stdio transport.
+ *
+ * @module tools/mailboxListing
+ */
+
+/**
+ * Names for Mail's local store. It is NOT an account — its mailboxes hang off
+ * the application, not off any `account` — so no `account` argument can ever
+ * reach them, and an empty result is especially misleading for these.
+ */
+export const LOCAL_STORE_NAMES = ["on my mac", "on my computer", "local", "local folders"];
+
+/** True when `name` is Mail's local store rather than a real account. */
+export function isLocalStoreName(name: string): boolean {
+  return LOCAL_STORE_NAMES.includes(name.trim().toLowerCase());
+}
+
+/**
+ * Explain a refused mailbox listing, naming the accounts that DO exist so the
+ * caller can correct the argument rather than concluding the mailbox is empty.
+ */
+export function unlistableStoreError(
+  account: string | undefined,
+  error: string | undefined,
+  knownAccounts: string[]
+): string {
+  const scope = account ? ` for "${account}"` : "";
+  const parts = [`Could not list mailboxes${scope}: ${error ?? "Mail declined the request"}`];
+  if (knownAccounts.length > 0) {
+    parts.push(`Accounts on this Mac: ${knownAccounts.join(", ")}.`);
+  }
+  if (account && isLocalStoreName(account)) {
+    parts.push(
+      `"${account}" is Mail's LOCAL store, not an account — its mailboxes are not children of ` +
+        `any account, so they cannot be reached with an \`account\` argument. Enumerating them ` +
+        `is not yet supported.`
+    );
+  }
+  return parts.join("\n\n");
+}


### PR DESCRIPTION
Partial progress on #183 — the half that needs no new AppleScript. **Does not close #183**: local "On My Mac" mailboxes are still not enumerated. What changes is that the server stops *implying they do not exist*.

## Why only half

The enumeration half rests on a question the repo cannot currently answer: **does `account of <a local mailbox>` return `missing value`, or raise?** Nothing in this codebase touches application-level `mailboxes` today, and the ownership filter that keeps local and account mailboxes disjoint depends on which it is. Getting it wrong risks double-listing every account mailbox on the repo's most expensive read path (`list-mailboxes` already carries a 60s timeout and its own comment conceding that "60s alone overruns most clients' request timeouts").

That needs a live check against a real On My Mac store, so it is deliberately not in this PR.

## What this fixes

**1. A refused listing was reported as an empty one.**

`listMailboxes` returns `[]` both when an account genuinely holds no mailboxes and when Mail **refused** the request — asking for something that is not an account raises `Can't get account "X"`. The tool called the *unchecked* variant, so both came back as:

```json
{ "mailboxes": [], "count": 0 }
```

…with a successful "No mailboxes found". That told the caller the opposite of the truth, and it is exactly the absent-vs-empty distinction enforced everywhere else here — an absent collateral array means "not computable", never "empty".

A refused listing now returns an **error** naming the accounts that do exist. Asking for `account="On My Mac"` additionally explains that the local store is not an account at all, so no `account` argument can reach it — instead of implying the store is empty.

This uses Mail's **own** answer via the existing `listMailboxesChecked`, rather than duplicating account resolution to pre-validate the name.

**2. The unscoped fan-out silently dropped sources it could not read.**

An IMAP account whose LIST threw, or an AppleScript account Mail refused, was logged to stderr and omitted — leaving a short list that looked complete. Same defect, one level up. Those are now named: `partial: true` + `failedAccounts`, the text says the list is incomplete, and a fan-out where *every* source failed is an error rather than "No mailboxes found". Matches the contract `get-mail-stats` and `get-unread-count` already follow.

`partial`/`failedAccounts` are declared in the `outputSchema` — a bare zod shape implies `additionalProperties: false` and the client would reject undeclared keys with `-32602`.

## Notes

The helper lives in `src/tools/mailboxListing.ts` rather than `index.ts` so it is testable at all: importing `index.ts` opens a stdio transport, which is why the batch handlers were extracted the same way.

6 new tests. Suite: 671 passed / 47 files. `typecheck` clean, `lint` 0 errors, `format:check` clean.

Refs #183