### PR TITLE
feat(imap): report countDelta on the IMAP batch path (#181)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.14.1",
+      "version": "2.15.0",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.14.1",
+      "version": "2.15.0",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.14.1",
+      "version": "2.15.0",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 ## [Unreleased]
 
+## [2.15.0] - 2026-08-16
+
+The last piece of #181's suggested direction: both backends now report the same
+reconciliation structure.
+
+### Added
+
+- **`countDelta` on the IMAP batch path.** `batch-delete-messages` and
+  `batch-move-messages` previously returned no reconciliation at all for
+  `imap:` ids, and that absence read as "no information" rather than
+  "unverified" — the asymmetry #181 was filed about. They now report the same
+  `countDelta` shape as the AppleScript path: `before`, `after`, `expected`,
+  `observed`, `status`, and a reason when the status is `unknown`.
+
+  The numbers come from the server's own `STATUS`, so unlike Mail's count they
+  are **not** subject to the lag #155 is about — a `match` on this path means
+  more than it does on the other.
+
+  A mixed batch reports an entry per source mailbox from whichever backend
+  handled it. Entries are **concatenated, never summed**: the two measure
+  different stores with different instruments, and collapsing them would average
+  a trustworthy reading with an untrustworthy one and hide which was which.
+
+  Only operations that actually remove messages from their source reconcile.
+  `batch-mark-as-read` and the flag tools change no count, so emitting
+  `expected: N, observed: 0` for them would manufacture an alarm — they report
+  no `countDelta`, and a guard pins that.
+
+### Changed
+
+- The four-way `unknown` classification (`count-unreadable`, `no-expectation`,
+  `count-did-not-move`, `count-partial`) is now **one shared function** used by
+  both backends. Giving IMAP its own copy would let the two drift, and these
+  categories are load-bearing: `count-did-not-move` deliberately does not send
+  the reader hunting a destination, while `count-partial` does. Getting that
+  backwards is the retracted `under` warning all over again.
+
+  No behaviour change on the AppleScript path — the branching is identical, just
+  relocated.
+
 ## [2.14.1] - 2026-08-16
 
 Closes #187 — the stale-**HIGH** counterpart to #179, and the direction #155

--- a/README.md
+++ b/README.md
@@ -1444,12 +1444,23 @@ Three more honesty rules:
   than list positions — and `expected` stays comparable with the mailbox instead
   of double-counting a duplicate into a false `over`.
 
-`imap:` ids are not reconciled by `countDelta`. An IMAP UID names exactly one
-message in exactly one mailbox, so the mis-targeting class this exists for cannot
-occur there; a batch of only `imap:` ids returns no `countDelta` rather than a
-fabricated one.
+**`imap:` ids are reconciled too, as of 2.15.0.** `batch-delete-messages` and
+`batch-move-messages` return the same `countDelta` structure on the IMAP path, so
+one shape covers both backends and a mixed batch reports an entry per source
+mailbox from whichever backend handled it. The entries are **concatenated, never
+summed** — Mail's own count can lag (#155) while the server's `STATUS` cannot, and
+averaging the two would hide which reading you were looking at.
 
-They carry their own post-condition check instead. `delete-message` and
+Only the operations that actually remove messages from their source reconcile.
+`batch-mark-as-read` and the flag tools change no count, so emitting
+`expected: N, observed: 0` for them would manufacture an alarm; they report no
+`countDelta` at all.
+
+Note the mis-targeting class `countDelta` was originally built for cannot occur
+on the IMAP path — a UID names exactly one message in exactly one mailbox — so
+there the value is effect confirmation rather than target confirmation.
+
+Single-message tools carry a post-condition check instead. `delete-message` and
 `move-message` on an `imap:` id return a **`verification`** object in
 `structuredContent`:
 

--- a/build/index.js
+++ b/build/index.js
@@ -78828,6 +78828,14 @@ function auditSnapshotChunk() {
   if (!Number.isFinite(n) || n < 1) return DEFAULT_SNAPSHOT_CHUNK;
   return Math.floor(n);
 }
+function classifyCountStatus(readable, expected, observed) {
+  if (!readable) return { status: "unknown", unknownReason: "count-unreadable" };
+  if (expected === null) return { status: "unknown", unknownReason: "no-expectation" };
+  if (observed === expected) return { status: "match" };
+  if ((observed ?? 0) > expected) return { status: "over" };
+  if (observed === 0) return { status: "unknown", unknownReason: "count-did-not-move" };
+  return { status: "unknown", unknownReason: "count-partial" };
+}
 function writeAuditRecord(record2) {
   const path = auditLogPath();
   if (!path) return;
@@ -79771,25 +79779,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       const readable = m.before >= 0 && m.after >= 0;
       const observed = readable ? m.before - m.after : null;
       const note = noteFor(m.account, m.mailbox);
-      let status;
-      let unknownReason;
-      if (!readable) {
-        status = "unknown";
-        unknownReason = "count-unreadable";
-      } else if (m.expected === null) {
-        status = "unknown";
-        unknownReason = "no-expectation";
-      } else if (observed === m.expected) {
-        status = "match";
-      } else if ((observed ?? 0) > m.expected) {
-        status = "over";
-      } else if (observed === 0) {
-        status = "unknown";
-        unknownReason = "count-did-not-move";
-      } else {
-        status = "unknown";
-        unknownReason = "count-partial";
-      }
+      const { status, unknownReason } = classifyCountStatus(readable, m.expected, observed);
       return {
         account: m.account,
         mailbox: m.mailbox,
@@ -84475,7 +84465,15 @@ async function imapFetchAttachment(id, attachmentName, deps = {}) {
     }
   });
 }
