### PR TITLE
fix(audit): a RENUMBERED message is no longer reported as collateral (#155)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 ## [Unreleased]
 
+## [2.15.1] - 2026-08-16
+
+### Fixed
+
+- **A message Mail merely RENUMBERED was reported as collateral data loss.**
+  The collateral diff keys each snapshot entry on `(numeric id, Message-ID)`.
+  Mail renumbers ids — @scottstern0325 established on #155 that pre-image ids do
+  not survive a move to Trash — so a message that only got a **new id** has a
+  different key in each phase, and therefore appeared in **both** halves of the
+  diff: once as `disappeared`, once as `appeared`.
+
+  If the caller had not named it, it also landed in `unrequested`, which the
+  audit log documents as *"IS the #155 symptom, with names attached"*. So the
+  instrument could report a message that **demonstrably never left** as evidence
+  of data loss — the fabricated finding this layer exists to avoid, produced by
+  a mechanism the reporter had already documented.
+
+  A message present in both snapshots under the same Message-ID did not leave
+  and did not arrive. Those are now identified, removed from `disappeared` and
+  `appeared`, and reported separately.
+
+### Added
+
+- **`renumbered` on the collateral diff** — `{ messageId, before, after }` per
+  message whose numeric id changed across the operation.
+
+  Two guards keep it from inventing pairings: an **empty** Message-ID matches
+  nothing (the snapshot emits one when Mail would not give it up, and treating
+  "unknown" as an identity would pair arbitrary messages), and a Message-ID seen
+  **more than once on either side** is skipped as ambiguous (duplicates are real
+  — a label store shows one message in several views, a resend reuses the
+  header).
+
+  ⚠️ This is a **correlation, not a mechanism**. It does not establish that
+  renumbering explains #155's unexplained `over` symptom; that remains unproven,
+  and `runBatchOperation` re-resolving ids after prior mutations argues against
+  it. `renumbered` says only "these ids changed".
+
 ## [2.15.0] - 2026-08-16
 
 The last piece of #181's suggested direction: both backends now report the same

--- a/build/index.js
+++ b/build/index.js
@@ -79170,6 +79170,26 @@ var COUNT_PARTIAL_NOTE = `Mail's count moved by less than this operation account
 function snapshotKey(entry) {
   return `${entry.id}\0${entry.messageId}`;
 }
+function crossCheckRenumbered(disappeared, appeared) {
+  const index = (entries) => {
+    const m = /* @__PURE__ */ new Map();
+    for (const e of entries) {
+      if (!e.messageId) continue;
+      m.set(e.messageId, m.has(e.messageId) ? null : e);
+    }
+    return m;
+  };
+  const gone = index(disappeared);
+  const came = index(appeared);
+  const out = [];
+  for (const [mid, before] of gone) {
+    const after = came.get(mid);
+    if (!before || !after) continue;
+    if (before.id === after.id) continue;
+    out.push({ messageId: mid, before: before.id, after: after.id });
+  }
+  return out;
+}
 function buildAppLevelScript(command) {
   return `
     tell application "Mail"
@@ -79845,8 +79865,12 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       const afterEntries = this.parseSnapshot(a.payload);
       const afterKeys = new Set(afterEntries.map((e) => snapshotKey(e)));
       const beforeKeys = new Set(beforeEntries.map((e) => snapshotKey(e)));
-      const disappeared = beforeEntries.filter((e) => !afterKeys.has(snapshotKey(e)));
-      const appeared = afterEntries.filter((e) => !beforeKeys.has(snapshotKey(e)));
+      const rawDisappeared = beforeEntries.filter((e) => !afterKeys.has(snapshotKey(e)));
+      const rawAppeared = afterEntries.filter((e) => !beforeKeys.has(snapshotKey(e)));
+      const renumbered = crossCheckRenumbered(rawDisappeared, rawAppeared);
+      const renumberedMids = new Set(renumbered.map((r) => r.messageId));
+      const disappeared = rawDisappeared.filter((e) => !renumberedMids.has(e.messageId));
+      const appeared = rawAppeared.filter((e) => !renumberedMids.has(e.messageId));
       const unrequested = disappeared.filter(
         (e) => !requestedNumericIds.has(canonicalNumericId(e.id))
       );
@@ -79860,7 +79884,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           disappeared,
           unrequested,
           appeared,
-          ...countStale.length ? { countStale } : {}
+          ...countStale.length ? { countStale } : {},
+          ...renumbered.length ? { renumbered } : {}
         });
         continue;
       }
