### PR TITLE
feat(local-store): make On My Mac mail addressable, not just listable (#183, #193)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.15.1",
+      "version": "2.16.0",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.15.1",
+      "version": "2.16.0",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.15.1",
+      "version": "2.16.0",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 ## [Unreleased]
 
+## [2.16.0] - 2026-08-16
+
+**Closes #183** and **#193**. 2.14.0 made Mail's local "On My Mac" mailboxes
+visible; this makes the mail inside them reachable.
+
+### Added
+
+- **The local store is addressable, not just listable.** `list-messages`,
+  `search-messages` and by-id reads (`get-message`, and the raw-source path
+  behind reply/forward) all reach local mailboxes now:
+
+  - `list-messages account="On My Mac" mailbox="Import"` returns the messages.
+  - `search-messages account="On My Mac"` searches them.
+  - `get-message id=<n>` resolves a message that lives only in a local mailbox.
+    The unscoped by-id walk gained a local pass, and the scoped fast path
+    understands a recorded local location instead of asking for an account that
+    cannot exist (`first account whose name is "On My Mac"` raises, which would
+    have dropped every local read back to the slow full scan).
+
+  Mailbox-name resolution is local-aware too, so aliases and casing work the
+  same way there as on an account.
+
+  Note the by-id walk collects local hits into the **same** candidate set as
+  account hits. An id present both in an account mailbox and locally is now
+  correctly reported as **ambiguous** rather than silently resolving to the
+  account copy — the same refusal the server already makes across accounts.
+
+### Fixed
+
+- **The mailbox create/delete/rename failure message claimed local mailboxes
+  were exempt, and they are not (#193).** It said *"only local 'On My Mac'
+  mailboxes support this"*. Measured 2026-08-16: `delete` on a genuinely local
+  mailbox raises `-10000` in every form — a bound reference, `delete mailbox
+  "X"`, and via the parent. So a user who had just failed to delete a local
+  mailbox was told local mailboxes are the ones that work.
+
+  `create` **does** succeed, which makes the asymmetry easy to trip over:
+  anything that creates a local mailbox cannot remove it through this server.
+
+  The remedy in the message was always right; only the exemption was wrong. It
+  now names the local store as affected too, and points at the IMAP path for
+  IMAP-configured accounts, which genuinely does work.
+
+### Notes
+
+- Application-level `mailboxes` is **flat** over nested local folders, with leaf
+  names — the last open question on #183, settled by creating a nested local
+  mailbox and observing both it and its parent appear as separate top-level
+  entries. Same shape as `mailboxes of account`, so the design needed no change.
+
 ## [2.15.1] - 2026-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -953,6 +953,11 @@ accounts only: the local store is a store, not an account. Nothing selects it
 implicitly — omitting `account` still resolves to a real account for every other
 tool.
 
+The mail inside them is reachable too: `list-messages` and `search-messages`
+accept `account="On My Mac"`, and `get-message` resolves an id that lives only in
+a local mailbox. An id present **both** in an account mailbox and locally is
+reported as ambiguous rather than silently resolving to the account copy.
+
 ---
 
 #### `get-unread-count`

--- a/build/index.js
+++ b/build/index.js
@@ -78980,7 +78980,7 @@ function describeMailboxOpError(op, raw) {
   const trimmed = (raw || "").trim();
   if (UNSUPPORTED_APPLESCRIPT_OP.test(trimmed)) {
     const verb = op.charAt(0).toUpperCase() + op.slice(1);
-    return `Mail.app cannot ${op} server-side (IMAP / Gmail / Workspace / iCloud / Exchange) mailboxes via AppleScript \u2014 only local "On My Mac" mailboxes support this. ${verb} it in Mail.app directly. (Mail.app error: ${trimmed})`;
+    return `Mail.app's scripting bridge will not ${op} this mailbox. That covers server-side (IMAP / Gmail / Workspace / iCloud / Exchange) mailboxes, and on current macOS it covers local "On My Mac" mailboxes too \u2014 measured 2026-08-16, see #193. ${verb} it in Mail.app directly; for an IMAP-configured account the IMAP path can do it instead. (Mail.app error: ${trimmed})`;
   }
   return trimmed || `Failed to ${op} mailbox`;
 }
@@ -80227,7 +80227,9 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       }
       return { messages: allMessages.slice(0, limit), diagnostics };
     }
