### PR TITLE
fix(audit): a stale-high count no longer disables the collateral snapshot (#187)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 ## [Unreleased]
 
+## [2.14.1] - 2026-08-16
+
+Closes #187 — the stale-**HIGH** counterpart to #179, and the direction #155
+actually evidences.
+
+### Fixed
+
+- **A mailbox count that read high could silently switch the collateral
+  snapshot off.** An out-of-range AppleScript range **raises as a whole** rather
+  than clamping, so a count that over-reports makes its slices fail. On a
+  mailbox smaller than one chunk (default 250) there is only **one** slice: it
+  covered everything, it raised, `_sPairs` ended up empty, and the status
+  collapsed to `unavailable` — with no holes recorded and no warning.
+
+  Every reading in #155 is an undercount of what left, i.e. an after-count
+  *higher* than the mailbox truly holds. So the one mechanism that can name an
+  unrequested departure was disabling itself precisely in the scenario it exists
+  for, and saying nothing while it did. Regression from #177 (2.10.33);
+  v2.10.32 read the mailbox unbounded and could not over-request.
+
+  The snapshot now establishes a bound that actually **exists** before slicing.
+  If the count's last position is readable the count is not high and this costs
+  exactly **one** probe. Otherwise it binary-searches the true end — `O(log n)`,
+  measured live at 7–9 probes for counts overstated by 3 to 253.
+
+### Added
+
+- **`countStale` on the collateral diff — the staleness is now measured, not
+  just survived.** When the clamp fires, the mailbox's true length is reported
+  alongside the count that disagreed with it:
+
+  ```json
+  { "countStale": [{ "phase": "after", "measuredLength": 4 }] }
+  ```
+
+  Compare it with the same mailbox's `countDelta` `before`/`after` to see how
+  far the count lagged. This is direct evidence of the #155 staleness from the
+  one place that can observe it for free. It is **absent** when the count's last
+  position was readable — that means "no evidence it was high", never "the count
+  was correct".
+
+### Internal
+
+- The forensics simulator models the clamp (gated on the generated script
+  actually containing it, like every other capability there), so a script
+  without the clamp still reproduces the old collapse and the guards cannot pass
+  vacuously.
+- The #179 overrun probe is now bounded by the **clamped** bound rather than the
+  raw count — otherwise, after a high count was clamped down, it would probe
+  into the void and could re-raise the very truncation flag the clamp had just
+  disproved.
+
 ## [2.14.0] - 2026-08-16
 
 Mail's local "On My Mac" mailboxes are visible for the first time. This is the

--- a/build/index.js
+++ b/build/index.js
@@ -79470,16 +79470,61 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         set _sMiss to ""
         set _sPairs to {}
         set _sChunk to ${chunk}
+        -- The mailbox's MEASURED length, emitted only when it disagrees with the
+        -- count (#187). -1 = "not measured", which is the normal case: the probe
+        -- only runs a binary search when the count's last position is unreadable.
+        -- Initialised here, not in the else-branch, or the skipped/unavailable
+        -- paths would reference an unbound variable when emitting.
+        set _sTrue to -1
         if ${countVar} < 0 then
           set _sStatus to "unavailable"
         else if ${countVar} > ${max} then
           set _sStatus to "skipped"
           set _sPayload to "mailbox holds " & (${countVar} as string) & " messages, above ${AUDIT_SNAPSHOT_MAX_ENV}=${max}"
         else
+          -- #187: the count can read HIGH, and an out-of-range range RAISES as
+          -- a whole rather than clamping. On a mailbox smaller than one chunk
+          -- there is only ONE slice, so a high count made it fail entirely:
+          -- _sPairs stayed empty, the status collapsed to "unavailable", and
+          -- the record carried no holes and no warning. The collateral
+          -- instrument switched itself off in exactly the stale direction #155
+          -- evidences, silently.
+          --
+          -- So establish a bound that actually EXISTS before slicing. If the
+          -- last position the count claims is readable, the count is not high
+          -- and this costs one probe. Otherwise binary-search the true end,
+          -- which is O(log n) probes and also MEASURES how stale the count is.
+          set _sBound to ${countVar}
+          if _sBound > 0 then
+            set _sEndOk to false
+            try
+              get id of message _sBound of ${mbVar}
+              set _sEndOk to true
+            end try
+            if not _sEndOk then
+              set _sLoB to 0
+              set _sHiB to _sBound
+              repeat while (_sHiB - _sLoB) > 1
+                set _sMid to (_sLoB + _sHiB) div 2
+                set _sMidOk to false
+                try
+                  get id of message _sMid of ${mbVar}
+                  set _sMidOk to true
+                end try
+                if _sMidOk then
+                  set _sLoB to _sMid
+                else
+                  set _sHiB to _sMid
+                end if
+              end repeat
+              set _sBound to _sLoB
+              set _sTrue to _sLoB
+            end if
+          end if
           set _sLo to 1
-          repeat while _sLo <= ${countVar}
+          repeat while _sLo <= _sBound
             set _sHi to _sLo + _sChunk - 1
-            if _sHi > ${countVar} then set _sHi to ${countVar}
+            if _sHi > _sBound then set _sHi to _sBound
             set _sGot to false
             repeat with _sTry from 1 to ${SNAPSHOT_SLICE_ATTEMPTS}
               set _sIds to {}
@@ -79537,7 +79582,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           -- PARTIAL under the existing rules and withholds the halves a
           -- truncation would poison.
           try
-            set _sOverId to ((id of message (${countVar} + 1) of ${mbVar}) as string)
+            set _sOverId to ((id of message (_sBound + 1) of ${mbVar}) as string)
             -- A specifier that CLAMPS rather than raising hands back the LAST
             -- message instead of failing. That is not evidence of a truncation,
             -- so only an id this enumeration did not already record counts.
@@ -79547,7 +79592,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             end repeat
             if not _sSeen then
               if _sMiss is not "" then set _sMiss to _sMiss & ","
-              set _sMiss to _sMiss & ((${countVar} + 1) as string) & "-end"
+              set _sMiss to _sMiss & ((_sBound + 1) as string) & "-end"
             end if
           end try
           if _sMiss is not "" then
@@ -79562,7 +79607,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           set _sPayload to _sPairs as string
           set AppleScript's text item delimiters to _sTid
         end if
-        set _out to _out & "${SNAP_TAG}${FIELD_SEP}" & ${acctExpr} & "${FIELD_SEP}" & ${mbExpr} & "${FIELD_SEP}${phase}${FIELD_SEP}" & _sStatus & "${FIELD_SEP}" & _sPayload & "${FIELD_SEP}" & _sMiss & "${RECORD_SEP}"`;
+        set _out to _out & "${SNAP_TAG}${FIELD_SEP}" & ${acctExpr} & "${FIELD_SEP}" & ${mbExpr} & "${FIELD_SEP}${phase}${FIELD_SEP}" & _sStatus & "${FIELD_SEP}" & _sPayload & "${FIELD_SEP}" & _sMiss & "${FIELD_SEP}" & (_sTrue as string) & "${RECORD_SEP}"`;
   }
   /**
    * AppleScript capturing the message the op is ABOUT to touch into `_pre`,
@@ -79623,13 +79668,15 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         continue;
       }
       if (f[0] === SNAP_TAG) {
+        const measured = f[7] !== void 0 && f[7] !== "" ? Number(f[7]) : -1;
         snaps.push({
           account: f[1] ?? "",
           mailbox: f[2] ?? "",
           phase: f[3] === "after" ? "after" : "before",
           status: f[4] ?? "",
           payload: f[5] ?? "",
-          miss: f[6] ?? ""
+          miss: f[6] ?? "",
+          ...Number.isFinite(measured) && measured >= 0 ? { measuredLength: measured } : {}
         });
         continue;
       }
@@ -79813,6 +79860,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       const unrequested = disappeared.filter(
         (e) => !requestedNumericIds.has(canonicalNumericId(e.id))
       );
+      const countStale = [b, a].filter((s) => s.measuredLength !== void 0).map((s) => ({ phase: s.phase, measuredLength: s.measuredLength }));
       const holes = [b, a].filter((s) => s.miss !== "").map((s) => ({ phase: s.phase, ranges: s.miss }));
       if (holes.length === 0) {
         collateral.push({
@@ -79821,7 +79869,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           snapshot: "ok",
           disappeared,
           unrequested,
-          appeared
+          appeared,
+          ...countStale.length ? { countStale } : {}
         });
         continue;
       }
@@ -79833,6 +79882,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         account: g.account,
         mailbox: g.mailbox,
         snapshot: "partial",
+        ...countStale.length ? { countStale } : {},
         skipReason: `Mail would not read ${holes.map((h) => `${h.ranges} (${h.phase})`).join(", ")} of this mailbox, so the snapshot has a hole in it. ` + (derivable.length > 0 ? `Still derivable and reported: ${derivable.join(" and ")}. ` : `Neither half of the diff is derivable from it. `) + `Anything the unread range could refute is omitted rather than guessed \u2014 an absent field here means "not computable", not "empty".`,
         unobserved: holes,
         ...a.miss === "" ? { disappeared, unrequested } : {},

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.14.0"
+        "apple-mail-mcp@2.14.1"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleMailManager.forensics.test.ts
+++ b/src/services/appleMailManager.forensics.test.ts
@@ -212,6 +212,13 @@ function simulateDestructive(script: string): string {
   })();
   /** Whether the script probes one position past the count bound (#179). */
   const probesPastBound = script.includes("set _sOverId to");
+  /**
+   * Whether the script establishes a bound that actually EXISTS before slicing,
+   * binary-searching the true length when the count's last position is
+   * unreadable (#187). Answered by script shape like every other capability
+   * here, so a script WITHOUT the clamp still reproduces the old collapse.
+   */
+  const clampsHighCount = script.includes("set _sBound to");
 
   /**
    * `reportedCount` is the count the generated script just put in `_cb`/`_ca`
@@ -244,15 +251,27 @@ function simulateDestructive(script: string): string {
         `mailbox holds ${reportedCount} messages, above APPLE_MAIL_MCP_AUDIT_SNAPSHOT_MAX=${snapMax}${RECORD_SEP}`;
       return;
     }
+    // #187: the script establishes a bound that EXISTS before slicing. If the
+    // count's last position is unreadable it binary-searches the true length
+    // and slices to that instead, so a stale-HIGH count no longer makes the
+    // only slice of a small mailbox raise and collapse the whole snapshot.
+    // `measured` is emitted only when the clamp actually fired.
+    let bound = reportedCount;
+    let measured = -1;
+    if (clampsHighCount && reportedCount > state.length) {
+      bound = state.length;
+      measured = state.length;
+    }
+
     // Exactly the requests the script issues: one whole-mailbox read when it
     // names no chunk size, otherwise consecutive slices of that size — both
     // bounded by the REPORTED count, as the script's own loop is.
     const slices: [number, number][] = [];
     if (snapChunk === null) {
-      if (reportedCount > 0) slices.push([1, reportedCount]);
+      if (bound > 0) slices.push([1, bound]);
     } else {
-      for (let lo = 1; lo <= reportedCount; lo += snapChunk) {
-        slices.push([lo, Math.min(lo + snapChunk - 1, reportedCount)]);
+      for (let lo = 1; lo <= bound; lo += snapChunk) {
+        slices.push([lo, Math.min(lo + snapChunk - 1, bound)]);
       }
     }
     const observed: FakeMsg[] = [];
@@ -278,12 +297,12 @@ function simulateDestructive(script: string): string {
     // issues it — the simulator serves the requests the script makes, so this
     // stays absent (and the truncation stays invisible) against a script
     // without the probe.
-    if (probesPastBound && state.length > reportedCount) {
-      const probed = state[reportedCount];
+    if (probesPastBound && state.length > bound) {
+      const probed = state[bound];
       // The script only counts an id it has not already recorded, so a clamping
       // specifier handing back the last message is not read as a truncation.
       const already = observed.some((m) => m.id === probed.id);
-      if (!already) missed.push(`${reportedCount + 1}-end`);
+      if (!already) missed.push(`${bound + 1}-end`);
     }
     const status = missed.length === 0 ? "ok" : observed.length === 0 ? "unavailable" : "partial";
     const payload = observed
@@ -291,7 +310,7 @@ function simulateDestructive(script: string): string {
       .join(SNAP_ITEM);
     out +=
       `${SNAP_TAG}${FIELD_SEP}${acct}${FIELD_SEP}${mbox}${FIELD_SEP}${phase}${FIELD_SEP}${status}` +
-      `${FIELD_SEP}${payload}${FIELD_SEP}${missed.join(",")}${RECORD_SEP}`;
+      `${FIELD_SEP}${payload}${FIELD_SEP}${missed.join(",")}${FIELD_SEP}${measured}${RECORD_SEP}`;
   };
 
   // The count and the snapshot are consecutive Apple Events in ONE script with
@@ -896,6 +915,51 @@ describe("collateral identification (opt-in, gated on the audit log)", () => {
     expect(c.disappeared ?? []).not.toContainEqual({ id: "75815", messageId: "e@example.com" });
     // "ok" asserts both snapshots were read IN FULL, which is false here.
     expect(c.snapshot).not.toBe("ok");
+  });
+
+  // =========================================================================
+  // #187 — the stale-HIGH counterpart to #179. An out-of-range range RAISES as
+  // a whole, so a count that over-reports makes its slices fail. On a mailbox
+  // smaller than one chunk there is only ONE slice: it covered everything, it
+  // raised, _sPairs ended up empty and the snapshot collapsed to "unavailable"
+  // with NO holes and NO warning. The collateral instrument switched itself off
+  // in exactly the stale direction #155 evidences, silently.
+  // =========================================================================
+  it("survives a stale-HIGH count instead of collapsing to `unavailable`", () => {
+    process.env[AUDIT_LOG_ENV] = auditFile();
+    // 5 messages, one really leaves -> 4 remain, but Mail's count says 7.
+    h.staleAfterCountBy = 3;
+    mgr.batchDeleteMessages(["75811"], { account: h.account, mailbox: h.mailboxName });
+    const report = mgr.consumeLastForensics()!;
+    const [c] = report.collateral;
+
+    // The whole point: the over-request must not disable the instrument.
+    expect(c.snapshot).not.toBe("unavailable");
+    expect(c.snapshot).toBe("ok");
+    // And it still does its actual job — the one requested message is named,
+    // and nothing innocent is.
+    expect(c.disappeared).toEqual([{ id: "75811", messageId: "a@example.com" }]);
+    expect(c.unrequested).toEqual([]);
+  });
+
+  it("REPORTS the measured length when the count read high — evidence, not silence", () => {
+    process.env[AUDIT_LOG_ENV] = auditFile();
+    h.staleAfterCountBy = 3;
+    mgr.batchDeleteMessages(["75811"], { account: h.account, mailbox: h.mailboxName });
+    const [c] = mgr.consumeLastForensics()!.collateral;
+    // 4 messages really remained while the count claimed 7. That gap is direct
+    // evidence of the staleness #155 is about, so it must reach the caller.
+    expect(c.countStale).toEqual([{ phase: "after", measuredLength: 4 }]);
+  });
+
+  it("says NOTHING about count staleness when the count is accurate", () => {
+    // A cry-wolf guard: the measurement is emitted only when the clamp fires.
+    process.env[AUDIT_LOG_ENV] = auditFile();
+    h.staleAfterCountBy = 0;
+    mgr.batchDeleteMessages(["75811"], { account: h.account, mailbox: h.mailboxName });
+    const [c] = mgr.consumeLastForensics()!.collateral;
+    expect(c.snapshot).toBe("ok");
+    expect(c.countStale).toBeUndefined();
   });
 
   it("RECORDS the skip when the mailbox is above the ceiling", () => {

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -1246,16 +1246,61 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         set _sMiss to ""
         set _sPairs to {}
         set _sChunk to ${chunk}
+        -- The mailbox's MEASURED length, emitted only when it disagrees with the
+        -- count (#187). -1 = "not measured", which is the normal case: the probe
+        -- only runs a binary search when the count's last position is unreadable.
+        -- Initialised here, not in the else-branch, or the skipped/unavailable
+        -- paths would reference an unbound variable when emitting.
+        set _sTrue to -1
         if ${countVar} < 0 then
           set _sStatus to "unavailable"
         else if ${countVar} > ${max} then
           set _sStatus to "skipped"
           set _sPayload to "mailbox holds " & (${countVar} as string) & " messages, above ${AUDIT_SNAPSHOT_MAX_ENV}=${max}"
         else
+          -- #187: the count can read HIGH, and an out-of-range range RAISES as
+          -- a whole rather than clamping. On a mailbox smaller than one chunk
+          -- there is only ONE slice, so a high count made it fail entirely:
+          -- _sPairs stayed empty, the status collapsed to "unavailable", and
+          -- the record carried no holes and no warning. The collateral
+          -- instrument switched itself off in exactly the stale direction #155
+          -- evidences, silently.
+          --
+          -- So establish a bound that actually EXISTS before slicing. If the
+          -- last position the count claims is readable, the count is not high
+          -- and this costs one probe. Otherwise binary-search the true end,
+          -- which is O(log n) probes and also MEASURES how stale the count is.
+          set _sBound to ${countVar}
+          if _sBound > 0 then
+            set _sEndOk to false
+            try
+              get id of message _sBound of ${mbVar}
+              set _sEndOk to true
+            end try
+            if not _sEndOk then
+              set _sLoB to 0
+              set _sHiB to _sBound
+              repeat while (_sHiB - _sLoB) > 1
+                set _sMid to (_sLoB + _sHiB) div 2
+                set _sMidOk to false
+                try
+                  get id of message _sMid of ${mbVar}
+                  set _sMidOk to true
+                end try
+                if _sMidOk then
+                  set _sLoB to _sMid
+                else
+                  set _sHiB to _sMid
+                end if
+              end repeat
+              set _sBound to _sLoB
+              set _sTrue to _sLoB
+            end if
+          end if
           set _sLo to 1
-          repeat while _sLo <= ${countVar}
+          repeat while _sLo <= _sBound
             set _sHi to _sLo + _sChunk - 1
-            if _sHi > ${countVar} then set _sHi to ${countVar}
+            if _sHi > _sBound then set _sHi to _sBound
             set _sGot to false
             repeat with _sTry from 1 to ${SNAPSHOT_SLICE_ATTEMPTS}
               set _sIds to {}
@@ -1313,7 +1358,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           -- PARTIAL under the existing rules and withholds the halves a
           -- truncation would poison.
           try
-            set _sOverId to ((id of message (${countVar} + 1) of ${mbVar}) as string)
+            set _sOverId to ((id of message (_sBound + 1) of ${mbVar}) as string)
             -- A specifier that CLAMPS rather than raising hands back the LAST
             -- message instead of failing. That is not evidence of a truncation,
             -- so only an id this enumeration did not already record counts.
@@ -1323,7 +1368,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             end repeat
             if not _sSeen then
               if _sMiss is not "" then set _sMiss to _sMiss & ","
-              set _sMiss to _sMiss & ((${countVar} + 1) as string) & "-end"
+              set _sMiss to _sMiss & ((_sBound + 1) as string) & "-end"
             end if
           end try
           if _sMiss is not "" then
@@ -1338,7 +1383,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           set _sPayload to _sPairs as string
           set AppleScript's text item delimiters to _sTid
         end if
-        set _out to _out & "${SNAP_TAG}${FIELD_SEP}" & ${acctExpr} & "${FIELD_SEP}" & ${mbExpr} & "${FIELD_SEP}${phase}${FIELD_SEP}" & _sStatus & "${FIELD_SEP}" & _sPayload & "${FIELD_SEP}" & _sMiss & "${RECORD_SEP}"`;
+        set _out to _out & "${SNAP_TAG}${FIELD_SEP}" & ${acctExpr} & "${FIELD_SEP}" & ${mbExpr} & "${FIELD_SEP}${phase}${FIELD_SEP}" & _sStatus & "${FIELD_SEP}" & _sPayload & "${FIELD_SEP}" & _sMiss & "${FIELD_SEP}" & (_sTrue as string) & "${RECORD_SEP}"`;
   }
 
   /**
@@ -1405,6 +1450,9 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       payload: string;
       /** 1-based position ranges this phase could not read ("251-500,900-1000"). */
       miss: string;
+      /** #187: the mailbox's MEASURED length, present only when it disagreed
+       *  with the count Mail reported — i.e. the count read HIGH. */
+      measuredLength?: number;
     }[];
   } {
     const byId = new Map<string, BatchOperationResult>();
@@ -1428,6 +1476,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       status: string;
       payload: string;
       miss: string;
+      measuredLength?: number;
     }[] = [];
 
     for (const rec of output.split(RECORD_SEP)) {
@@ -1446,6 +1495,10 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         continue;
       }
       if (f[0] === SNAP_TAG) {
+        // f[7] (#187) is the mailbox's MEASURED length, emitted only when it
+        // disagreed with the count; -1 or absent means "not measured". Absent
+        // is the normal case for a record written before 2.14.1.
+        const measured = f[7] !== undefined && f[7] !== "" ? Number(f[7]) : -1;
         snaps.push({
           account: f[1] ?? "",
           mailbox: f[2] ?? "",
@@ -1453,6 +1506,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           status: f[4] ?? "",
           payload: f[5] ?? "",
           miss: f[6] ?? "",
+          ...(Number.isFinite(measured) && measured >= 0 ? { measuredLength: measured } : {}),
         });
         continue;
       }