@@ -79873,6 +79898,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         mailbox: g.mailbox,
         snapshot: "partial",
         ...countStale.length ? { countStale } : {},
+        ...renumbered.length ? { renumbered } : {},
         skipReason: `Mail would not read ${holes.map((h) => `${h.ranges} (${h.phase})`).join(", ")} of this mailbox, so the snapshot has a hole in it. ` + (derivable.length > 0 ? `Still derivable and reported: ${derivable.join(" and ")}. ` : `Neither half of the diff is derivable from it. `) + `Anything the unread range could refute is omitted rather than guessed \u2014 an absent field here means "not computable", not "empty".`,
         unobserved: holes,
         ...a.miss === "" ? { disappeared, unrequested } : {},

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.15.0"
+        "apple-mail-mcp@2.15.1"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleMailManager.forensics.test.ts
+++ b/src/services/appleMailManager.forensics.test.ts
@@ -61,6 +61,13 @@ const h = vi.hoisted(() => ({
   /** Mail refuses to report a count at all: `_cb`/`_ca` stay at -1. */
   suppressCount: false,
   /**
+   * Mail RENUMBERS every surviving message by this offset during the operation:
+   * same Message-ID, new numeric id. The reporter established that pre-image ids
+   * do not survive a move to Trash, so this is a real behaviour, and it is the
+   * one that makes a survivor land in BOTH halves of the collateral diff (#155).
+   */
+  renumberSurvivorsBy: 0,
+  /**
    * What `messages i thru j of mb` does when `j` exceeds the mailbox's real
    * length. AppleScript RAISES on an out-of-range element range (`items 2 thru
    * 5 of {1,2,3}` → -1728), so the default is `false` = the slice fails whole.
@@ -353,6 +360,15 @@ function simulateDestructive(script: string): string {
     h.mailbox = h.mailbox.filter((m) => !h.collateral.includes(m.id));
   }
 
+  // Mail renumbering the survivors. Message-IDs are untouched — that asymmetry
+  // is the entire point: the numeric id is not an identity, the Message-ID is.
+  if (h.renumberSurvivorsBy !== 0) {
+    h.mailbox = h.mailbox.map((m) => ({
+      ...m,
+      id: String(Number(m.id) + h.renumberSurvivorsBy),
+    }));
+  }
+
   // `staleAfterCountBy` now bounds the after-SNAPSHOT as well as the after-COUNT,
   // which is the point: they are read by the same script against the same
   // lagging state. A stale-LOW count truncates the enumeration (#179); a
@@ -405,6 +421,7 @@ beforeEach(() => {
   h.staleAfterCountBy = 0;
   h.suppressCount = false;
   h.outOfRangeSliceClamps = false;
+  h.renumberSurvivorsBy = 0;
   tmp = mkdtempSync(join(tmpdir(), "amcp-audit-"));
   delete process.env[AUDIT_LOG_ENV];
   delete process.env[AUDIT_SUBJECTS_ENV];
@@ -960,6 +977,61 @@ describe("collateral identification (opt-in, gated on the audit log)", () => {
     const [c] = mgr.consumeLastForensics()!.collateral;
     expect(c.snapshot).toBe("ok");
     expect(c.countStale).toBeUndefined();
+  });
+
+  // =========================================================================
+  // #155 renumber cross-check. `snapshotKey` is (numeric id, Message-ID), and
+  // Mail renumbers ids — the reporter established that pre-image ids do not
+  // survive a move to Trash. So a message that merely got a NEW ID lands in
+  // both halves of the diff and was reported as collateral: a message that
+  // demonstrably never left, named as data loss.
+  // =========================================================================
+  it("does not report a RENUMBERED survivor as collateral", () => {
+    process.env[AUDIT_LOG_ENV] = auditFile();
+    h.renumberSurvivorsBy = 1000; // every survivor gets a new id
+    mgr.batchDeleteMessages(["75811"], { account: h.account, mailbox: h.mailboxName });
+    const [c] = mgr.consumeLastForensics()!.collateral;
+
+    // Only the requested message left. The four survivors changed id, and not
+    // one of them may be named as having disappeared.
+    expect(c.disappeared).toEqual([{ id: "75811", messageId: "a@example.com" }]);
+    expect(c.unrequested).toEqual([]);
+    // Nor may they read as newly ARRIVED.
+    expect(c.appeared).toEqual([]);
+  });
+
+  it("REPORTS the renumbering as its own observation, with both ids", () => {
+    process.env[AUDIT_LOG_ENV] = auditFile();
+    h.renumberSurvivorsBy = 1000;
+    mgr.batchDeleteMessages(["75811"], { account: h.account, mailbox: h.mailboxName });
+    const [c] = mgr.consumeLastForensics()!.collateral;
+    expect(c.renumbered).toEqual([
+      { messageId: "b@example.com", before: "75812", after: "76812" },
+      { messageId: "c@example.com", before: "75813", after: "76813" },
+      { messageId: "d@example.com", before: "75814", after: "76814" },
+      { messageId: "e@example.com", before: "75815", after: "76815" },
+    ]);
+  });
+
+  it("says nothing about renumbering when no id changed", () => {
+    // Cry-wolf guard: the field exists only when there is something to report.
+    process.env[AUDIT_LOG_ENV] = auditFile();
+    mgr.batchDeleteMessages(["75811"], { account: h.account, mailbox: h.mailboxName });
+    const [c] = mgr.consumeLastForensics()!.collateral;
+    expect(c.renumbered).toBeUndefined();
+    expect(c.disappeared).toEqual([{ id: "75811", messageId: "a@example.com" }]);
+  });
+
+  it("still names a genuine collateral departure while renumbering is happening", () => {
+    // The cross-check must not become a blanket excuse: a message that really
+    // left has no counterpart in `appeared`, so it stays reported.
+    process.env[AUDIT_LOG_ENV] = auditFile();
+    h.renumberSurvivorsBy = 1000;
+    h.collateral = ["75814"]; // leaves without being asked for
+    mgr.batchDeleteMessages(["75811"], { account: h.account, mailbox: h.mailboxName });
+    const [c] = mgr.consumeLastForensics()!.collateral;
+    expect(c.unrequested).toEqual([{ id: "75814", messageId: "d@example.com" }]);
+    expect(c.renumbered?.map((r) => r.messageId)).not.toContain("d@example.com");
   });
 
   it("RECORDS the skip when the mailbox is above the ceiling", () => {

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -821,6 +821,64 @@ function snapshotKey(entry: { id: string; messageId: string }): string {
 }
 
 /**
+ * Cross-check the two halves of the diff for messages that were RENUMBERED
+ * rather than having left. (#155)
+ *
+ * `snapshotKey` is `(numeric id, Message-ID)`. Mail renumbers ids — the reporter
+ * established that pre-image ids do not survive a move to Trash — so a message
+ * that merely got a new id has a different key in each phase and therefore lands
+ * in **both** `disappeared` and `appeared`. Its Message-ID is unchanged in both,
+ * which is what makes it identifiable: the RFC Message-ID is the authoritative
+ * identity here and the numeric id is not.
+ *
+ * A message present in both snapshots under the same Message-ID **demonstrably
+ * did not leave**, so reporting it as `disappeared` — and, if the caller never
+ * named it, as `unrequested` — is a fabricated finding. Removing it is correct
+ * regardless of what ultimately explains #155.
+ *
+ * Two guards stop this inventing pairings of its own:
+ *   • an EMPTY Message-ID matches nothing. The snapshot emits one when Mail
+ *     would not give it up, and treating "unknown" as an identity would pair
+ *     arbitrary messages together.
+ *   • a Message-ID seen more than once on either side is skipped as ambiguous.
+ *     Duplicates are real (a label store shows one message in several views; a
+ *     resend reuses the header), and guessing which of two candidates renumbered
+ *     into which would be exactly the unverified causal story this layer must
+ *     not tell.
+ *
+ * ⚠️ This REPORTS a correlation. It does NOT establish that renumbering is the
+ * mechanism behind #155's unexplained `over` symptom — that remains unproven,
+ * and `runBatchOperation` re-resolving ids after prior mutations argues against
+ * it. Read `renumbered` as "these ids changed", and nothing more.
+ */
+function crossCheckRenumbered(
+  disappeared: { id: string; messageId: string }[],
+  appeared: { id: string; messageId: string }[]
+): { messageId: string; before: string; after: string }[] {
+  const index = (
+    entries: { id: string; messageId: string }[]
+  ): Map<string, { id: string; messageId: string } | null> => {
+    const m = new Map<string, { id: string; messageId: string } | null>();
+    for (const e of entries) {
+      if (!e.messageId) continue;
+      // A second sighting poisons the entry permanently: null = ambiguous.
+      m.set(e.messageId, m.has(e.messageId) ? null : e);
+    }
+    return m;
+  };
+  const gone = index(disappeared);
+  const came = index(appeared);
+  const out: { messageId: string; before: string; after: string }[] = [];
+  for (const [mid, before] of gone) {
+    const after = came.get(mid);
+    if (!before || !after) continue;
+    if (before.id === after.id) continue; // same id: not a renumber
+    out.push({ messageId: mid, before: before.id, after: after.id });
+  }
+  return out;
+}
+
+/**
  * Builds an AppleScript command at the application level.
  */
 function buildAppLevelScript(command: string): string {
@@ -1721,8 +1779,16 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       const afterEntries = this.parseSnapshot(a.payload);
       const afterKeys = new Set(afterEntries.map((e) => snapshotKey(e)));
       const beforeKeys = new Set(beforeEntries.map((e) => snapshotKey(e)));
-      const disappeared = beforeEntries.filter((e) => !afterKeys.has(snapshotKey(e)));
-      const appeared = afterEntries.filter((e) => !beforeKeys.has(snapshotKey(e)));
+      const rawDisappeared = beforeEntries.filter((e) => !afterKeys.has(snapshotKey(e)));
+      const rawAppeared = afterEntries.filter((e) => !beforeKeys.has(snapshotKey(e)));
+      // #155: a message Mail merely RENUMBERED is in both halves — same
+      // Message-ID, different numeric id. It did not leave and it did not
+      // arrive, so leaving it in would name an innocent message as collateral
+      // (and, if the caller never asked for it, as `unrequested`).
+      const renumbered = crossCheckRenumbered(rawDisappeared, rawAppeared);
+      const renumberedMids = new Set(renumbered.map((r) => r.messageId));
+      const disappeared = rawDisappeared.filter((e) => !renumberedMids.has(e.messageId));
+      const appeared = rawAppeared.filter((e) => !renumberedMids.has(e.messageId));
       // Both sides are canonical numeric ids: the caller's, canonicalised by the
       // callers of this method, and the snapshot's, canonicalised in
       // parseSnapshot. Comparing an AppleScript "9.99999999E+8" against a
@@ -1755,6 +1821,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
           unrequested,
           appeared,
           ...(countStale.length ? { countStale } : {}),
+          ...(renumbered.length ? { renumbered } : {}),
         });
         continue;
       }
@@ -1767,6 +1834,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         mailbox: g.mailbox,
         snapshot: "partial",
         ...(countStale.length ? { countStale } : {}),
+        ...(renumbered.length ? { renumbered } : {}),
         skipReason:
           `Mail would not read ${holes.map((h) => `${h.ranges} (${h.phase})`).join(", ")} of ` +
           `this mailbox, so the snapshot has a hole in it. ` +

--- a/src/services/auditLog.ts
+++ b/src/services/auditLog.ts
@@ -332,6 +332,22 @@ export interface CollateralDiff {
    * readable, i.e. no evidence it was high — never "the count was correct".
    */
   countStale?: { phase: "before" | "after"; measuredLength: number }[];
+  /**
+   * Messages Mail RENUMBERED across the operation — same RFC Message-ID, a
+   * different numeric id — rather than removed. (#155)
+   *
+   * These are excluded from `disappeared` and `appeared`, because a message
+   * present in both snapshots demonstrably did not leave and did not arrive;
+   * before 2.15.1 they were reported as collateral, which is a fabricated
+   * finding. The reporter established that pre-image ids do not survive a move
+   * to Trash, so this is expected on that path rather than alarming.
+   *
+   * ⚠️ A correlation, not a mechanism. This does NOT establish that renumbering
+   * explains #155's unexplained `over` symptom — that is still unproven, and
+   * `runBatchOperation` re-resolving ids after prior mutations argues against
+   * it. It says only "these ids changed".
+   */
+  renumbered?: { messageId: string; before: string; after: string }[];
   skipReason?: string;
   /**
    * The slices of the mailbox that could not be read, per phase — 1-based


### PR DESCRIPTION
The #155 renumber cross-check. It turned out to be a **bug fix**, not just the diagnostic it was scoped as. Refs #155 — does not close it.

## What it found

The collateral diff keys each snapshot entry on `(numeric id, Message-ID)`. Mail **renumbers ids** — @scottstern0325 established on #155 that pre-image ids do not survive a move to Trash — so a message that only got a *new id* has a different key in each phase and therefore appeared in **both** halves of the diff:

- in `disappeared`, because its before-key is absent from the after set
- in `appeared`, because its after-key is absent from the before set

And if the caller had not named it, it also landed in **`unrequested`** — which the audit log documents verbatim as *"IS the #155 symptom, with names attached"*.

So the instrument could report a message that **demonstrably never left** as evidence of data loss. That is the fabricated finding this whole layer exists to prevent, produced by a mechanism the reporter had already documented on the very issue it was reporting into.

## The fix

A message present in both snapshots under the same Message-ID did not leave and did not arrive. Those are identified, removed from `disappeared`/`appeared`, and reported separately as `renumbered: [{ messageId, before, after }]`.

The Message-ID is the authoritative identity here and the numeric id is not — which the audit log already said, in the docstring explaining why the pre-image records both.

## Guards against the cross-check inventing pairings

- An **empty** Message-ID matches nothing. The snapshot emits one when Mail would not give it up, and treating "unknown" as an identity would pair arbitrary messages together.
- A Message-ID seen **more than once on either side** is skipped as ambiguous. Duplicates are real — a label store shows one message in several views, a resend reuses the header — and guessing which candidate renumbered into which would be exactly the unverified causal story this layer must not tell.
- A test pins that a **genuine** collateral departure is still named while renumbering is happening, so this cannot become a blanket excuse.

## What this does NOT claim

⚠️ A correlation, not a mechanism. This does **not** establish that renumbering explains #155's unexplained `over` symptom. That remains unproven, and `runBatchOperation` re-resolving ids after prior mutations argues against it. `renumbered` says only *"these ids changed"*.

It does mean some past `unrequested` readings may have been this rather than real collateral — worth keeping in mind when reading the field going forward.

## Verification

3 of the 4 new tests fail against the pre-fix source; the 4th is a cry-wolf guard (nothing reported when no id changed) and holds in both directions.

The simulator gained the ability to renumber survivors **while leaving Message-IDs untouched** — that asymmetry is the entire point, and without it the bug is not expressible.

Suite: 692 passed / 48 files. `typecheck` clean, `lint` 0 errors, `format:check` clean.