-    const targetAccount = this.resolveAccount(account);
+    const local = isLocalStoreLabel(account);
+    const targetAccount = local ? LOCAL_STORE_LABEL : this.resolveAccount(account);
+    const mbIter = local ? "_mbs" : "mailboxes";
     const searchCondition = buildSearchCondition({ query, from, subject, isRead, isFlagged });
     let dateSetup = "";
     let dateFilter = "";
@@ -80259,7 +80261,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       set _wantNames to ${nameList}
       set msgCount to 0
       set seenIds to {}
-      repeat with mb in mailboxes
+      repeat with mb in ${mbIter}
         if msgCount >= ${limit} then exit repeat
         set mbName to ""
         try
@@ -80304,7 +80306,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       set _skipped to ""
       set _notSearched to ""
       set _startedAt to current date
-      repeat with mb in mailboxes
+      repeat with mb in ${mbIter}
         if msgCount >= ${limit} then exit repeat
         set mbName to ""
         try
@@ -80334,7 +80336,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       return outputText & "${DIAG_MARKER}timedOut=" & (_timedOut as string) & "${DIAG_FIELD_SEP}skipped=" & _skipped & "${DIAG_FIELD_SEP}notSearched=" & _notSearched
     `;
     }
-    const script = buildAccountScopedScript(targetAccount, searchCommand);
+    const script = local ? buildAppLevelScript(`${localMailboxBindingFragment()}${searchCommand}`) : buildAccountScopedScript(targetAccount, searchCommand);
     const result = executeAppleScript(script, { timeoutMs: SEARCH_ACCOUNT_TIMEOUT_MS });
     if (!result.success) {
       console.error(`Failed to search messages in "${targetAccount}": ${result.error}`);
@@ -80445,9 +80447,16 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
    */
   scopedByIdScript(account, mailbox, id, innerAction) {
     const resolved = this.resolveMailbox(mailbox, account);
-    return buildAppLevelScript(`
-      try
-        set acct to (first account whose name is "${escapeForAppleScript(account)}")
+    const bind = isLocalStoreLabel(account) ? `${localMailboxBindingFragment()}
+        set targetMb to missing value
+        ignoring case
+          repeat with mb in _mbs
+            if (name of mb) is "${escapeForAppleScript(resolved)}" then
+              set targetMb to mb
+              exit repeat
+            end if
+          end repeat
+        end ignoring` : `set acct to (first account whose name is "${escapeForAppleScript(account)}")
         set targetMb to missing value
         ignoring case
           repeat with mb in mailboxes of acct
@@ -80456,7 +80465,10 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
               exit repeat
             end if
           end repeat
-        end ignoring
+        end ignoring`;
+    return buildAppLevelScript(`
+      try
+        ${bind}
         if targetMb is not missing value then
           set matchingMsgs to (messages of targetMb whose id is ${Number(id)})
           if (count of matchingMsgs) > 0 then
@@ -80519,6 +80531,19 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
               end if
             end try
           end repeat
+        end repeat
+        -- #183: local mailboxes belong to no account, so the walk above cannot
+        -- reach them. Collect into the SAME _hits/_names, which means an id
+        -- present both in an account and locally is now correctly reported as
+        -- ambiguous rather than silently resolving to the account copy.${localMailboxBindingFragment()}
+        repeat with mb in _mbs
+          try
+            set matchingMsgs to (messages of mb whose id is ${Number(id)})
+            if (count of matchingMsgs) > 0 then
+              set end of _hits to item 1 of matchingMsgs
+              set _names to _names & "${LOCAL_STORE_LABEL}/" & (name of mb) & ", "
+            end if
+          end try
         end repeat
         if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
         if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
@@ -80610,6 +80635,19 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             end try
           end repeat
         end repeat
+        -- #183: local mailboxes belong to no account, so the walk above cannot
+        -- reach them. Collect into the SAME _hits/_names, which means an id
+        -- present both in an account and locally is now correctly reported as
+        -- ambiguous rather than silently resolving to the account copy.${localMailboxBindingFragment()}
+        repeat with mb in _mbs
+          try
+            set matchingMsgs to (messages of mb whose id is ${Number(id)})
+            if (count of matchingMsgs) > 0 then
+              set end of _hits to item 1 of matchingMsgs
+              set _names to _names & "${LOCAL_STORE_LABEL}/" & (name of mb) & ", "
+            end if
+          end try
+        end repeat
         if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
         if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
         if (count of _hits) is 1 then
@@ -80673,10 +80711,12 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       }
       return { messages: allMessages.slice(0, limit), diagnostics };
     }
-    const targetAccount = this.resolveAccount(account);
+    const local = isLocalStoreLabel(account);
+    const targetAccount = local ? LOCAL_STORE_LABEL : this.resolveAccount(account);
     const safeFrom = from ? escapeForAppleScript(from) : "";
     const fromFilter = from ? `whose sender contains "${safeFrom}"` : "";
     const scanThreshold = getMailboxScanThreshold();
+    const mbIter = local ? "_mbs" : "mailboxes";
     let listCommand;
     if (mailbox) {
       const targetMailbox = this.resolveMailbox(mailbox, targetAccount);
@@ -80691,7 +80731,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       set msgCount to 0
       set skipped to 0
       set seenIds to {}
-      repeat with mb in mailboxes
+      repeat with mb in ${mbIter}
         if msgCount >= ${limit} then exit repeat
         set mbName to ""
         try
@@ -80738,7 +80778,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       set _skipped to ""
       set _notSearched to ""
       set _startedAt to current date
-      repeat with mb in mailboxes
+      repeat with mb in ${mbIter}
         if msgCount >= ${limit} then exit repeat
         set mbName to ""
         try
@@ -80768,7 +80808,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       return outputText & "${DIAG_MARKER}timedOut=" & (_timedOut as string) & "${DIAG_FIELD_SEP}skipped=" & _skipped & "${DIAG_FIELD_SEP}notSearched=" & _notSearched
     `;
     }
