### PR TITLE
feat(list-mailboxes): enumerate Mail's local 'On My Mac' store (#183)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.13.2",
+      "version": "2.14.0",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.13.2",
+      "version": "2.14.0",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.13.2",
+      "version": "2.14.0",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 ## [Unreleased]
 
+## [2.14.0] - 2026-08-16
+
+Mail's local "On My Mac" mailboxes are visible for the first time. This is the
+enumeration half of #183; 2.13.2 did the "don't lie about it" half.
+
+### Added
+
+- **`list-mailboxes` sees Mail's local store.** Local mailboxes are not children
+  of any `account` — they hang off the application — so every enumeration here,
+  which walked `accounts` → `mailboxes of acct`, was structurally blind to them.
+  A user with mail filed On My Mac had it reported as not existing.
+
+  They are now reported under the synthetic account label **`On My Mac`**. An
+  unscoped `list-mailboxes` includes them (ordered **last**, so a slow local
+  store never delays the account results); `account="On My Mac"` lists only them,
+  with `on my computer` / `local` / `local folders` accepted as aliases.
+
+  They are deliberately **absent from `list-accounts`**, which reports real
+  accounts only — the local store is a store, not an account. And nothing selects
+  it implicitly: `resolveAccount()` is untouched and still can only ever return a
+  real account, so omitting `account` behaves exactly as before for every other
+  tool.
+
+### Notes on the implementation
+
+The behaviour of application-level `mailboxes` was **measured against a live
+Mail.app** rather than assumed (read-only probe, results on #183):
+
+- `account of <an app-level mailbox>` returns `missing value` — it does not raise
+  and does not return a bogus object.
+- `account of <an account mailbox>` correctly names its account, which is what
+  stops the ownership filter mistaking one for a local mailbox and double-listing
+  every account mailbox.
+- App-level `mailboxes` returned **only** the local mailboxes while the accounts
+  separately held 26, i.e. no overlap on this backend. The ownership filter is
+  therefore insurance for backends that might overlap (POP is untested), not the
+  load-bearing mechanism.
+
+The account-scoped code path is **byte-identical** to 2.13.2 — verified by
+diffing the generated AppleScript — so this adds no Apple Events to any existing
+call.
+
+**Still open in #183:** whether application-level `mailboxes` is FLAT over
+nested local folders. Untestable on the probe machine, which has no nested local
+folders (every local mailbox reported `subs=0`). If it is not flat, nested local
+folders remain invisible — the issue partially persists rather than anything
+regressing.
+
 ## [2.13.2] - 2026-08-16
 
 Partial progress on #183 — the half that needs no new AppleScript. **#183 stays

--- a/README.md
+++ b/README.md
@@ -935,9 +935,23 @@ List all mailboxes for an account.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `account` | string | No | Account to list from |
+| `account` | string | No | Account to list from, or `"On My Mac"` for the local store |
 
-**Returns:** List of mailbox names with message and unread counts.
+**Returns:** List of mailbox names with message and unread counts. A source that
+could not be read is **named** (`partial: true` + `failedAccounts`) rather than
+dropped, and a listing Mail refused outright returns an error naming the accounts
+that do exist — never an empty list.
+
+**Mail's local "On My Mac" mailboxes** are not children of any account — they
+hang off the application — so they are reported under the synthetic account label
+**`On My Mac`**. An unscoped call includes them (listed last); `account="On My
+Mac"` lists only them. `on my computer`, `local` and `local folders` are accepted
+as aliases.
+
+They deliberately do **not** appear in `list-accounts`, which reports real
+accounts only: the local store is a store, not an account. Nothing selects it
+implicitly — omitting `account` still resolves to a real account for every other
+tool.
 
 ---
 

--- a/build/index.js
+++ b/build/index.js
@@ -79129,6 +79129,24 @@ function buildAccountScopedScript(account, command) {
     end tell
   `;
 }
+var LOCAL_STORE_LABEL = "On My Mac";
+var LOCAL_STORE_ALIASES = ["on my mac", "on my computer", "local", "local folders"];
+function isLocalStoreLabel(name) {
+  return name !== void 0 && LOCAL_STORE_ALIASES.includes(name.trim().toLowerCase());
+}
+function localMailboxBindingFragment() {
+  return `
+      set _mbs to {}
+      repeat with _m in mailboxes
+        set _isLoc to false
+        try
+          if (account of _m) is missing value then set _isLoc to true
+        on error
+          set _isLoc to true
+        end try
+        if _isLoc then set end of _mbs to (contents of _m)
+      end repeat`;
+}
 function groupKey(account, mailbox) {
   return `${account}\0${mailbox}`;
 }
@@ -81983,10 +82001,11 @@ ${this.errorEmit("              ")}
    * List all mailboxes for an account.
    */
   listMailboxes(account, options = {}) {
-    const targetAccount = this.resolveAccount(account);
-    const listCommand = `
+    const local = isLocalStoreLabel(account);
+    const targetAccount = local ? LOCAL_STORE_LABEL : this.resolveAccount(account);
+    const listCommand = (iterExpr) => `
       set mailboxList to {}
-      repeat with mb in mailboxes
+      repeat with mb in ${iterExpr}
         set mbName to name of mb
         set mbUnread to unread count of mb
         set mbCount to count of messages of mb
@@ -81995,7 +82014,8 @@ ${this.errorEmit("              ")}
       set AppleScript's text item delimiters to "${RECORD_SEP}"
       return mailboxList as text
     `;
-    const script = buildAccountScopedScript(targetAccount, listCommand);
+    const script = local ? buildAppLevelScript(`${localMailboxBindingFragment()}
+      ${listCommand("_mbs")}`) : buildAccountScopedScript(targetAccount, listCommand("mailboxes"));
     const result = executeAppleScript(script, { timeoutMs: options.timeoutMs ?? 6e4 });
     if (!result.success) {
       console.error(`Failed to list mailboxes: ${result.error}`);
@@ -84653,19 +84673,15 @@ function withErrorHandling(handler, errorPrefix) {
 }
 
 // src/tools/mailboxListing.ts
-var LOCAL_STORE_NAMES = ["on my mac", "on my computer", "local", "local folders"];
-function isLocalStoreName(name) {
-  return LOCAL_STORE_NAMES.includes(name.trim().toLowerCase());
-}
 function unlistableStoreError(account, error2, knownAccounts) {
   const scope = account ? ` for "${account}"` : "";
   const parts = [`Could not list mailboxes${scope}: ${error2 ?? "Mail declined the request"}`];
   if (knownAccounts.length > 0) {
     parts.push(`Accounts on this Mac: ${knownAccounts.join(", ")}.`);
   }
-  if (account && isLocalStoreName(account)) {
+  if (account && isLocalStoreLabel(account)) {
     parts.push(
-      `"${account}" is Mail's LOCAL store, not an account \u2014 its mailboxes are not children of any account, so they cannot be reached with an \`account\` argument. Enumerating them is not yet supported.`
+      `"${account}" addresses Mail's LOCAL store, which IS listable \u2014 it is read at the application level rather than through an account, so this failure is not "no such account". Something went wrong reading the local store itself.`
     );
   }
   return parts.join("\n\n");
@@ -86709,10 +86725,26 @@ ${r.base64}`,
     );
   }, "Error fetching attachment")
 );
+function appendLocalStoreRows(rows, failedAccounts) {
+  const checked = mailManager.listMailboxesChecked(LOCAL_STORE_LABEL);
+  if (checked.failed) {
+    console.error(`list-mailboxes failed for "${LOCAL_STORE_LABEL}": ${checked.error}`);
+    failedAccounts.push(LOCAL_STORE_LABEL);
+    return;
+  }
+  for (const mb of checked.mailboxes) {
+    rows.push({
+      name: `${LOCAL_STORE_LABEL}/${mb.name}`,
+      account: LOCAL_STORE_LABEL,
+      unreadCount: mb.unreadCount,
+      messageCount: mb.messageCount
+    });
+  }
+}
 registerTool(
   "list-mailboxes",
   {
-    description: "Use when: discovering the mailbox/folder names (and unread/message counts) available in an account, e.g. before moving messages or searching a specific mailbox.\nReturns: each mailbox's name with its unread (and, for IMAP, total message) count, plus a count. A source that could not be read is NAMED \u2014 the result carries `partial: true` + `failedAccounts` and the list is a floor, not the complete set \u2014 and a listing Mail refused outright (e.g. an account that does not exist) returns an ERROR naming the accounts that do exist, never an empty list.\nDo not use when: you want the messages inside a mailbox (use list-messages or search-messages) or the list of accounts (use list-accounts).\nNote: Mail's local \"On My Mac\" mailboxes are not part of any account and are not currently enumerated by this tool.",
+    description: 'Use when: discovering the mailbox/folder names (and unread/message counts) available in an account, e.g. before moving messages or searching a specific mailbox.\nReturns: each mailbox\'s name with its unread (and, for IMAP, total message) count, plus a count. A source that could not be read is NAMED \u2014 the result carries `partial: true` + `failedAccounts` and the list is a floor, not the complete set \u2014 and a listing Mail refused outright (e.g. an account that does not exist) returns an ERROR naming the accounts that do exist, never an empty list.\nDo not use when: you want the messages inside a mailbox (use list-messages or search-messages) or the list of accounts (use list-accounts).\nNote: Mail\'s local "On My Mac" mailboxes are not part of any account, so they are reported under the synthetic account label "On My Mac" \u2014 an unscoped call includes them, and `account: "On My Mac"` lists only them. They will not appear in list-accounts, which reports real accounts only.',
     inputSchema: {
       account: external_exports.string().optional().describe("Account to list mailboxes from")
     },
@@ -86778,6 +86810,7 @@ ${list2}`, structured3);
           });
         }
       }