-async function imapBatch(ids, deps, op) {
+async function mailboxCount(client, path) {
+  try {
+    const st = await client.status(path, { messages: true });
+    return typeof st.messages === "number" ? st.messages : null;
+  } catch {
+    return null;
+  }
+}
+async function imapBatch(ids, deps, op, opts = {}) {
   const groups = /* @__PURE__ */ new Map();
   const errors = [];
   let failed = 0;
@@ -84492,15 +84490,39 @@ async function imapBatch(ids, deps, op) {
     groups.set(key, g);
   }
   let success = 0;
+  const countDelta = [];
   for (const g of groups.values()) {
     try {
       await useClient(depsForAccount(g.account, deps), async (client) => {
+        const before = opts.reconcile ? await mailboxCount(client, g.path) : null;
         const lock = await client.getMailboxLock(g.path);
         try {
           await op(client, g.uids, g.path);
         } finally {
           lock.release();
         }
+        if (!opts.reconcile) return;
+        const after = await mailboxCount(client, g.path);
+        const readable = before !== null && after !== null;
+        const observed = readable ? before - after : null;
+        const { status, unknownReason } = classifyCountStatus(readable, g.uids.length, observed);
+        countDelta.push({
+          account: g.account,
+          mailbox: g.path,
+          before,
+          after,
+          expected: g.uids.length,
+          observed,
+          status,
+          ...unknownReason ? { unknownReason } : {},
+          ...unknownReason === "count-unreadable" ? { note: "The server did not answer STATUS for this mailbox" } : {},
+          ...unknownReason === "count-did-not-move" ? {
+            note: `The mailbox count did not move. On a label store (Gmail) a message can stay visible in an all-mail view after being moved out of a label, so this is not by itself evidence the operation failed \u2014 check the destination.`
+          } : {},
+          ...unknownReason === "count-partial" ? {
+            note: `Fewer messages left than were operated on. \`observed\` is a LOWER BOUND on what left, not a count of what left \u2014 a concurrent delivery to this mailbox masks departures one-for-one.`
+          } : {}
+        });
       });
       success += g.uids.length;
     } catch (e) {
@@ -84508,7 +84530,7 @@ async function imapBatch(ids, deps, op) {
       errors.push(`${g.path}: ${errText(e)}`);
     }
   }
-  return { success, failed, errors };
+  return { success, failed, errors, ...countDelta.length ? { countDelta } : {} };
 }
 var imapBatchMarkRead = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids) => {
   assertMutated(
@@ -84543,17 +84565,27 @@ var imapBatchUnflag = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids) =
     `IMAP unflag of ${uids.length} message(s)`
   );
 });