-    const script = buildAccountScopedScript(targetAccount, listCommand);
+    const script = local ? buildAppLevelScript(`${localMailboxBindingFragment()}${listCommand}`) : buildAccountScopedScript(targetAccount, listCommand);
     const result = executeAppleScript(script, { timeoutMs: SEARCH_ACCOUNT_TIMEOUT_MS });
     if (!result.success) {
       console.error(`Failed to list messages in "${targetAccount}": ${result.error}`);
@@ -82736,16 +82776,14 @@ end tell`;
    * Used internally by the cache; prefer getCachedMailboxNames().
    */
   fetchMailboxNames(account) {
-    const script = buildAccountScopedScript(
-      account,
-      `
+    const body = `
       set mbNames to {}
-      repeat with mb in mailboxes
+      repeat with mb in ${isLocalStoreLabel(account) ? "_mbs" : "mailboxes"}
         set end of mbNames to name of mb
       end repeat
       return mbNames
-    `
-    );
+    `;
+    const script = isLocalStoreLabel(account) ? buildAppLevelScript(`${localMailboxBindingFragment()}${body}`) : buildAccountScopedScript(account, body);
     const result = executeAppleScript(script);
     if (!result.success || !result.output) {
       return [];

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.15.1"
+        "apple-mail-mcp@2.16.0"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleMailManager.guard.test.ts
+++ b/src/services/appleMailManager.guard.test.ts
@@ -248,10 +248,21 @@ describe("server-side create/rename guard (BUG B)", () => {
 });
 
 describe("describeMailboxOpError create verb", () => {
-  it("maps a -10000 create failure to the server-side-mailbox explanation", () => {
+  it("maps a -10000 create failure to the scripting-bridge explanation", () => {
     const msg = describeMailboxOpError("create", "AppleEvent handler failed (-10000)");
-    expect(msg).toMatch(/Mail\.app cannot create server-side/);
+    expect(msg).toMatch(/scripting bridge will not create this mailbox/);
     expect(msg).toMatch(/Create it in Mail\.app directly/);
+  });
+
+  // #193: the message used to say "only local On My Mac mailboxes support
+  // this". Measured 2026-08-16, a local mailbox raises -10000 too — so that
+  // clause sent a user who had just failed on a local mailbox looking in
+  // exactly the wrong place. The remedy was right; the exemption was not.
+  it("does NOT claim local On My Mac mailboxes are exempt", () => {
+    const msg = describeMailboxOpError("delete", "AppleEvent handler failed (-10000)");
+    expect(msg).not.toMatch(/only local .* support this/i);
+    expect(msg).toMatch(/local "On My Mac" mailboxes too/);
+    expect(msg).toMatch(/Delete it in Mail\.app directly/);
   });
 
   it("passes through an unrelated create error unchanged", () => {

--- a/src/services/appleMailManager.localStore.test.ts
+++ b/src/services/appleMailManager.localStore.test.ts
@@ -150,3 +150,50 @@ describe("#183 the local store is addressable as a synthetic account", () => {
     expect(checked.error).toMatch(/-1728/);
   });
 });
+
+describe("#183 the local store is addressable, not just listable", () => {
+  /** The last generated script, which is what actually reaches Mail. */
+  const lastScript = (): string => h.calls[h.calls.length - 1];
+
+  it("list-messages scopes to the local store without a `tell account`", () => {
+    mgr.listMessages("Import", LOCAL_STORE_LABEL, 5);
+    expect(lastScript()).not.toMatch(/tell account/);
+    expect(lastScript()).toMatch(/account of _m\) is missing value/);
+  });
+
+  it("search-messages scopes to the local store the same way", () => {
+    mgr.searchMessages("anything", undefined, LOCAL_STORE_LABEL, 5);
+    expect(lastScript()).not.toMatch(/tell account/);
+    expect(lastScript()).toMatch(/account of _m\) is missing value/);
+  });
+
+  it("the unscoped by-id walk also searches local mailboxes", () => {
+    mgr.getMessageContent("109", false);
+    const walk = h.calls.filter((c) => c.includes("_hits")).pop() ?? "";
+    // Both passes must be present: accounts AND the local store.
+    expect(walk).toMatch(/repeat with acct in accounts/);
+    expect(walk).toMatch(/repeat with mb in _mbs/);
+    // And a local hit is attributed to the synthetic label, not to "".
+    expect(walk).toContain(`"${LOCAL_STORE_LABEL}/"`);
+  });
+
+  it("a recorded LOCAL location does not ask for an account that cannot exist", () => {
+    // `first account whose name is "On My Mac"` raises, which would silently
+    // drop every local by-id read back to the slow full scan.
+    mgr.listMessages("Import", LOCAL_STORE_LABEL, 5); // records the location
+    h.calls.length = 0;
+    mgr.getMessageContent("109", false);
+    const scoped = h.calls.find((c) => c.includes("targetMb")) ?? "";
+    if (scoped) {
+      expect(scoped).not.toMatch(/first account whose name is "On My Mac"/);
+    }
+  });
+
+  // Don't-regress: a real account still takes the account-scoped form.
+  it("a real account still uses `tell account` for list and search", () => {
+    mgr.listMessages("INBOX", "rob@superiortech.io", 5);
+    expect(lastScript()).toMatch(/tell account "rob@superiortech\.io"/);
+    mgr.searchMessages("x", undefined, "rob@superiortech.io", 5);
+    expect(lastScript()).toMatch(/tell account "rob@superiortech\.io"/);
+  });
+});

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -375,7 +375,13 @@ export function describeMailboxOpError(op: "create" | "delete" | "rename", raw: 
   const trimmed = (raw || "").trim();
   if (UNSUPPORTED_APPLESCRIPT_OP.test(trimmed)) {
     const verb = op.charAt(0).toUpperCase() + op.slice(1);
-    return `Mail.app cannot ${op} server-side (IMAP / Gmail / Workspace / iCloud / Exchange) mailboxes via AppleScript — only local "On My Mac" mailboxes support this. ${verb} it in Mail.app directly. (Mail.app error: ${trimmed})`;
+    return (
+      `Mail.app's scripting bridge will not ${op} this mailbox. That covers server-side ` +
+      `(IMAP / Gmail / Workspace / iCloud / Exchange) mailboxes, and on current macOS it covers ` +
+      `local "On My Mac" mailboxes too — measured 2026-08-16, see #193. ${verb} it in Mail.app ` +
+      `directly; for an IMAP-configured account the IMAP path can do it instead. ` +
+      `(Mail.app error: ${trimmed})`
+    );
   }
   return trimmed || `Failed to ${op} mailbox`;
 }