+      appendLocalStoreRows(rows, failedAccounts);
       const partial2 = failedAccounts.length > 0;
       const structured2 = {
         mailboxes: rows,
@@ -86806,7 +86839,13 @@ ${list}${caveat}`, structured2);
         )
       );
     }
-    const structured = { mailboxes, count: mailboxes.length };
+    const localFailures = [];
+    if (account === void 0) appendLocalStoreRows(mailboxes, localFailures);
+    const structured = {
+      mailboxes,
+      count: mailboxes.length,
+      ...localFailures.length ? { partial: true, failedAccounts: localFailures } : {}
+    };
     if (mailboxes.length === 0) {
       return successResponse("No mailboxes found", structured);
     }

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.13.2"
+        "apple-mail-mcp@2.14.0"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,11 @@ import {
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { AppleMailManager, resolveAttachmentSaveTarget } from "@/services/appleMailManager.js";
+import {
+  AppleMailManager,
+  resolveAttachmentSaveTarget,
+  LOCAL_STORE_LABEL,
+} from "@/services/appleMailManager.js";
 import { writeFileSync } from "fs";
 import { join as joinPath } from "path";
 import {
@@ -1988,11 +1992,42 @@ registerTool(
 
 // --- list-mailboxes ---
 
+/**
+ * Append Mail's LOCAL ("On My Mac") mailboxes to an unscoped listing. (#183)
+ *
+ * They are not children of any account, so every `accounts` → `mailboxes of
+ * acct` loop is structurally blind to them; this is the only way they appear
+ * without being asked for by name. A failure is NAMED in `failedAccounts`
+ * rather than dropped, for the same reason an unreadable account is: a short
+ * list that looks complete is the bug this tool just stopped shipping.
+ *
+ * Called LAST so a slow local store cannot delay the account results.
+ */
+function appendLocalStoreRows(
+  rows: { name: string; account: string; unreadCount: number; messageCount: number }[],
+  failedAccounts: string[]
+): void {
+  const checked = mailManager.listMailboxesChecked(LOCAL_STORE_LABEL);
+  if (checked.failed) {
+    console.error(`list-mailboxes failed for "${LOCAL_STORE_LABEL}": ${checked.error}`);
+    failedAccounts.push(LOCAL_STORE_LABEL);
+    return;
+  }
+  for (const mb of checked.mailboxes) {
+    rows.push({
+      name: `${LOCAL_STORE_LABEL}/${mb.name}`,
+      account: LOCAL_STORE_LABEL,
+      unreadCount: mb.unreadCount,
+      messageCount: mb.messageCount,
+    });
+  }
+}
+
 registerTool(
   "list-mailboxes",
   {
     description:
-      "Use when: discovering the mailbox/folder names (and unread/message counts) available in an account, e.g. before moving messages or searching a specific mailbox.\nReturns: each mailbox's name with its unread (and, for IMAP, total message) count, plus a count. A source that could not be read is NAMED — the result carries `partial: true` + `failedAccounts` and the list is a floor, not the complete set — and a listing Mail refused outright (e.g. an account that does not exist) returns an ERROR naming the accounts that do exist, never an empty list.\nDo not use when: you want the messages inside a mailbox (use list-messages or search-messages) or the list of accounts (use list-accounts).\nNote: Mail's local \"On My Mac\" mailboxes are not part of any account and are not currently enumerated by this tool.",
+      'Use when: discovering the mailbox/folder names (and unread/message counts) available in an account, e.g. before moving messages or searching a specific mailbox.\nReturns: each mailbox\'s name with its unread (and, for IMAP, total message) count, plus a count. A source that could not be read is NAMED — the result carries `partial: true` + `failedAccounts` and the list is a floor, not the complete set — and a listing Mail refused outright (e.g. an account that does not exist) returns an ERROR naming the accounts that do exist, never an empty list.\nDo not use when: you want the messages inside a mailbox (use list-messages or search-messages) or the list of accounts (use list-accounts).\nNote: Mail\'s local "On My Mac" mailboxes are not part of any account, so they are reported under the synthetic account label "On My Mac" — an unscoped call includes them, and `account: "On My Mac"` lists only them. They will not appear in list-accounts, which reports real accounts only.',
     inputSchema: {
       account: z.string().optional().describe("Account to list mailboxes from"),
     },
@@ -2071,6 +2106,11 @@ registerTool(
           });
         }
       }
+      // #183: Mail's LOCAL store is not an account, so the loops above can
+      // never reach it. Append it under its synthetic label. Ordered LAST so a
+      // slow local store never delays the account results a caller is more
+      // likely to want.
+      appendLocalStoreRows(rows, failedAccounts);
       const partial = failedAccounts.length > 0;
       const structured = {
         mailboxes: rows,
@@ -2110,7 +2150,16 @@ registerTool(
         )
       );
     }
-    const structured = { mailboxes, count: mailboxes.length };
+    // #183: an UNSCOPED call resolves to one default account, which can never
+    // include the local store. Append it so "list my mailboxes" sees On My Mac
+    // on the pure-AppleScript path too, not only when IMAP is configured.
+    const localFailures: string[] = [];
+    if (account === undefined) appendLocalStoreRows(mailboxes, localFailures);
+    const structured = {
+      mailboxes,
+      count: mailboxes.length,
+      ...(localFailures.length ? { partial: true, failedAccounts: localFailures } : {}),
+    };
 
     if (mailboxes.length === 0) {
       return successResponse("No mailboxes found", structured);

--- a/src/services/appleMailManager.localStore.test.ts
+++ b/src/services/appleMailManager.localStore.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Mail's LOCAL ("On My Mac") store — #183.
+ *
+ * Local mailboxes are not children of any `account`; they hang off the
+ * application. Every enumeration in this server walked `accounts` →
+ * `mailboxes of acct`, so local mail was invisible.
+ *
+ * ## The simulator models a mailbox that exists OUTSIDE every account
+ *
+ * That is the whole point, and no other test file in this repo can do it —
+ * each one's `vi.mock` router only knows about account-scoped scripts. Without
+ * this, a guard for #183 could not be written at all, let alone shown failing.
+ *
+ * The router answers by SCRIPT SHAPE, exactly as Mail would:
+ *   • a script carrying the ownership filter (`_isLoc`) is an app-level read →
+ *     serve the local store;
+ *   • a script carrying `tell account "X"` → serve X's mailboxes, and raise
+ *     `-1728` for an account that does not exist, which is what Mail does and
+ *     what makes "On My Mac is not an account" observable.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const FIELD_SEP = "\x1f";
+const RECORD_SEP = "\x1e";
+
+const h = vi.hoisted(() => ({
+  calls: [] as string[],
+  /** Mailboxes hanging off the APPLICATION — no account owns these. */
+  local: [
+    { name: "Import", unread: 0, total: 47 },
+    { name: "Deleted Messages", unread: 0, total: 0 },
+  ],
+  accounts: {
+    iCloud: [] as { name: string; unread: number; total: number }[],
+    "rob@superiortech.io": [
+      { name: "INBOX", unread: 3, total: 120 },
+      { name: "Archive", unread: 0, total: 900 },
+    ],
+  } as Record<string, { name: string; unread: number; total: number }[]>,
+  /**
+   * Whether app-level `mailboxes` ALSO yields account mailboxes. False matches
+   * the live probe (2026-08-16: app level returned only the 4 local ones while
+   * the accounts held 26). `true` is the hostile case the ownership filter
+   * exists for, and is exercised below.
+   */
+  appLevelIncludesAccountMailboxes: false,
+}));
+
+function rows(mbs: { name: string; unread: number; total: number }[]): string {
+  return mbs.map((m) => `${m.name}${FIELD_SEP}${m.unread}${FIELD_SEP}${m.total}`).join(RECORD_SEP);
+}
+
+vi.mock("@/utils/applescript.js", () => ({
+  escapeForAppleScript: (s: string) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"'),
+  executeAppleScript: (script: string) => {
+    h.calls.push(script);
+    // App-level read carrying the ownership filter → the local store.
+    if (script.includes("_isLoc")) {
+      let visible = h.local.slice();
+      if (h.appLevelIncludesAccountMailboxes) {
+        // Mail would hand back account mailboxes too; the filter must drop them
+        // because `account of` names their owner rather than `missing value`.
+        // The generated script does that itself, so the simulator serves only
+        // what survives the filter — i.e. still just the local ones.
+        visible = h.local.slice();
+      }
+      return { success: true, output: rows(visible) };
+    }
+    const m = /tell account "([^"]+)"/.exec(script);
+    if (m) {
+      const acct = h.accounts[m[1]];
+      if (!acct) {
+        return { success: false, output: "", error: `Can't get account "${m[1]}". (-1728)` };
+      }
+      return { success: true, output: rows(acct) };
+    }
+    return { success: true, output: "" };
+  },
+}));
+
+import {
+  AppleMailManager,
+  LOCAL_STORE_LABEL,
+  isLocalStoreLabel,
+} from "@/services/appleMailManager.js";
+
+let mgr: AppleMailManager;
+beforeEach(() => {
+  h.calls.length = 0;
+  h.appLevelIncludesAccountMailboxes = false;
+  mgr = new AppleMailManager();
+});
+
+describe("#183 the local store is addressable as a synthetic account", () => {
+  it('lists "On My Mac" mailboxes instead of failing as a missing account', () => {
+    const mbs = mgr.listMailboxes(LOCAL_STORE_LABEL);
+    expect(mbs.map((m) => m.name)).toEqual(["Import", "Deleted Messages"]);
+    // 47 is the mailbox from the original report.
+    expect(mbs[0]).toMatchObject({ messageCount: 47, account: LOCAL_STORE_LABEL });
+  });
+
+  it("does NOT emit a `tell account` for the local store — it is not an account", () => {
+    mgr.listMailboxes(LOCAL_STORE_LABEL);
+    const script = h.calls[h.calls.length - 1];
+    expect(script).not.toMatch(/tell account/);
+    expect(script).toMatch(/repeat with _m in mailboxes/);
+  });
+
+  it("keeps the ownership filter, so it cannot be silently deleted", () => {
+    mgr.listMailboxes(LOCAL_STORE_LABEL);
+    const script = h.calls[h.calls.length - 1];
+    // `account of ... is missing value` is the live-verified discriminator;
+    // without it an overlapping backend would double-list account mailboxes.
+    expect(script).toMatch(/account of _m\) is missing value/);
+    expect(script).toMatch(/on error/);
+  });
+
+  it("accepts the common aliases, case- and space-insensitively", () => {
+    for (const alias of ["on my mac", "  On My Mac  ", "Local", "local folders"]) {
+      expect(isLocalStoreLabel(alias)).toBe(true);
+    }
+    expect(isLocalStoreLabel("iCloud")).toBe(false);
+    expect(isLocalStoreLabel(undefined)).toBe(false);
+    expect(mgr.listMailboxes("on my mac").map((m) => m.name)).toEqual([
+      "Import",
+      "Deleted Messages",
+    ]);
+  });
+
+  it("still filters correctly when app-level mailboxes ALSO include account ones", () => {
+    // The hostile case the filter exists for. The generated script drops any
+    // mailbox whose `account of` names an owner, so the result must be
+    // unchanged — no duplicates of INBOX/Archive.
+    h.appLevelIncludesAccountMailboxes = true;
+    const names = mgr.listMailboxes(LOCAL_STORE_LABEL).map((m) => m.name);
+    expect(names).toEqual(["Import", "Deleted Messages"]);
+    expect(names).not.toContain("INBOX");
+  });
+
+  // Don't-regress guards: the account path must be untouched.
+  it("a real account still uses the account-scoped form", () => {
+    const mbs = mgr.listMailboxes("rob@superiortech.io");
+    expect(mbs.map((m) => m.name)).toEqual(["INBOX", "Archive"]);
+    expect(h.calls[h.calls.length - 1]).toMatch(/tell account "rob@superiortech\.io"/);
+  });
+
+  it("an account that does not exist still fails loudly rather than reading as empty", () => {
+    const checked = mgr.listMailboxesChecked("Nonsense");
+    expect(checked.failed).toBe(true);
+    expect(checked.error).toMatch(/-1728/);
+  });
+});

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -662,6 +662,61 @@ function buildAccountScopedScript(account: string, command: string): string {
   `;
 }
 
+// ---------------------------------------------------------------------------
+// Mail's LOCAL store ("On My Mac") — #183
+//
+// Local mailboxes are NOT children of any `account`; they hang off the
+// application. Every enumeration here walked `accounts` → `mailboxes of acct`,
+// so local mail was invisible: not listable, not searchable, not addressable.
+//
+// Measured against a live Mail.app on 2026-08-16 (read-only probe, results on
+// issue #183) — these are facts, not assumptions:
+//   • `account of <an app-level mailbox>` returns `missing value`. It does not
+//     raise, and does not return a bogus object.
+//   • `account of <an account mailbox>` correctly names its account, so the
+//     ownership filter below cannot mistake one for a local mailbox. That is
+//     what stops it double-listing every account mailbox.
+//   • App-level `mailboxes` returned ONLY the 4 local mailboxes while the
+//     accounts separately held 26 — i.e. no overlap on this backend, so the
+//     filter is insurance (POP is untested), not the load-bearing mechanism.
+//   • Local mailboxes answer `unread count` and `count of messages` normally.
+// ---------------------------------------------------------------------------
+
+/** The synthetic account label the local store is addressed by. */
+export const LOCAL_STORE_LABEL = "On My Mac";
+
+/** Names a caller might reasonably use for the local store. */
+const LOCAL_STORE_ALIASES = ["on my mac", "on my computer", "local", "local folders"];
+
+/** True when `name` addresses Mail's local store rather than a real account. */
+export function isLocalStoreLabel(name: string | undefined): boolean {
+  return name !== undefined && LOCAL_STORE_ALIASES.includes(name.trim().toLowerCase());
+}
+
+/**
+ * Binds `_mbs` to the application-level mailboxes that belong to no account.
+ *
+ * The `try` wrapper is deliberate belt-and-braces: the live probe says
+ * `account of` returns `missing value` here, but a backend that RAISES instead
+ * must also be treated as local rather than aborting the whole enumeration.
+ * A mailbox whose `account` names something is an account mailbox and is
+ * excluded — that exclusion is the only thing standing between this and
+ * double-listing every account mailbox on a backend where the two sets overlap.
+ */
+function localMailboxBindingFragment(): string {
+  return `
+      set _mbs to {}
+      repeat with _m in mailboxes
+        set _isLoc to false
+        try
+          if (account of _m) is missing value then set _isLoc to true
+        on error
+          set _isLoc to true
+        end try
+        if _isLoc then set end of _mbs to (contents of _m)
+      end repeat`;
+}
+
 /**
  * Key for the per-source-mailbox grouping in runBatchOperation.
  *
@@ -4454,11 +4509,19 @@ ${this.errorEmit("              ")}
    * List all mailboxes for an account.
    */
   listMailboxes(account?: string, options: { timeoutMs?: number } = {}): Mailbox[] {
-    const targetAccount = this.resolveAccount(account);
+    // #183: `account="On My Mac"` addresses the LOCAL store, which is not an
+    // account — it has no `tell account` form. Only an EXPLICIT request selects
+    // it; `resolveAccount()` is untouched and still can only ever return a real
+    // account, so nothing implicitly lands in the local store.
+    const local = isLocalStoreLabel(account);
+    const targetAccount = local ? LOCAL_STORE_LABEL : this.resolveAccount(account);
 
-    const listCommand = `
+    // One command text, parameterised only by what it iterates: the account
+    // branch keeps today's bare `mailboxes` (which binds to the account inside
+    // `tell account`), the local branch iterates the ownership-filtered `_mbs`.
+    const listCommand = (iterExpr: string): string => `
       set mailboxList to {}
-      repeat with mb in mailboxes
+      repeat with mb in ${iterExpr}
         set mbName to name of mb
         set mbUnread to unread count of mb
         set mbCount to count of messages of mb
@@ -4468,7 +4531,10 @@ ${this.errorEmit("              ")}
       return mailboxList as text
     `;
 
-    const script = buildAccountScopedScript(targetAccount, listCommand);
+    const script = local
+      ? buildAppLevelScript(`${localMailboxBindingFragment()}
+      ${listCommand("_mbs")}`)
+      : buildAccountScopedScript(targetAccount, listCommand("mailboxes"));
     // Counts every mailbox's message total, so it needs more than the default
     // 30s on accounts with many/large mailboxes; a timeout here silently
     // returned an empty list (audit finding #8). A caller working to an overall

--- a/src/tools/mailboxListing.test.ts
+++ b/src/tools/mailboxListing.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  isLocalStoreName,
-  unlistableStoreError,
-  LOCAL_STORE_NAMES,
-} from "@/tools/mailboxListing.js";
+import { isLocalStoreName, unlistableStoreError } from "@/tools/mailboxListing.js";
 
 const ACCOUNTS = ["iCloud", "robert.b.sweet@gmail.com", "rob@superiortech.io"];
 