-var imapBatchDelete = (ids, deps = {}) => imapBatch(ids, deps, async (c, uids, path) => {
-  await trashUids(c, uids, path);
-});
+var imapBatchDelete = (ids, deps = {}) => imapBatch(
+  ids,
+  deps,
+  async (c, uids, path) => {
+    await trashUids(c, uids, path);
+  },
+  { reconcile: true }
+);
 function imapBatchMove(ids, destMailbox, deps = {}) {
-  return imapBatch(ids, deps, async (c, uids) => {
-    const dest = await findMailboxPathOrThrow(c, destMailbox) ?? resolveMailboxPath(destMailbox, "list");
-    assertMutated(
-      await c.messageMove(uids, dest, { uid: true }),
-      `IMAP move of ${uids.length} message(s) to "${dest}"`
-    );
-  });
+  return imapBatch(
+    ids,
+    deps,
+    async (c, uids) => {
+      const dest = await findMailboxPathOrThrow(c, destMailbox) ?? resolveMailboxPath(destMailbox, "list");
+      assertMutated(
+        await c.messageMove(uids, dest, { uid: true }),
+        `IMAP move of ${uids.length} message(s) to "${dest}"`
+      );
+    },
+    { reconcile: true }
+  );
 }
 function senderName(from) {
   const a = from?.[0];
@@ -84752,13 +84784,15 @@ async function hybridBatchCounts(ids, appleFn, imapFn) {
     fail += res.length - s;
     errors.push(...res.filter((r) => !r.success && r.error).map((r) => r.error));
   }
+  let countDelta;
   if (imapIds.length > 0) {
     const r = await imapFn(imapIds);
     success += r.success;
     fail += r.failed;
     errors.push(...r.errors);
+    if (r.countDelta?.length) countDelta = r.countDelta;
   }
-  return { success, fail, errors };
+  return { success, fail, errors, ...countDelta ? { countDelta } : {} };
 }
 function distinctErrors(errors) {
   return [...new Set(errors.filter(Boolean))];
@@ -84797,6 +84831,10 @@ ${warnings.join("\n")}` : "";
 function toManagerScope(args) {
   return { account: args.sourceAccount, mailbox: args.sourceMailbox };
 }
+function mergeCountDeltas(apple, imap) {
+  const all = [...apple ?? [], ...imap ?? []];
+  return all.length ? { countDelta: all } : {};
+}
 async function runBatchDelete(deps, args) {
   const { ids, sourceMailbox, sourceAccount } = args;
   let forensics = { warnings: [] };
@@ -84820,7 +84858,10 @@ async function runBatchDelete(deps, args) {
       allFailed: (n) => `Failed to delete all ${n} message(s)`,
       partial: (ok, failed) => `Deleted ${ok} message(s), ${failed} failed`
     },
-    forensics.countDelta ? { countDelta: forensics.countDelta } : {},
+    // #181: merge both backends' reconciliation. An AppleScript-only batch is
+    // unchanged; an IMAP-only one now reports a delta where it previously
+    // reported nothing; a mixed batch reports both, per source mailbox.
+    mergeCountDeltas(forensics.countDelta, counts.countDelta),
     forensics.warnings
   );
 }
@@ -84854,7 +84895,10 @@ async function runBatchMove(deps, args) {
       allFailed: (n) => `Failed to move all ${n} message(s)`,
       partial: (ok, failed) => `Moved ${ok} message(s) to "${mailbox}", ${failed} failed`
     },
-    { mailbox, ...forensics.countDelta ? { countDelta: forensics.countDelta } : {} },
+    {
+      mailbox,
+      ...mergeCountDeltas(forensics.countDelta, counts.countDelta)
+    },
     forensics.warnings
   );
 }

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.14.1"
+        "apple-mail-mcp@2.15.0"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -46,6 +46,7 @@ import {
   auditSnapshotChunk,
   SNAPSHOT_SLICE_ATTEMPTS,
   AUDIT_SNAPSHOT_MAX_ENV,
+  classifyCountStatus,
   type CountDelta,
   type AuditPreImage,
   type AuditOutcome,
@@ -1628,33 +1629,11 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       const readable = m.before >= 0 && m.after >= 0;
       const observed = readable ? m.before - m.after : null;
       const note = noteFor(m.account, m.mailbox);
-      let status: CountDelta["status"];
-      let unknownReason: CountDelta["unknownReason"];
       // Four disjoint ways there is nothing this server will assert. They are
       // NOT interchangeable to a reader, so each carries its own reason and its
-      // own note — see the #155 retraction on CountDelta.
-      if (!readable) {
-        status = "unknown";
-        unknownReason = "count-unreadable";
-      } else if (m.expected === null) {
-        status = "unknown";
-        unknownReason = "no-expectation";
-      } else if (observed === m.expected) {
-        status = "match";
-      } else if ((observed ?? 0) > m.expected) {
-        status = "over";
-      } else if (observed === 0) {
-        // The count did not move at all. On a store that flags deletions
-        // instead of removing them this is the ORDINARY reading for an
-        // operation that fully succeeded, so it must keep saying so.
-        status = "unknown";
-        unknownReason = "count-did-not-move";
-      } else {
-        // It moved, but short. A flag-only store cannot produce this, which is
-        // the whole reason it is worth telling apart from the case above.
-        status = "unknown";
-        unknownReason = "count-partial";
-      }
+      // own note — see the #155 retraction on CountDelta. The classification
+      // itself is shared with the IMAP path so the two cannot drift (#181).
+      const { status, unknownReason } = classifyCountStatus(readable, m.expected, observed);
       return {
         account: m.account,
         mailbox: m.mailbox,

--- a/src/services/auditLog.ts
+++ b/src/services/auditLog.ts
@@ -162,6 +162,38 @@ export function auditSnapshotChunk(): number {
  * The vocabulary is deleted rather than deprecated so the compiler enumerates
  * every consumer; a dead status string gets re-implemented by the next author.
  */
+/**
+ * Classify a count delta into the four disjoint "nothing to assert" cases plus
+ * the two findings. ONE implementation, shared by both backends. (#181)
+ *
+ * The AppleScript path grew this branching for #155; the IMAP path had no
+ * reconciliation at all. Giving IMAP its own copy would let the two drift, and
+ * these categories are load-bearing — `count-did-not-move` deliberately does
+ * NOT tell the reader to check a destination (on a flag-only store nothing was
+ * moved, so an empty Trash would read as failure), while `count-partial` does.
+ * Getting that backwards is the retracted `under` warning all over again.
+ *
+ * Note `observed` is a LOWER BOUND on what left, not a count of what left — see
+ * the #155 retraction on `CountDelta`.
+ */
+export function classifyCountStatus(
+  readable: boolean,
+  expected: number | null,
+  observed: number | null
+): { status: CountDelta["status"]; unknownReason?: CountDelta["unknownReason"] } {
+  if (!readable) return { status: "unknown", unknownReason: "count-unreadable" };
+  if (expected === null) return { status: "unknown", unknownReason: "no-expectation" };
+  if (observed === expected) return { status: "match" };
+  if ((observed ?? 0) > expected) return { status: "over" };
+  // The count did not move at all. On a store that flags deletions instead of
+  // removing them this is the ORDINARY reading for an operation that fully
+  // succeeded, so it must keep saying so.
+  if (observed === 0) return { status: "unknown", unknownReason: "count-did-not-move" };
+  // It moved, but short. A flag-only store cannot produce this, which is the
+  // whole reason it is worth telling apart from the case above.
+  return { status: "unknown", unknownReason: "count-partial" };
+}
+
 export interface CountDelta {
   /** Account holding the affected mailbox ("" when Mail would not say). */
   account: string;

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -1844,3 +1844,122 @@ describe("#181 three-valued verification of accepted IMAP mutations", () => {
     expect(r.verification).toMatchObject({ why: expect.stringMatching(/still present/) });
   });
 });
+
+// ---------------------------------------------------------------------------
+// #181: the IMAP path reports what it did to each source mailbox, in the SAME
+// countDelta shape as the AppleScript path. Before this it reported nothing,
+// and its absence read as "no information" rather than "unverified" — the
+// asymmetry the issue was filed for. The numbers come from the server's own
+// STATUS, so unlike Mail's count they are not subject to the #155 lag.
+// ---------------------------------------------------------------------------
+describe("#181 IMAP batch operations reconcile the source mailbox count", () => {
+  const IDS = [encodeImapId("acct", "INBOX", 5), encodeImapId("acct", "INBOX", 6)];
+
+  /** A client whose STATUS drops by `drop` after the mutation runs. */
+  function countingClient(drop: number, extra: Partial<ImapClientLike> = {}): ImapClientLike {
+    let mutated = false;
+    return {
+      ...makeClient([], {}),
+      list: async () => [
+        { path: "Archive", name: "Archive" },
+        { path: "Trash", name: "Trash", specialUse: "\\Trash" },
+      ],
+      status: async (path: string) => ({ path, messages: mutated ? 10 - drop : 10 }),
+      messageMove: async () => {
+        mutated = true;
+        return { path: "INBOX", destination: "Archive" };
+      },
+      ...extra,
+    };
+  }
+
+  it("reports a clean move as `match`", async () => {
+    const r = await imapBatchMove(IDS, "Archive", {
+      config: cfg,
+      connect: async () => countingClient(2),
+    });
+    expect(r.countDelta).toEqual([
+      {
+        account: "acct",
+        mailbox: "INBOX",
+        before: 10,
+        after: 8,
+        expected: 2,
+        observed: 2,
+        status: "match",
+      },
+    ]);
+  });
+
+  it("reports MORE leaving than were asked for as `over` — the one real alarm", async () => {
+    const r = await imapBatchMove(IDS, "Archive", {
+      config: cfg,
+      connect: async () => countingClient(5),
+    });
+    expect(r.countDelta?.[0]).toMatchObject({ expected: 2, observed: 5, status: "over" });
+  });
+
+  it("a count that did not move is `unknown`, and does NOT claim failure", async () => {
+    const r = await imapBatchMove(IDS, "Archive", {
+      config: cfg,
+      connect: async () => countingClient(0),
+    });
+    expect(r.countDelta?.[0]).toMatchObject({
+      status: "unknown",
+      unknownReason: "count-did-not-move",
+    });
+    // A Gmail label store legitimately produces this, so it must not send the
+    // reader hunting a failure — but it must mention checking the destination.
+    expect(r.countDelta?.[0].note).toMatch(/all-mail view/i);
+  });
+
+  it("a short-but-nonzero drop is `count-partial`, distinct from did-not-move", async () => {
+    const r = await imapBatchMove(IDS, "Archive", {
+      config: cfg,
+      connect: async () => countingClient(1),
+    });
+    expect(r.countDelta?.[0]).toMatchObject({
+      expected: 2,
+      observed: 1,
+      status: "unknown",
+      unknownReason: "count-partial",
+    });
+    expect(r.countDelta?.[0].note).toMatch(/LOWER BOUND/);
+  });
+
+  it("an unreadable STATUS is `count-unreadable`, never a silent zero", async () => {
+    const client = countingClient(2, {
+      status: async () => {
+        throw new Error("STATUS refused");
+      },
+    });
+    const r = await imapBatchMove(IDS, "Archive", { config: cfg, connect: async () => client });
+    expect(r.countDelta?.[0]).toMatchObject({
+      before: null,
+      after: null,
+      observed: null,
+      status: "unknown",
+      unknownReason: "count-unreadable",
+    });
+  });
+
+  it("batch delete reconciles too", async () => {
+    const r = await imapBatchDelete(IDS, { config: cfg, connect: async () => countingClient(2) });
+    expect(r.countDelta?.[0]).toMatchObject({ expected: 2, observed: 2, status: "match" });
+  });
+
+  // The guard against manufacturing an alarm: these change no count, so a
+  // countDelta of expected:2 / observed:0 would read as a failed operation.
+  it("mark-read and flag report NO countDelta — they change no count", async () => {
+    const read = await imapBatchMarkRead(IDS, {
+      config: cfg,
+      connect: async () => countingClient(0),
+    });
+    expect(read.countDelta).toBeUndefined();
+    const unflag = await imapBatchUnflag(IDS, {
+      config: cfg,
+      connect: async () => countingClient(0),
+    });
+    expect(unflag.countDelta).toBeUndefined();
+  });
+});

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -30,6 +30,7 @@ import { ImapFlow } from "imapflow";
 import { readKeychainPassword } from "@/services/smtpMailer.js";
 import { SETUP_HINT } from "@/utils/docsUrls.js";
 import { extractHtmlBody, extractTextBody } from "@/utils/mimeParse.js";
+import { classifyCountStatus, type CountDelta } from "@/services/auditLog.js";
 import { MAX_IMAP_ATTACHMENT_BYTES } from "@/utils/attachmentLimits.js";
 
 export const IMAP_ENV = {
@@ -1813,12 +1814,37 @@ export interface ImapBatchResult {
   success: number;
   failed: number;
   errors: string[];
+  /**
+   * What the operation actually did to each SOURCE mailbox. (#181)
+   *
+   * Present only for operations that remove messages from their source — the
+   * batch move and delete — because those are the ones where "how many left"
+   * is a meaningful question. Marking read or flagging changes no count, and
+   * emitting `expected: N, observed: 0` for them would manufacture an alarm.
+   *
+   * Same shape and the same classification as the AppleScript path, so a caller
+   * reads one structure regardless of backend. Unlike that path, the numbers
+   * come from the server's own `STATUS`, so they are not subject to the
+   * Mail.app count lag #155 is about.
+   */
+  countDelta?: CountDelta[];
+}
+
+/** Server-side message count, or null when STATUS would not answer. */
+async function mailboxCount(client: ImapClientLike, path: string): Promise<number | null> {
+  try {
+    const st = await client.status(path, { messages: true });
+    return typeof st.messages === "number" ? st.messages : null;
+  } catch {
+    return null;
+  }
 }
 
 async function imapBatch(
   ids: string[],
   deps: ImapDeps,
-  op: (client: ImapClientLike, uids: number[], path: string) => Promise<void>
+  op: (client: ImapClientLike, uids: number[], path: string) => Promise<void>,
+  opts: { reconcile?: boolean } = {}
 ): Promise<ImapBatchResult> {
   const groups = new Map<string, { account: string; path: string; uids: number[] }>();
   const errors: string[] = [];
@@ -1836,15 +1862,53 @@ async function imapBatch(
     groups.set(key, g);
   }
   let success = 0;
+  const countDelta: CountDelta[] = [];
   for (const g of groups.values()) {
     try {
       await useClient(depsForAccount(g.account, deps), async (client) => {
+        // STATUS is taken OUTSIDE the mailbox lock and before/after the op, so
+        // the reading is the server's own and not this connection's cached view.
+        const before = opts.reconcile ? await mailboxCount(client, g.path) : null;
         const lock = await client.getMailboxLock(g.path);
         try {
           await op(client, g.uids, g.path);
         } finally {
           lock.release();
         }
+        if (!opts.reconcile) return;
+        const after = await mailboxCount(client, g.path);
+        const readable = before !== null && after !== null;
+        const observed = readable ? before - after : null;
+        const { status, unknownReason } = classifyCountStatus(readable, g.uids.length, observed);
+        countDelta.push({
+          account: g.account,
+          mailbox: g.path,
+          before,
+          after,
+          expected: g.uids.length,
+          observed,
+          status,
+          ...(unknownReason ? { unknownReason } : {}),
+          ...(unknownReason === "count-unreadable"
+            ? { note: "The server did not answer STATUS for this mailbox" }
+            : {}),
+          ...(unknownReason === "count-did-not-move"
+            ? {
+                note:
+                  `The mailbox count did not move. On a label store (Gmail) a message can stay ` +
+                  `visible in an all-mail view after being moved out of a label, so this is not ` +
+                  `by itself evidence the operation failed — check the destination.`,
+              }
+            : {}),
+          ...(unknownReason === "count-partial"
+            ? {
+                note:
+                  `Fewer messages left than were operated on. \`observed\` is a LOWER BOUND on ` +
+                  `what left, not a count of what left — a concurrent delivery to this mailbox ` +
+                  `masks departures one-for-one.`,
+              }
+            : {}),
+        });
       });
       success += g.uids.length;
     } catch (e) {
@@ -1852,7 +1916,7 @@ async function imapBatch(
       errors.push(`${g.path}: ${errText(e)}`);
     }
   }