@@ -2232,7 +2238,13 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       return { messages: allMessages.slice(0, limit), diagnostics };
     }
 
-    const targetAccount = this.resolveAccount(account);
+    // #183: same routing as list-messages — the local store is selected only by
+    // an explicit label and has no `tell account` form.
+    const local = isLocalStoreLabel(account);
+    const targetAccount = local ? LOCAL_STORE_LABEL : this.resolveAccount(account);
+    // Inside `tell account` the bare `mailboxes` is the account's; at
+    // application level the local branch iterates the ownership-filtered `_mbs`.
+    const mbIter = local ? "_mbs" : "mailboxes";
 
     // `query` is a subject-OR-sender substring match; from/subject/isRead/isFlagged
     // are additional AND filters. Date filtering stays post-fetch below — `whose`
@@ -2294,7 +2306,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       set _wantNames to ${nameList}
       set msgCount to 0
       set seenIds to {}
-      repeat with mb in mailboxes
+      repeat with mb in ${mbIter}
         if msgCount >= ${limit} then exit repeat
         set mbName to ""
         try
@@ -2343,7 +2355,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       set _skipped to ""
       set _notSearched to ""
       set _startedAt to current date
-      repeat with mb in mailboxes
+      repeat with mb in ${mbIter}
         if msgCount >= ${limit} then exit repeat
         set mbName to ""
         try