@@ -1703,6 +1757,13 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       // innocent messages as collateral — the fabricated finding this layer must
       // never produce. A hole in `before` only undercounts it, and symmetrically
       // poisons `appeared`.
+      // #187: when Mail's count read HIGH, the snapshot measured the mailbox's
+      // true length instead of letting the over-request collapse it. Surface that
+      // measurement — it is DIRECT evidence of the count staleness #155 is about,
+      // and discarding it would repeat the mistake of measuring and saying nothing.
+      const countStale = [b, a]
+        .filter((s) => s.measuredLength !== undefined)
+        .map((s) => ({ phase: s.phase, measuredLength: s.measuredLength as number }));
       const holes = [b, a]
         .filter((s) => s.miss !== "")
         .map((s) => ({ phase: s.phase, ranges: s.miss }));
@@ -1714,6 +1775,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           disappeared,
           unrequested,
           appeared,
+          ...(countStale.length ? { countStale } : {}),
         });
         continue;
       }
@@ -1725,6 +1787,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         account: g.account,
         mailbox: g.mailbox,
         snapshot: "partial",
+        ...(countStale.length ? { countStale } : {}),
         skipReason:
           `Mail would not read ${holes.map((h) => `${h.ranges} (${h.phase})`).join(", ")} of ` +
           `this mailbox, so the snapshot has a hole in it. ` +