-  return { success, failed, errors };
+  return { success, failed, errors, ...(countDelta.length ? { countDelta } : {}) };
 }
 
 // Every op below routes its imapflow result through `assertMutated`: a throw is
@@ -1905,24 +1969,34 @@ export const imapBatchUnflag = (ids: string[], deps: ImapDeps = {}): Promise<Ima
     );
   });
 export const imapBatchDelete = (ids: string[], deps: ImapDeps = {}): Promise<ImapBatchResult> =>
-  imapBatch(ids, deps, async (c, uids, path) => {
-    await trashUids(c, uids, path);
-  });
+  imapBatch(
+    ids,
+    deps,
+    async (c, uids, path) => {
+      await trashUids(c, uids, path);
+    },
+    { reconcile: true }
+  );
 export function imapBatchMove(
   ids: string[],
   destMailbox: string,
   deps: ImapDeps = {}
 ): Promise<ImapBatchResult> {
-  return imapBatch(ids, deps, async (c, uids) => {
-    // #137: throws on an ambiguous destination; imapBatch records it per group
-    // as a failure rather than moving the batch somewhere the caller didn't name.
-    const dest =
-      (await findMailboxPathOrThrow(c, destMailbox)) ?? resolveMailboxPath(destMailbox, "list");
-    assertMutated(
-      await c.messageMove(uids, dest, { uid: true }),
-      `IMAP move of ${uids.length} message(s) to "${dest}"`
-    );
-  });
+  return imapBatch(
+    ids,
+    deps,
+    async (c, uids) => {
+      // #137: throws on an ambiguous destination; imapBatch records it per group
+      // as a failure rather than moving the batch somewhere the caller didn't name.
+      const dest =
+        (await findMailboxPathOrThrow(c, destMailbox)) ?? resolveMailboxPath(destMailbox, "list");
+      assertMutated(
+        await c.messageMove(uids, dest, { uid: true }),
+        `IMAP move of ${uids.length} message(s) to "${dest}"`
+      );
+    },
+    { reconcile: true }
+  );
 }
 
 // ===========================================================================