@@ -2374,7 +2386,9 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     `;
     }
 
-    const script = buildAccountScopedScript(targetAccount, searchCommand);
+    const script = local
+      ? buildAppLevelScript(`${localMailboxBindingFragment()}${searchCommand}`)
+      : buildAccountScopedScript(targetAccount, searchCommand);
     const result = executeAppleScript(script, { timeoutMs: SEARCH_ACCOUNT_TIMEOUT_MS });
 
     if (!result.success) {
@@ -2512,9 +2526,22 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     innerAction: string
   ): string {
     const resolved = this.resolveMailbox(mailbox, account);
-    return buildAppLevelScript(`
-      try
-        set acct to (first account whose name is "${escapeForAppleScript(account)}")
+    // #183: a recorded location can now name the LOCAL store, which is not an
+    // account — `first account whose name is "On My Mac"` would raise and drop
+    // us to the slow full scan every time. Bind the mailbox at the application
+    // level instead, through the same ownership filter.
+    const bind = isLocalStoreLabel(account)
+      ? `${localMailboxBindingFragment()}
+        set targetMb to missing value
+        ignoring case
+          repeat with mb in _mbs
+            if (name of mb) is "${escapeForAppleScript(resolved)}" then
+              set targetMb to mb
+              exit repeat
+            end if
+          end repeat
+        end ignoring`
+      : `set acct to (first account whose name is "${escapeForAppleScript(account)}")
         set targetMb to missing value
         ignoring case
           repeat with mb in mailboxes of acct
@@ -2523,7 +2550,10 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
               exit repeat
             end if
           end repeat
-        end ignoring
+        end ignoring`;
+    return buildAppLevelScript(`
+      try
+        ${bind}
         if targetMb is not missing value then
           set matchingMsgs to (messages of targetMb whose id is ${Number(id)})
           if (count of matchingMsgs) > 0 then
@@ -2610,6 +2640,19 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
               end if
             end try
           end repeat
+        end repeat
+        -- #183: local mailboxes belong to no account, so the walk above cannot
+        -- reach them. Collect into the SAME _hits/_names, which means an id
+        -- present both in an account and locally is now correctly reported as
+        -- ambiguous rather than silently resolving to the account copy.${localMailboxBindingFragment()}
+        repeat with mb in _mbs
+          try
+            set matchingMsgs to (messages of mb whose id is ${Number(id)})
+            if (count of matchingMsgs) > 0 then
+              set end of _hits to item 1 of matchingMsgs
+              set _names to _names & "${LOCAL_STORE_LABEL}/" & (name of mb) & ", "
+            end if
+          end try
         end repeat
         if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
         if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
@@ -2733,6 +2776,19 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             end try
           end repeat
         end repeat
+        -- #183: local mailboxes belong to no account, so the walk above cannot
+        -- reach them. Collect into the SAME _hits/_names, which means an id
+        -- present both in an account and locally is now correctly reported as
+        -- ambiguous rather than silently resolving to the account copy.${localMailboxBindingFragment()}
+        repeat with mb in _mbs
+          try
+            set matchingMsgs to (messages of mb whose id is ${Number(id)})
+            if (count of matchingMsgs) > 0 then
+              set end of _hits to item 1 of matchingMsgs
+              set _names to _names & "${LOCAL_STORE_LABEL}/" & (name of mb) & ", "
+            end if
+          end try
+        end repeat
         if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
         if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
         if (count of _hits) is 1 then
@@ -2815,11 +2871,19 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       return { messages: allMessages.slice(0, limit), diagnostics };
     }
 
-    const targetAccount = this.resolveAccount(account);
+    // #183: the local store is addressed by its synthetic label and has no
+    // `tell account` form. Only an EXPLICIT request selects it — resolveAccount
+    // is untouched and can still only ever return a real account.
+    const local = isLocalStoreLabel(account);
+    const targetAccount = local ? LOCAL_STORE_LABEL : this.resolveAccount(account);
 
     const safeFrom = from ? escapeForAppleScript(from) : "";
     const fromFilter = from ? `whose sender contains "${safeFrom}"` : "";
     const scanThreshold = getMailboxScanThreshold();
+    // What the "every mailbox" loops iterate. Inside `tell account` the bare
+    // `mailboxes` binds to the account's; at application level the local branch
+    // iterates the ownership-filtered `_mbs` instead (#183).
+    const mbIter = local ? "_mbs" : "mailboxes";
 
     let listCommand: string;
 
@@ -2848,7 +2912,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       set msgCount to 0
       set skipped to 0
       set seenIds to {}
-      repeat with mb in mailboxes
+      repeat with mb in ${mbIter}
         if msgCount >= ${limit} then exit repeat
         set mbName to ""
         try
@@ -2897,7 +2961,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       set _skipped to ""
       set _notSearched to ""
       set _startedAt to current date
-      repeat with mb in mailboxes
+      repeat with mb in ${mbIter}
         if msgCount >= ${limit} then exit repeat
         set mbName to ""
         try
@@ -2928,7 +2992,9 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     `;
     }
 