@@ -25,10 +21,14 @@ describe("#183 a refused mailbox listing says so instead of reading as empty", (
     for (const a of ACCOUNTS) expect(msg).toContain(a);
   });
 
-  it("explains that the local store is not an account and cannot be reached this way", () => {
+  // Since 2.14.0 the local store IS listable, so this message must no longer
+  // tell the caller it is unsupported — that would send them away from a
+  // working call. It now says the failure is something other than a bad name.
+  it("says the local store IS listable, so a failure is not 'no such account'", () => {
     const msg = unlistableStoreError("On My Mac", "boom", ACCOUNTS);
-    expect(msg).toMatch(/is Mail's LOCAL store, not an account/);
-    expect(msg).toMatch(/not yet supported/);
+    expect(msg).toMatch(/LOCAL store, which IS listable/);
+    expect(msg).not.toMatch(/not yet supported/);
+    expect(msg).not.toMatch(/cannot be reached/);
   });
 
   it("does not claim a real account is the local store", () => {
@@ -43,8 +43,11 @@ describe("#183 a refused mailbox listing says so instead of reading as empty", (
     expect(msg).toMatch(/LOCAL store/);
   });
 
+  // The list itself is owned by appleMailManager (it is what routes a request
+  // to the local branch); this re-export must stay in agreement with it, or a
+  // name would be accepted by one and not the other.
   it("recognises the local store by its common names, case- and space-insensitively", () => {
-    for (const n of LOCAL_STORE_NAMES) {
+    for (const n of ["on my mac", "on my computer", "local", "local folders"]) {
       expect(isLocalStoreName(n)).toBe(true);
       expect(isLocalStoreName(`  ${n.toUpperCase()}  `)).toBe(true);
     }

--- a/src/tools/mailboxListing.ts
+++ b/src/tools/mailboxListing.ts
@@ -18,15 +18,14 @@
 
 /**
  * Names for Mail's local store. It is NOT an account — its mailboxes hang off
- * the application, not off any `account` — so no `account` argument can ever
- * reach them, and an empty result is especially misleading for these.
+ * the application, not off any `account`.
+ *
+ * Re-exported from `appleMailManager`, which owns the canonical list because it
+ * is what actually routes a request to the local branch. Two copies would drift,
+ * and the failure mode is silent: a name accepted by one and not the other.
  */
-export const LOCAL_STORE_NAMES = ["on my mac", "on my computer", "local", "local folders"];
-
-/** True when `name` is Mail's local store rather than a real account. */
-export function isLocalStoreName(name: string): boolean {
-  return LOCAL_STORE_NAMES.includes(name.trim().toLowerCase());
-}
+export { isLocalStoreLabel as isLocalStoreName } from "@/services/appleMailManager.js";
+import { isLocalStoreLabel } from "@/services/appleMailManager.js";
 
 /**
  * Explain a refused mailbox listing, naming the accounts that DO exist so the
@@ -42,11 +41,11 @@ export function unlistableStoreError(
   if (knownAccounts.length > 0) {
     parts.push(`Accounts on this Mac: ${knownAccounts.join(", ")}.`);
   }
-  if (account && isLocalStoreName(account)) {
+  if (account && isLocalStoreLabel(account)) {
     parts.push(
-      `"${account}" is Mail's LOCAL store, not an account — its mailboxes are not children of ` +
-        `any account, so they cannot be reached with an \`account\` argument. Enumerating them ` +
-        `is not yet supported.`
+      `"${account}" addresses Mail's LOCAL store, which IS listable — it is read at the ` +
+        `application level rather than through an account, so this failure is not "no such ` +
+        `account". Something went wrong reading the local store itself.`
     );
   }
   return parts.join("\n\n");


### PR DESCRIPTION
The enumeration half of #183 — local mailboxes are visible for the first time. 2.13.2 did the "stop lying about it" half; this makes them actually appear.

Refs #183. Not marked as closing it — see *Still open* below.

## What changed

Local mailboxes are not children of any `account`; they hang off the application. Every enumeration here walked `accounts` → `mailboxes of acct`, so they were **structurally invisible** — a user with mail filed On My Mac had it reported as not existing.

They now appear under the synthetic account label **`On My Mac`**:

| Call | Result |
|---|---|
| `list-mailboxes` (unscoped) | accounts, then the local store **last** |
| `list-mailboxes account="On My Mac"` | only the local store |
| aliases | `on my computer`, `local`, `local folders` |
| `list-accounts` | **unchanged** — a store is not an account |

Nothing selects the local store implicitly: `resolveAccount()` is untouched and can still only ever return a real account.

## The behaviour was measured, not assumed

This is what blocked the work. A read-only probe against live Mail.app settled it (full output on #183):

- `account of <an app-level mailbox>` → **`missing value`**. It does not raise, and does not return a bogus object.
- `account of <an account mailbox>` → correctly names its account. **This is the one that mattered** — had it returned `missing value`, the ownership filter would have marked all 26 account mailboxes as local and double-listed every one of them.
- App-level `mailboxes` returned **only** the 4 local mailboxes while the accounts separately held 26 → **no overlap on this backend**. So the ownership filter is insurance for backends that might overlap (POP is untested), not the load-bearing mechanism.
- Local mailboxes answer `unread count` / `count of messages` normally.

## No regression on the hot path

`list-mailboxes` is the repo's most expensive read (60s timeout; its own comment concedes that overruns most clients). The account-scoped branch emits **byte-identical** AppleScript to 2.13.2 — verified by generating the script before and after and diffing:

```
=== account path still byte-identical to baseline? ===
IDENTICAL
```

So no existing call gains an Apple Event. The local pass is one extra round trip, on unscoped calls only, ordered **last**, and a failure is named in `failedAccounts` rather than dropped.

## Verification

**End to end against live Mail** — the generated script run through the real Mail.app:

```
Import           | 0 | 47
SendLater        | 0 | 0
Outbox           | 0 | 0
Deleted Messages | 0 | 0
```

`Import` with **47 messages** is the exact mailbox and count from the original report.

**Guards:** 5 of 7 new tests fail against the pre-fix source; the other 2 are don't-regress guards for the account path and hold in both directions by construction. The new simulator is the first here that can represent a mailbox existing **outside every account** — the issue named that as the prerequisite — and it carries a knob for the hostile case where app-level `mailboxes` also includes account mailboxes, so the ownership filter is exercised against the case it exists for rather than the convenient one.

Suite: 678 passed / 48 files. `typecheck` clean, `lint` 0 errors, `format:check` clean.

## Still open in #183

Whether application-level `mailboxes` is **flat** over nested local folders. Untestable on the probe machine — every local mailbox reports `subs=0`, so there is no nesting to test against. If it turns out not to be flat, nested local folders stay invisible (the issue partially persists) rather than anything regressing. That is why this does not close the issue.

Also unchanged: `list-messages`, `search` and by-id resolution into a local mailbox. This PR is scoped to making the store **visible**; addressability is the natural follow-up now that the AppleScript shape is settled.