--- a/src/tools/batchMutations.ts
+++ b/src/tools/batchMutations.ts
@@ -17,6 +17,7 @@
 import type { BatchOperationResult } from "@/types.js";
 import type { ToolResponse } from "@/tools/respond.js";
 import type { ImapBatchResult } from "@/services/imapClient.js";
+import type { CountDelta } from "@/services/auditLog.js";
 import { hybridBatchCounts, batchResponse } from "@/tools/batchResults.js";
 
 /** The source scope a caller pins numeric ids to. Both fields or neither (#159). */
@@ -67,6 +68,23 @@ export function toManagerScope(args: {
   return { account: args.sourceAccount, mailbox: args.sourceMailbox };
 }
 
+/**
+ * Combine the AppleScript and IMAP reconciliation into one `countDelta`. (#181)
+ *
+ * Concatenated, never summed: the two measure different stores with different
+ * instruments — Mail's own count, which #155 showed can lag, versus the
+ * server's `STATUS`, which cannot. Collapsing them into one number would
+ * average a trustworthy reading with an untrustworthy one and hide which was
+ * which. Each entry already names its own account and mailbox.
+ */
+function mergeCountDeltas(
+  apple: CountDelta[] | undefined,
+  imap: CountDelta[] | undefined
+): { countDelta?: CountDelta[] } {
+  const all = [...(apple ?? []), ...(imap ?? [])];
+  return all.length ? { countDelta: all } : {};
+}
+
 /** `batch-delete-messages`. */
 export async function runBatchDelete(
   deps: BatchMutationDeps,
@@ -94,7 +112,10 @@ export async function runBatchDelete(
       allFailed: (n) => `Failed to delete all ${n} message(s)`,
       partial: (ok, failed) => `Deleted ${ok} message(s), ${failed} failed`,
     },
-    forensics.countDelta ? { countDelta: forensics.countDelta } : {},
+    // #181: merge both backends' reconciliation. An AppleScript-only batch is
+    // unchanged; an IMAP-only one now reports a delta where it previously
+    // reported nothing; a mixed batch reports both, per source mailbox.
+    mergeCountDeltas(forensics.countDelta as CountDelta[] | undefined, counts.countDelta),
     forensics.warnings
   );
 }