-    const script = buildAccountScopedScript(targetAccount, listCommand);
+    const script = local
+      ? buildAppLevelScript(`${localMailboxBindingFragment()}${listCommand}`)
+      : buildAccountScopedScript(targetAccount, listCommand);
     const result = executeAppleScript(script, { timeoutMs: SEARCH_ACCOUNT_TIMEOUT_MS });
 
     if (!result.success) {
@@ -5499,16 +5565,19 @@ end tell`;
    * Used internally by the cache; prefer getCachedMailboxNames().
    */
   private fetchMailboxNames(account: string): string[] {
-    const script = buildAccountScopedScript(
-      account,
-      `
+    const body = `
       set mbNames to {}
-      repeat with mb in mailboxes
+      repeat with mb in ${isLocalStoreLabel(account) ? "_mbs" : "mailboxes"}
         set end of mbNames to name of mb
       end repeat
       return mbNames
-    `
-    );
+    `;
+    // #183: the local store has no `tell account` form. Routing it here is what
+    // makes `resolveMailbox` — and therefore every case-insensitive / alias
+    // lookup downstream — work against a local mailbox name.
+    const script = isLocalStoreLabel(account)
+      ? buildAppLevelScript(`${localMailboxBindingFragment()}${body}`)
+      : buildAccountScopedScript(account, body);
 
     const result = executeAppleScript(script);
     if (!result.success || !result.output) {


### PR DESCRIPTION
**Closes #183.** **Closes #193.**

2.14.0 made Mail's local "On My Mac" mailboxes visible. This makes the mail inside them reachable, which is what the issue was actually about.

## What works now

| call | before | after |
|---|---|---|
| `list-messages account="On My Mac" mailbox="Import"` | nothing | the messages |
| `search-messages account="On My Mac"` | nothing | searches them |
| `get-message id=<n>` for a local-only message | "Message not found" | resolves it |

Mailbox-name resolution is local-aware too, so aliases and casing work the same there as on an account.

**Verified end to end against live Mail** on `robs-homeoffice-mbpromax`, against the real 47-message `Import` mailbox:

- `list-messages` returned real rows (`109 | "Pricing Tool Rewrite…" | Robert Sweet <…> | 2022-10-19 …`)
- `search-messages` found a message inside it, correctly tagged with the mailbox name
- `get-message id=109` returned its subject, Message-ID and body

All three previously returned nothing.

## Two decisions worth flagging

**The scoped fast path needed a local branch, not just the walk.** `first account whose name is "On My Mac"` *raises* — so without this, every local by-id read would have silently fallen back to the slow full-mailbox scan on every single call, which is the exact performance trap `scopedByIdScript` exists to avoid.

**Local hits go into the SAME candidate set as account hits.** So an id present both in an account mailbox and locally is now reported as **ambiguous** rather than silently resolving to the account copy. That is a behaviour change, and it is the right one — it is the same refusal the server already makes when an id is ambiguous across accounts, and picking the account copy by luck of iteration order is the #152/#155 defect class.

## #193, found while doing this

Settling the flatness question needed a throwaway nested local mailbox. Creating one **works**; deleting one **fails with -10000 in every form** — bound reference, `delete mailbox "X"`, and via the parent.

That matters because the failure message said *"only local 'On My Mac' mailboxes support this"* — telling a user who had just failed to delete a local mailbox that local mailboxes are the ones that work. The remedy in the message was always right; only the exemption was wrong. Now corrected, with a pointer to the IMAP path for IMAP-configured accounts, which genuinely does work.

⚠️ The asymmetry has a practical consequence worth knowing: **anything that creates a local mailbox cannot clean up after itself through this server.**

## #183's last open question, settled

Application-level `mailboxes` is **flat** over nested local folders, with **leaf** names — verified by creating `AMCPFlatTest` and `AMCPFlatTest/Nested` and observing both appear as separate top-level entries (`Nested`, `AMCPFlatTest`). Same shape as `mailboxes of account`, so the design needed no change.

## Verification

5 new guards on top of the 7 from 2.14.0, including don't-regress guards that a real account still takes the account-scoped form for both list and search. The `-10000` message has a guard pinning that it no longer claims local mailboxes are exempt.

Suite: 698 passed / 48 files. `typecheck` clean, `lint` 0 errors, `format:check` clean.