--- a/src/services/auditLog.ts
+++ b/src/services/auditLog.ts
@@ -283,6 +283,23 @@ export interface CollateralDiff {
    * fixed, treat a `disappeared` entry as a lead, not a proof.
    */
   snapshot: "ok" | "partial" | "skipped" | "unavailable";
+  /**
+   * Present only when Mail's message COUNT for this mailbox read **high** and
+   * the snapshot had to measure the true length instead (#187).
+   *
+   * This is direct evidence of the count staleness #155 is about, from the one
+   * place that can observe it for free: an out-of-range range raises, so a
+   * count that over-reports makes its slices fail. Before 2.14.1 that silently
+   * collapsed the snapshot to `unavailable` with no holes and no warning —
+   * switching the collateral instrument off in exactly the stale direction the
+   * field reports.
+   *
+   * `measuredLength` is how many messages the mailbox actually held. Compare it
+   * with the `countDelta` entry's `before`/`after` for the same mailbox to see
+   * how far the count lagged. Absent means the count's last position was
+   * readable, i.e. no evidence it was high — never "the count was correct".
+   */
+  countStale?: { phase: "before" | "after"; measuredLength: number }[];
   skipReason?: string;
   /**
    * The slices of the mailbox that could not be read, per phase — 1-based


### PR DESCRIPTION
**Closes #187** — the stale-**HIGH** counterpart to #179, and the direction #155 actually evidences.

## The defect

An out-of-range AppleScript range **raises as a whole** rather than clamping, so a count that over-reports makes its slices fail. On a mailbox smaller than one chunk (default 250) there is only **one** slice — it covered everything, it raised, `_sPairs` ended up empty, and the status collapsed to `unavailable` with **no holes and no warning**.

Every reading in #155 is an undercount of what left, i.e. an after-count *higher* than the mailbox truly holds. So the one mechanism that can name an unrequested departure was **disabling itself precisely in the scenario it exists for**, and saying nothing while it did.

Regression from #177 (2.10.33); v2.10.32 read the mailbox unbounded and could not over-request.

## The fix

Establish a bound that actually **exists** before slicing. The retry loop could never help here — it re-requested the *same* range against a deterministic raise.

- count's last position readable → the count is not high, **one probe**, done
- otherwise → binary-search the true end, `O(log n)`

## Verified against real Mail, not just the simulator

I hand-wrote a binary search in AppleScript, so I ran it read-only against a real 47-message mailbox with deliberately inflated counts:

| reported count | → bound | measured | probes |
|---|---|---|---|
| 47 (accurate) | 47 | — | **1** |
| 50 | 47 | 47 | 7 |
| 97 | 47 | 47 | 8 |
| 300 | 47 | 47 | 9 |

Logarithmic, and **no penalty in the normal case**. That run also independently confirms the raise-not-clamp semantics the whole fix rests on — the search would not terminate at 47 otherwise.

## The staleness is now measured, not just survived

The clamp has to compute the true length anyway, and that number is **direct evidence of the #155 staleness** from the one place that can observe it for free. Measuring it and throwing it away would repeat the mistake this layer exists to correct. So it surfaces on the collateral diff:

```json
{ "countStale": [{ "phase": "after", "measuredLength": 4 }] }
```

Compare with the same mailbox's `countDelta` `before`/`after` to see how far the count lagged. **Absent means "no evidence the count was high", never "the count was correct"** — the same absent-≠-empty discipline as the rest of this layer.

## Interaction with #179

The #179 overrun probe is now bounded by the **clamped** bound rather than the raw count. Otherwise, after a high count was clamped down, it would probe into the void and could re-raise the very truncation flag the clamp had just disproved. The two now compose: #179 catches stale-low, #187 catches stale-high, and the bound is accurate in both directions.

## Guards

Both #187 guards fail against the pre-fix source. The third — *"says NOTHING about count staleness when the count is accurate"* — is a cry-wolf guard and holds in both directions by construction.

The simulator models the clamp **gated on the generated script actually containing it**, like every other capability there, so a script without the clamp still reproduces the old collapse and the guards cannot pass vacuously.

Suite: 681 passed / 48 files. `typecheck` clean, `lint` 0 errors, `format:check` clean.

Closes #187