@@ -141,7 +162,10 @@ export async function runBatchMove(
       allFailed: (n) => `Failed to move all ${n} message(s)`,
       partial: (ok, failed) => `Moved ${ok} message(s) to "${mailbox}", ${failed} failed`,
     },
-    { mailbox, ...(forensics.countDelta ? { countDelta: forensics.countDelta } : {}) },
+    {
+      mailbox,
+      ...mergeCountDeltas(forensics.countDelta as CountDelta[] | undefined, counts.countDelta),
+    },
     forensics.warnings
   );
 }

--- a/src/tools/batchResults.ts
+++ b/src/tools/batchResults.ts
@@ -10,6 +10,7 @@
  * @module tools/batchResults
  */
 import { successResponse, errorResponse, type ToolResponse } from "@/tools/respond.js";
+import type { CountDelta } from "@/services/auditLog.js";
 import type { ImapBatchResult } from "@/services/imapClient.js";
 
 /**
@@ -29,7 +30,7 @@ export async function hybridBatchCounts(
   ids: string[],
   appleFn: (numericIds: string[]) => { success: boolean; error?: string }[],
   imapFn: (imapIds: string[]) => Promise<ImapBatchResult>
-): Promise<{ success: number; fail: number; errors: string[] }> {
+): Promise<{ success: number; fail: number; errors: string[]; countDelta?: CountDelta[] }> {
   const distinctIds = [...new Set(ids)];
   const imapIds = distinctIds.filter((i) => i.startsWith("imap:"));
   const numericIds = distinctIds.filter((i) => !i.startsWith("imap:"));
@@ -45,13 +46,19 @@ export async function hybridBatchCounts(
     // refused as ambiguous (#152) showed up only as an anonymous failure count.
     errors.push(...res.filter((r) => !r.success && r.error).map((r) => r.error as string));
   }
+  // #181: the IMAP path now reconciles too, so a mixed batch reports what each
+  // backend did to each source mailbox in ONE structure. Kept separate from the
+  // AppleScript deltas by mailbox, never summed — they measure different stores
+  // with different instruments (server STATUS vs Mail's own count).
+  let countDelta: CountDelta[] | undefined;
   if (imapIds.length > 0) {
     const r = await imapFn(imapIds);
     success += r.success;
     fail += r.failed;
     errors.push(...r.errors);
+    if (r.countDelta?.length) countDelta = r.countDelta;
   }
-  return { success, fail, errors };
+  return { success, fail, errors, ...(countDelta ? { countDelta } : {}) };
 }
 
 /** The distinct, non-empty failure reasons, in first-seen order. */

--- a/test/imap.integration.test.ts
+++ b/test/imap.integration.test.ts
@@ -225,6 +225,32 @@ run("IMAP 2.1 optimizations (GreenMail) integration", () => {
     expect(Buffer.from(fetched.base64 as string, "base64").toString()).toBe("PDF-BYTES-HERE");
   });
 
+  // #181: the countDelta the IMAP path now reports must agree with a REAL
+  // server's STATUS, not just with a mock that returns whatever we told it to.
+  it("batch move reports a countDelta that matches the server's own STATUS", async () => {
+    expect((await imapCreateMailbox("CDdest", deps)).success).toBe(true);
+    await appendMessage("CountDelta A", "a");
+    await appendMessage("CountDelta B", "b");
+    const found = (
+      await imapSearchMessages({ mailbox: "INBOX", subject: "CountDelta", limit: 10 }, deps)
+    ).text;
+    const ids = [...found.matchAll(/imap:[A-Za-z0-9_-]+/g)].map((m) => m[0]).slice(0, 2);
+    expect(ids.length).toBe(2);
+
+    const r = await imapBatchMove(ids, "CDdest", deps);
+    expect(r.success).toBe(2);
+    const [d] = r.countDelta ?? [];
+    expect(d).toBeDefined();
+    expect(d.mailbox).toBe("INBOX");
+    expect(d.expected).toBe(2);
+    // A real server removes both from the source, so this is the `match` case.
+    // before/after come from STATUS and must be internally consistent.
+    expect(d.before! - d.after!).toBe(d.observed);
+    expect(d.observed).toBe(2);
+    expect(d.status).toBe("match");
+    await imapDeleteMailbox("CDdest", deps);
+  });
+
   it("batch mark-read + move over a UID set (I2)", async () => {
     await imapCreateMailbox("BatchDest", deps);
     const u1 = await appendRaw("From: a@x.com\nSubject: batch-1\n\nb");


### PR DESCRIPTION
The last piece of #181's suggested direction — both backends now report the same reconciliation structure. Refs #181 (already closed by 2.13.0).

## What changed

`batch-delete-messages` and `batch-move-messages` returned **no** reconciliation for `imap:` ids, and that absence read as *"no information"* rather than *"unverified"* — the asymmetry #181 was filed about. They now report the same `countDelta` shape as the AppleScript path.

The numbers come from the server's own `STATUS`, so unlike Mail's count they are **not** subject to the lag #155 is about. A `match` on this path means more than it does on the other.

## Three decisions worth flagging

**1. Entries are concatenated, never summed.** A mixed batch reports an entry per source mailbox from whichever backend handled it. The two measure different stores with different instruments — Mail's own count, which #155 showed can lag, versus server `STATUS`, which cannot. Collapsing them into one number would average a trustworthy reading with an untrustworthy one and hide which was which.

**2. Only operations that remove messages reconcile.** `batch-mark-as-read` and the flag tools change no count, so emitting `expected: 2, observed: 0` for them would manufacture an alarm out of a completely successful operation. They report no `countDelta`, and a guard pins that.

**3. The classifier is now shared, not duplicated.** The four-way `unknown` split (`count-unreadable`, `no-expectation`, `count-did-not-move`, `count-partial`) moved into one function used by both backends. These categories are load-bearing: `count-did-not-move` deliberately does **not** tell the reader to check a destination (on a flag-only store nothing moved, so an empty Trash would read as failure), while `count-partial` does. Getting that backwards is the retracted `under` warning all over again — a second copy would eventually drift into exactly that.

No behaviour change on the AppleScript path; the branching is identical, just relocated.

## Verification

**6 of 7 new unit tests fail against the pre-fix source.** The 7th is the no-alarm guard for mark-read/flag and holds in both directions by construction.

Also asserted **against a real server** rather than only a mock — a GreenMail batch move now checks that `before - after === observed` and that the status is `match`, so the numbers are the server's own and not a mock repeating what it was handed:

```
Test Files  1 passed (1)
     Tests  12 passed (12)
```

Suite: 688 passed / 48 files. `typecheck` clean, `lint` 0 errors, `format:check` clean.
