### PR TITLE
fix(imap): search all provider mailboxes

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.0",
+      "version": "2.17.1",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.0",
+      "version": "2.17.1",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.17.0",
+      "version": "2.17.1",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [2.17.1] - 2026-08-25
+
 ### Fixed
 
 - Unscoped IMAP `search-messages` no longer assumes every provider exposes
@@ -8,6 +10,7 @@
   mailbox (including iCloud folders), de-duplicates by Message-ID, and applies
   offset/limit to the globally newest results. Mailboxes that cannot be
   searched are named in partial-result diagnostics instead of being hidden.
+  (#199, #200 — thanks @fkoehler)
 
 ## [2.17.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+### Fixed
+
+- Unscoped IMAP `search-messages` no longer assumes every provider exposes
+  Gmail's `[Gmail]/All Mail` path. The server now uses an advertised RFC 6154
+  `\\All` mailbox when one exists; otherwise it searches every selectable
+  mailbox (including iCloud folders), de-duplicates by Message-ID, and applies
+  offset/limit to the globally newest results. Mailboxes that cannot be
+  searched are named in partial-result diagnostics instead of being hidden.
+
 ## [2.17.0] - 2026-08-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -470,11 +470,20 @@ matching `account` is passed. There are three cases:
   sort newest-first; count tools (`get-unread-count`, `get-mail-stats`) count each
   account via exactly one backend so a coverage mismatch can never double- (or
   under-) count.
-  - **Default mailbox is resolved per account.** When you don't pin a `mailbox`, a
-    fan-out search scopes each account to its own default — Gmail/Workspace to
-    `[Gmail]/All Mail`, every other IMAP host (iCloud, etc.) to `INBOX` (since
-    `[Gmail]/All Mail` is Gmail-only and selecting it elsewhere would silently drop
-    that account). Pin a `mailbox` to search a wider scope on non-Gmail accounts.
+  - **An omitted mailbox on `search-messages` searches the account's entire
+    store, not just one default folder** (v2.17.1, [#199](https://github.com/sweetrb/apple-mail-mcp/issues/199)).
+    Per account, the fan-out uses the server-advertised RFC 6154 `\All`
+    mailbox when one exists (Gmail/Workspace's `[Gmail]/All Mail`); otherwise
+    it searches every selectable mailbox the server lists (iCloud, generic
+    IMAP), merges the matches, de-duplicates by Message-ID, and sorts
+    newest-first before applying `limit`/`offset`. A mailbox that can't be
+    selected or searched is named in the result instead of silently dropping
+    coverage. Scanning every mailbox on a large, deeply-nested account costs
+    one `SEARCH` + a bounded `FETCH` per mailbox over the pooled IMAP
+    connection — pin a `mailbox` to skip the fan-out when you already know
+    where to look. `list-messages` (no query) still defaults an omitted
+    mailbox to `INBOX` on every provider — only unscoped *search* scans the
+    whole account.
 
 If IMAP is **not** configured at all, every read behaves exactly as before
 (pure AppleScript). The three mailbox-**write** ops (`create-mailbox`,

--- a/build/index.js
+++ b/build/index.js
@@ -84030,8 +84030,8 @@ var defaultConnect = async (cfg) => {
   }
   return client;
 };
-function resolveMailboxPath(mailbox, mode) {
-  if (!mailbox) return mode === "search" ? "[Gmail]/All Mail" : "INBOX";
+function resolveMailboxPath(mailbox, _mode) {
+  if (!mailbox) return "INBOX";
   const map = {
     "all mail": "[Gmail]/All Mail",
     "sent mail": "[Gmail]/Sent Mail",
@@ -84094,49 +84094,127 @@ function structuredRow(m, account, path) {
     ...env.messageId ? { messageId: env.messageId } : {}
   };
 }
+function hasMailboxFlag(mailbox, wanted) {
+  const normalized = wanted.toLowerCase();
+  return [...mailbox.flags ?? []].some((flag) => flag.toLowerCase() === normalized);
+}
+function messageDateEpoch(message) {
+  if (!message.envelope?.date) return 0;
+  const epoch = new Date(message.envelope.date).getTime();
+  return Number.isNaN(epoch) ? 0 : epoch;
+}
+function messageIdentity(entry) {
+  const raw = entry.message.envelope?.messageId?.trim() ?? "";
+  const messageId = raw.replace(/^<+|>+$/g, "").trim().toLowerCase();
+  return messageId ? `mid:${messageId}` : `${entry.path}\0${entry.message.uid}`;
+}
+async function fetchMailboxMatches(client, path, criteria, newestCount) {
+  const lock = await client.getMailboxLock(path);
+  try {
+    const found = await client.search(criteria, { uid: true });
+    const uids = Array.isArray(found) ? found : [];
+    if (uids.length === 0 || newestCount === 0) return { messages: [], total: uids.length };
+    const newest = uids.slice().reverse().slice(0, newestCount);
+    const byUid = /* @__PURE__ */ new Map();
+    for await (const msg of client.fetch(
+      newest.join(","),
+      // BODYSTRUCTURE rides along so `hasAttachments` is computed rather
+      // than assumed. Measured on 50 real messages: ~390ms -> ~465ms for
+      // the fetch (~17%), same single round trip, no extra request.
+      { envelope: true, flags: true, bodyStructure: true },
+      { uid: true }
+    )) {
+      byUid.set(msg.uid, msg);
+    }
+    return {
+      messages: newest.map((uid) => byUid.get(uid)).filter((message) => message !== void 0),
+      total: uids.length
+    };
+  } finally {
+    lock.release();
+  }
+}
 async function run(args, listMode, deps) {
   return useClient(
     { ...deps, account: deps.account ?? args.account },
     async (client, cfg) => {
-      const path = resolveMailboxPath(args.mailbox, listMode ? "list" : "search");
-      const lock = await client.getMailboxLock(path);
-      try {
-        const found = await client.search(buildCriteria(args, listMode), { uid: true });
-        const uids = Array.isArray(found) ? found : [];
-        if (uids.length === 0) {
-          return {
-            text: `No messages found via IMAP in "${path}" (account ${cfg.accountLabel}).`,
-            messages: [],
-            count: 0,
-            partial: false
-          };
+      const unscopedSearch = !listMode && !args.mailbox;
+      let paths;
+      let allMailboxCount = 0;
+      if (unscopedSearch) {
+        const listed = await client.list();
+        const selectable = listed.filter((mailbox) => !hasMailboxFlag(mailbox, "\\Noselect"));
+        const allMailbox = selectable.find(
+          (mailbox) => mailbox.specialUse?.toLowerCase() === "\\all"
+        );
+        paths = allMailbox ? [allMailbox.path] : selectable.map((mailbox) => mailbox.path);
+        allMailboxCount = paths.length;
+        if (paths.length === 0) {
+          throw new Error(`No selectable IMAP mailboxes found for account ${cfg.accountLabel}.`);
         }
-        const limit = args.limit ?? 50;
-        const offset = args.offset ?? 0;
-        const newest = uids.slice().reverse().slice(offset, offset + limit);
-        const byUid = /* @__PURE__ */ new Map();
-        for await (const msg of client.fetch(
-          newest.join(","),
-          // BODYSTRUCTURE rides along so `hasAttachments` is computed rather
-          // than assumed. Measured on 50 real messages: ~390ms -> ~465ms for
-          // the fetch (~17%), same single round trip, no extra request.
-          { envelope: true, flags: true, bodyStructure: true },
-          { uid: true }
-        )) {
-          byUid.set(msg.uid, msg);
+      } else {
+        paths = [resolveMailboxPath(args.mailbox, listMode ? "list" : "search")];
+      }
+      const limit = args.limit ?? 50;
+      const offset = args.offset ?? 0;
+      const criteria = buildCriteria(args, listMode);
+      const newestPerMailbox = offset + limit;
+      const fetched = [];
+      const failedMailboxes = [];
+      let totalMatched = 0;
+      for (const path of paths) {
+        try {
+          const result = await fetchMailboxMatches(client, path, criteria, newestPerMailbox);
+          totalMatched += result.total;
+          fetched.push(...result.messages.map((message) => ({ message, path })));
+        } catch (error2) {
+          failedMailboxes.push(path);
+          console.error(
+            `IMAP ${listMode ? "list" : "search"} failed for account "${cfg.accountLabel}", mailbox "${path}": ${String(error2)}`
+          );
         }
-        const ordered = newest.map((u) => byUid.get(u)).filter((m) => m !== void 0);
-        const rows = ordered.map((m) => formatRow(m, cfg.accountLabel, path));
-        const messages = ordered.map((m) => structuredRow(m, cfg.accountLabel, path));
-        const verb = listMode ? "listed" : "matched";
-        const text = `Found ${rows.length} message(s) via IMAP (server-side, account ${cfg.accountLabel}, mailbox "${path}"; ${uids.length} total ${verb}):
+      }
+      if (failedMailboxes.length === paths.length) {
+        throw new Error(
+          `IMAP ${listMode ? "list" : "search"} failed in every requested mailbox for account ${cfg.accountLabel}: ${failedMailboxes.join(", ")}.`
+        );
+      }
+      let ordered = fetched;
+      if (unscopedSearch) {
+        ordered = fetched.slice().sort((a, b) => messageDateEpoch(b.message) - messageDateEpoch(a.message));
+        const unique = /* @__PURE__ */ new Map();
+        for (const entry of ordered) {
+          const key = messageIdentity(entry);
+          if (!unique.has(key)) unique.set(key, entry);
+        }
+        ordered = [...unique.values()].slice(offset, offset + limit);
+      } else {
+        ordered = fetched.slice(offset, offset + limit);
+      }
+      const rows = ordered.map(({ message, path }) => formatRow(message, cfg.accountLabel, path));
+      const messages = ordered.map(
+        ({ message, path }) => structuredRow(message, cfg.accountLabel, path)
+      );
+      const partial2 = failedMailboxes.length > 0;
+      const failureNote = partial2 ? `
+
+Partial result. Could not search mailbox(es): ${failedMailboxes.map((path) => `"${path}"`).join(", ")}.` : "";
+      const verb = listMode ? "listed" : "matched";
+      const scope = unscopedSearch ? allMailboxCount === 1 ? `mailbox "${paths[0]}"` : `${allMailboxCount} selectable mailboxes` : `mailbox "${paths[0]}"`;
+      if (messages.length === 0) {
+        return {
+          text: `No messages found via IMAP in ${scope} (account ${cfg.accountLabel}).${failureNote}`,
+          messages,
+          count: 0,
+          partial: partial2,
+          failedMailboxes
+        };
+      }
+      const text = `Found ${rows.length} message(s) via IMAP (server-side, account ${cfg.accountLabel}, ${scope}; ${totalMatched} total ${verb}):
 ` + rows.join("\n") + `
 
-Note: these IMAP IDs (imap:\u2026) work with get-message and the message mutations (mark/flag/move/delete-message), which route back to IMAP.`;
-        return { text, messages, count: messages.length, partial: false };
-      } finally {
-        lock.release();
-      }
+Note: these IMAP IDs (imap:\u2026) work with get-message and the message mutations (mark/flag/move/delete-message), which route back to IMAP.` + failureNote;
+      return { text, messages, count: messages.length, partial: partial2, failedMailboxes };
     },
     true
   );
@@ -85240,26 +85318,26 @@ function mergeMessages(imapRows, appleRows, limit) {
   merged.sort((a, b) => dateEpoch(b) - dateEpoch(a));
   return limit >= 0 ? merged.slice(0, limit) : merged;
 }
-function isGmailHost(host) {
-  return /(^|\.)gmail\.com$/i.test(host.trim());
-}
 async function fanOutImapMessages(args, kind, deps = {}, configs = resolveImapConfigs()) {
   const rows = [];
   const accountsQueried = [];
   const accountsFailed = [];
+  const failedMailboxes = [];
   for (const config2 of configs) {
-    const mailbox = args.mailbox ?? (isGmailHost(config2.host) ? void 0 : "INBOX");
-    const perAccountArgs = { ...args, account: void 0, mailbox };
+    const perAccountArgs = { ...args, account: void 0 };
     try {
       const res = kind === "search" ? await imapSearchMessages(perAccountArgs, { ...deps, config: config2 }) : await imapListMessages(perAccountArgs, { ...deps, config: config2 });
       rows.push(...res.messages);
       accountsQueried.push(config2.accountLabel);
+      failedMailboxes.push(
+        ...res.failedMailboxes.map((mailbox) => `${config2.accountLabel} / ${mailbox}`)
+      );
     } catch (e) {
       accountsFailed.push(config2.accountLabel);
       console.error(`IMAP fan-out failed for account "${config2.accountLabel}": ${String(e)}`);
     }
   }
-  return { rows, accountsQueried, accountsFailed };
+  return { rows, accountsQueried, accountsFailed, failedMailboxes };
 }
 function configMatchesAccount(config2, account) {
   const name = account.name.trim().toLowerCase();
@@ -85847,7 +85925,8 @@ var LIST_OUTPUT_SCHEMA = {
   partial: external_exports.boolean().optional(),
   skippedLargeMailboxes: external_exports.array(external_exports.string()).optional(),
   notSearchedMailboxes: external_exports.array(external_exports.string()).optional(),
-  timedOutAccounts: external_exports.array(external_exports.string()).optional()
+  timedOutAccounts: external_exports.array(external_exports.string()).optional(),
+  failedMailboxes: external_exports.array(external_exports.string()).optional()
 };
 var BATCH_COUNT_OUTPUT_SCHEMA = {
   ok: external_exports.boolean().optional(),
@@ -85926,8 +86005,9 @@ function mergedMessageResponse(fan, apple, limit, verb) {
   const merged = mergeMessages(fan.rows, apple.rows, limit);
   const diagnostics = {
     ...apple.diagnostics,
-    partial: apple.diagnostics.partial || fan.accountsFailed.length > 0,
-    timedOutAccounts: [...apple.diagnostics.timedOutAccounts, ...fan.accountsFailed]
+    partial: apple.diagnostics.partial || fan.accountsFailed.length > 0 || fan.failedMailboxes.length > 0,
+    timedOutAccounts: [...apple.diagnostics.timedOutAccounts, ...fan.accountsFailed],
+    notSearchedMailboxes: [...apple.diagnostics.notSearchedMailboxes, ...fan.failedMailboxes]
   };
   const structured = {
     messages: merged,
@@ -85935,7 +86015,8 @@ function mergedMessageResponse(fan, apple, limit, verb) {
     partial: diagnostics.partial,
     skippedLargeMailboxes: diagnostics.skippedLargeMailboxes,
     notSearchedMailboxes: diagnostics.notSearchedMailboxes,
-    timedOutAccounts: diagnostics.timedOutAccounts
+    timedOutAccounts: diagnostics.timedOutAccounts,
+    failedMailboxes: fan.failedMailboxes
   };
   const coverageBlock = partialCoverageBlock(diagnostics);
   if (merged.length === 0) {
@@ -86031,7 +86112,8 @@ registerTool(
           return successResponse(r.text, {
             messages: r.messages,
             count: r.count,
-            partial: r.partial
+            partial: r.partial,
+            failedMailboxes: r.failedMailboxes
           });
         }
         const fan = await fanOutImapMessages(imapArgs, "search");
@@ -86178,7 +86260,8 @@ registerTool(
       subject: external_exports.string().optional(),
       messages: external_exports.array(MESSAGE_ROW_SCHEMA).optional(),
       count: external_exports.number().optional(),
-      partial: external_exports.boolean().optional()
+      partial: external_exports.boolean().optional(),
+      failedMailboxes: external_exports.array(external_exports.string()).optional()
     }
   },
   withErrorHandling(async ({ id, account, mailbox, limit = 50 }) => {
@@ -86206,7 +86289,8 @@ ${r.text}`, {
           subject: base,
           messages: r.messages,
           count: r.count,
-          partial: r.partial
+          partial: r.partial,
+          failedMailboxes: r.failedMailboxes
         });
       }
       const fan = await fanOutImapMessages({ subject: base, mailbox, limit }, "search");
@@ -86231,17 +86315,19 @@ ${r.text}`, {
       const orderedRows = mergedNewestFirst.slice().reverse().sort(
         (a, b) => (a.dateReceived ? new Date(a.dateReceived).getTime() : 0) - (b.dateReceived ? new Date(b.dateReceived).getTime() : 0)
       );
-      const partial2 = apple.diagnostics.partial || fan.accountsFailed.length > 0;
+      const partial2 = apple.diagnostics.partial || fan.accountsFailed.length > 0 || fan.failedMailboxes.length > 0;
       const coverage = partialCoverageBlock({
         ...apple.diagnostics,
         partial: partial2,
-        timedOutAccounts: [...apple.diagnostics.timedOutAccounts, ...fan.accountsFailed]
+        timedOutAccounts: [...apple.diagnostics.timedOutAccounts, ...fan.accountsFailed],
+        notSearchedMailboxes: [...apple.diagnostics.notSearchedMailboxes, ...fan.failedMailboxes]
       });
       const structured2 = {
         subject: base,
         messages: orderedRows,
         count: orderedRows.length,
-        partial: partial2
+        partial: partial2,
+        failedMailboxes: fan.failedMailboxes
       };
       if (orderedRows.length === 0) {
         return successResponse(`No messages found in thread "${base}".${coverage}`, structured2);
@@ -86304,7 +86390,8 @@ registerTool(
         return successResponse(r.text, {
           messages: r.messages,
           count: r.count,
-          partial: r.partial
+          partial: r.partial,
+          failedMailboxes: r.failedMailboxes
         });
       }
       const fan = await fanOutImapMessages({ mailbox, limit, offset, from, unreadOnly }, "list");

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.17.0"
+        "apple-mail-mcp@2.17.1"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,8 +188,7 @@ const FLAG_COLOR_SCHEMA = z
 const MESSAGE_ROW_SCHEMA = z.object({}).passthrough();
 
 /** Shape returned by list/search style tools (messages + count + optional
- *  partial-coverage diagnostics). Diagnostics only appear on the AppleScript
- *  path, so they are optional. */
+ *  partial-coverage diagnostics from either backend). */
 const LIST_OUTPUT_SCHEMA = {
   messages: z.array(MESSAGE_ROW_SCHEMA).optional(),
   count: z.number().optional(),
@@ -197,6 +196,7 @@ const LIST_OUTPUT_SCHEMA = {
   skippedLargeMailboxes: z.array(z.string()).optional(),
   notSearchedMailboxes: z.array(z.string()).optional(),
   timedOutAccounts: z.array(z.string()).optional(),
+  failedMailboxes: z.array(z.string()).optional(),
 };
 
 /** Shape returned by the batch count tools. */
@@ -338,7 +338,12 @@ function appleScanForAccounts(
  * @param verb "matched" (search) or "listed" (list) — only affects empty-state text.
  */
 function mergedMessageResponse(
-  fan: { rows: MessageRow[]; accountsQueried: string[]; accountsFailed: string[] },
+  fan: {
+    rows: MessageRow[];
+    accountsQueried: string[];
+    accountsFailed: string[];
+    failedMailboxes: string[];
+  },
   apple: AppleScan,
   limit: number,
   verb: "matched" | "listed"
@@ -348,8 +353,10 @@ function mergedMessageResponse(
   // partial merge is never mistaken for a confirmed "no such mail".
   const diagnostics: SearchDiagnostics = {
     ...apple.diagnostics,
-    partial: apple.diagnostics.partial || fan.accountsFailed.length > 0,
+    partial:
+      apple.diagnostics.partial || fan.accountsFailed.length > 0 || fan.failedMailboxes.length > 0,
     timedOutAccounts: [...apple.diagnostics.timedOutAccounts, ...fan.accountsFailed],
+    notSearchedMailboxes: [...apple.diagnostics.notSearchedMailboxes, ...fan.failedMailboxes],
   };
   const structured = {
     messages: merged,
@@ -358,6 +365,7 @@ function mergedMessageResponse(
     skippedLargeMailboxes: diagnostics.skippedLargeMailboxes,
     notSearchedMailboxes: diagnostics.notSearchedMailboxes,
     timedOutAccounts: diagnostics.timedOutAccounts,
+    failedMailboxes: fan.failedMailboxes,
   };
   const coverageBlock = partialCoverageBlock(diagnostics);
   if (merged.length === 0) {
@@ -556,6 +564,7 @@ registerTool(
             messages: r.messages,
             count: r.count,
             partial: r.partial,
+            failedMailboxes: r.failedMailboxes,
           });
         }
         const fan = await fanOutImapMessages(imapArgs, "search");
@@ -731,6 +740,7 @@ registerTool(
       messages: z.array(MESSAGE_ROW_SCHEMA).optional(),
       count: z.number().optional(),
       partial: z.boolean().optional(),
+      failedMailboxes: z.array(z.string()).optional(),
     },
   },
   withErrorHandling(async ({ id, account, mailbox, limit = 50 }) => {
@@ -771,6 +781,7 @@ registerTool(
           messages: r.messages,
           count: r.count,
           partial: r.partial,
+          failedMailboxes: r.failedMailboxes,
         });
       }
       const fan = await fanOutImapMessages({ subject: base, mailbox, limit }, "search");
@@ -800,17 +811,22 @@ registerTool(
             (a.dateReceived ? new Date(a.dateReceived as string).getTime() : 0) -
             (b.dateReceived ? new Date(b.dateReceived as string).getTime() : 0)
         );
-      const partial = apple.diagnostics.partial || fan.accountsFailed.length > 0;
+      const partial =
+        apple.diagnostics.partial ||
+        fan.accountsFailed.length > 0 ||
+        fan.failedMailboxes.length > 0;
       const coverage = partialCoverageBlock({
         ...apple.diagnostics,
         partial,
         timedOutAccounts: [...apple.diagnostics.timedOutAccounts, ...fan.accountsFailed],
+        notSearchedMailboxes: [...apple.diagnostics.notSearchedMailboxes, ...fan.failedMailboxes],
       });
       const structured = {
         subject: base,
         messages: orderedRows,
         count: orderedRows.length,
         partial,
+        failedMailboxes: fan.failedMailboxes,
       };
       if (orderedRows.length === 0) {
         return successResponse(`No messages found in thread "${base}".${coverage}`, structured);
@@ -905,6 +921,7 @@ registerTool(
           messages: r.messages,
           count: r.count,
           partial: r.partial,
+          failedMailboxes: r.failedMailboxes,
         });
       }
       const fan = await fanOutImapMessages({ mailbox, limit, offset, from, unreadOnly }, "list");

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -84,7 +84,7 @@ function makeClient(uids: number[], rec: Rec): ImapClientLike {
       }
     },
     fetchOne: async () => false,
-    list: async () => [],
+    list: async () => [{ path: "[Gmail]/All Mail", name: "All Mail", specialUse: "\\All" }],
     status: async (path: string) => ({ path, messages: 0, unseen: 0, recent: 0 }),
     download: async () => ({
       meta: { filename: "file.bin" },
@@ -388,8 +388,8 @@ describe("imapHealthCheck configured-gate (#138)", () => {
 });
 
 describe("resolveMailboxPath", () => {
-  it("defaults to All Mail for search, INBOX for list", () => {
-    expect(resolveMailboxPath(undefined, "search")).toBe("[Gmail]/All Mail");
+  it("uses the provider-neutral INBOX fallback when no path is pinned", () => {
+    expect(resolveMailboxPath(undefined, "search")).toBe("INBOX");
     expect(resolveMailboxPath(undefined, "list")).toBe("INBOX");
   });
   it("maps common Gmail folder names", () => {
@@ -439,6 +439,94 @@ describe("imapSearchMessages", () => {
     expect(res.text).toMatch(/No messages found via IMAP/);
     expect(res.count).toBe(0);
     expect(res.messages).toEqual([]);
+  });
+
+  it("searches every selectable mailbox when the server has no special-use All mailbox", async () => {
+    let selected = "";
+    const locked: string[] = [];
+    const matches: Record<string, number[]> = {
+      INBOX: [1],
+      Archive: [2, 3],
+      Projects: [],
+    };
+    const dates: Record<string, string> = {
+      "INBOX:1": "2026-06-03T00:00:00Z",
+      "Archive:2": "2026-06-01T00:00:00Z",
+      "Archive:3": "2026-06-02T00:00:00Z",
+    };
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [
+        { path: "INBOX", name: "INBOX" },
+        { path: "Archive", name: "Archive" },
+        { path: "Projects", name: "Projects" },
+        { path: "Folders", name: "Folders", flags: new Set(["\\Noselect"]) },
+      ],
+      getMailboxLock: async (path: string) => {
+        selected = path;
+        locked.push(path);
+        return { release: () => undefined };
+      },
+      search: async () => matches[selected] ?? [],
+      fetch: async function* (range: string) {
+        for (const uid of range.split(",").map(Number)) {
+          yield {
+            uid,
+            envelope: {
+              subject: `${selected} ${uid}`,
+              date: new Date(dates[`${selected}:${uid}`]),
+              from: [{ address: "sender@example.com" }],
+            },
+            flags: new Set<string>(),
+          };
+        }
+      },
+    };
+
+    const res = await imapSearchMessages(
+      { query: "needle", limit: 2 },
+      {
+        config: { ...cfg, host: "imap.mail.me.com", accountLabel: "iCloud" },
+        connect: async () => client,
+      }
+    );
+
+    expect(locked).toEqual(["INBOX", "Archive", "Projects"]);
+    expect(res.messages.map((m) => `${m.mailbox}:${decodeImapId(m.id as string)?.uid}`)).toEqual([
+      "INBOX:1",
+      "Archive:3",
+    ]);
+    expect(res.partial).toBe(false);
+  });
+
+  it("reports a partial all-mailbox search instead of hiding a failed mailbox", async () => {
+    let selected = "";
+    const client: ImapClientLike = {
+      ...makeClient([], {}),
+      list: async () => [
+        { path: "INBOX", name: "INBOX" },
+        { path: "Archive", name: "Archive" },
+      ],
+      getMailboxLock: async (path: string) => {
+        selected = path;
+        if (path === "Archive") throw new Error("cannot select");
+        return { release: () => undefined };
+      },
+      search: async () => (selected === "INBOX" ? [7] : []),
+    };
+
+    const res = await imapSearchMessages(
+      { query: "needle" },
+      {
+        config: { ...cfg, host: "imap.mail.me.com", accountLabel: "iCloud" },
+        connect: async () => client,
+      }
+    );
+
+    expect(res.count).toBe(1);
+    expect(res.partial).toBe(true);
+    expect(res.failedMailboxes).toEqual(["Archive"]);
+    expect(res.text).toContain('Could not search mailbox(es): "Archive"');
   });
 });
 

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -121,6 +121,8 @@ interface ImapMailboxListing {
   name: string;
   /** RFC 6154 special-use flag ("\\Trash", "\\Sent", …) when the server advertises it. */
   specialUse?: string;
+  /** Includes "\\Noselect" for hierarchy containers that cannot be opened. */
+  flags?: Set<string>;
 }
 type FlagOpts = { uid: boolean };
 /**
@@ -542,8 +544,8 @@ const defaultConnect: ImapConnect = async (cfg) => {
 };
 
 /** Map common (Gmail) mailbox names to their IMAP paths. */
-export function resolveMailboxPath(mailbox: string | undefined, mode: "search" | "list"): string {
-  if (!mailbox) return mode === "search" ? "[Gmail]/All Mail" : "INBOX";
+export function resolveMailboxPath(mailbox: string | undefined, _mode: "search" | "list"): string {
+  if (!mailbox) return "INBOX";
   const map: Record<string, string> = {
     "all mail": "[Gmail]/All Mail",
     "sent mail": "[Gmail]/Sent Mail",
@@ -632,6 +634,68 @@ export interface ImapListResult {
   messages: Record<string, unknown>[];
   count: number;
   partial: boolean;
+  /** Mailboxes omitted from an unscoped IMAP search because SELECT/SEARCH failed. */
+  failedMailboxes: string[];
+}
+
+interface FetchedMailboxMessage {
+  message: ImapMessage;
+  path: string;
+}
+
+function hasMailboxFlag(mailbox: ImapMailboxListing, wanted: string): boolean {
+  const normalized = wanted.toLowerCase();
+  return [...(mailbox.flags ?? [])].some((flag) => flag.toLowerCase() === normalized);
+}
+
+function messageDateEpoch(message: ImapMessage): number {
+  if (!message.envelope?.date) return 0;
+  const epoch = new Date(message.envelope.date).getTime();
+  return Number.isNaN(epoch) ? 0 : epoch;
+}
+
+function messageIdentity(entry: FetchedMailboxMessage): string {
+  const raw = entry.message.envelope?.messageId?.trim() ?? "";
+  const messageId = raw
+    .replace(/^<+|>+$/g, "")
+    .trim()
+    .toLowerCase();
+  return messageId ? `mid:${messageId}` : `${entry.path}\u0000${entry.message.uid}`;
+}
+
+async function fetchMailboxMatches(
+  client: ImapClientLike,
+  path: string,
+  criteria: Record<string, unknown>,
+  newestCount: number
+): Promise<{ messages: ImapMessage[]; total: number }> {
+  const lock = await client.getMailboxLock(path);
+  try {
+    const found = await client.search(criteria, { uid: true });
+    const uids = Array.isArray(found) ? found : [];
+    if (uids.length === 0 || newestCount === 0) return { messages: [], total: uids.length };
+
+    const newest = uids.slice().reverse().slice(0, newestCount);
+    const byUid = new Map<number, ImapMessage>();
+    for await (const msg of client.fetch(
+      newest.join(","),
+      // BODYSTRUCTURE rides along so `hasAttachments` is computed rather
+      // than assumed. Measured on 50 real messages: ~390ms -> ~465ms for
+      // the fetch (~17%), same single round trip, no extra request.
+      { envelope: true, flags: true, bodyStructure: true },
+      { uid: true }
+    )) {
+      byUid.set(msg.uid, msg);
+    }
+    return {
+      messages: newest
+        .map((uid) => byUid.get(uid))
+        .filter((message): message is ImapMessage => message !== undefined),
+      total: uids.length,
+    };
+  } finally {
+    lock.release();
+  }
 }
 
 async function run(
@@ -644,51 +708,97 @@ async function run(
   return useClient(
     { ...deps, account: deps.account ?? args.account },
     async (client, cfg) => {
-      const path = resolveMailboxPath(args.mailbox, listMode ? "list" : "search");
-      const lock = await client.getMailboxLock(path);
-      try {
-        const found = await client.search(buildCriteria(args, listMode), { uid: true });
-        const uids = Array.isArray(found) ? found : [];
-        if (uids.length === 0) {
-          return {
-            text: `No messages found via IMAP in "${path}" (account ${cfg.accountLabel}).`,
-            messages: [],
-            count: 0,
-            partial: false,
-          };
+      const unscopedSearch = !listMode && !args.mailbox;
+      let paths: string[];
+      let allMailboxCount = 0;
+      if (unscopedSearch) {
+        const listed = await client.list();
+        const selectable = listed.filter((mailbox) => !hasMailboxFlag(mailbox, "\\Noselect"));
+        const allMailbox = selectable.find(
+          (mailbox) => mailbox.specialUse?.toLowerCase() === "\\all"
+        );
+        paths = allMailbox ? [allMailbox.path] : selectable.map((mailbox) => mailbox.path);
+        allMailboxCount = paths.length;
+        if (paths.length === 0) {
+          throw new Error(`No selectable IMAP mailboxes found for account ${cfg.accountLabel}.`);
         }
-        const limit = args.limit ?? 50;
-        const offset = args.offset ?? 0;
-        // UIDs are ascending → newest are the highest. Apply offset+limit from the newest end.
-        const newest = uids
-          .slice()
-          .reverse()
-          .slice(offset, offset + limit);
-        const byUid = new Map<number, ImapMessage>();
-        for await (const msg of client.fetch(
-          newest.join(","),
-          // BODYSTRUCTURE rides along so `hasAttachments` is computed rather
-          // than assumed. Measured on 50 real messages: ~390ms -> ~465ms for
-          // the fetch (~17%), same single round trip, no extra request.
-          { envelope: true, flags: true, bodyStructure: true },
-          { uid: true }
-        )) {
-          byUid.set(msg.uid, msg);
-        }
-        const ordered = newest
-          .map((u) => byUid.get(u))
-          .filter((m): m is ImapMessage => m !== undefined);
-        const rows = ordered.map((m) => formatRow(m, cfg.accountLabel, path));
-        const messages = ordered.map((m) => structuredRow(m, cfg.accountLabel, path));
-        const verb = listMode ? "listed" : "matched";
-        const text =
-          `Found ${rows.length} message(s) via IMAP (server-side, account ${cfg.accountLabel}, mailbox "${path}"; ${uids.length} total ${verb}):\n` +
-          rows.join("\n") +
-          `\n\nNote: these IMAP IDs (imap:…) work with get-message and the message mutations (mark/flag/move/delete-message), which route back to IMAP.`;
-        return { text, messages, count: messages.length, partial: false };
-      } finally {
-        lock.release();
+      } else {
+        paths = [resolveMailboxPath(args.mailbox, listMode ? "list" : "search")];
       }
+
+      const limit = args.limit ?? 50;
+      const offset = args.offset ?? 0;
+      const criteria = buildCriteria(args, listMode);
+      const newestPerMailbox = offset + limit;
+      const fetched: FetchedMailboxMessage[] = [];
+      const failedMailboxes: string[] = [];
+      let totalMatched = 0;
+
+      for (const path of paths) {
+        try {
+          const result = await fetchMailboxMatches(client, path, criteria, newestPerMailbox);
+          totalMatched += result.total;
+          fetched.push(...result.messages.map((message) => ({ message, path })));
+        } catch (error) {
+          failedMailboxes.push(path);
+          console.error(
+            `IMAP ${listMode ? "list" : "search"} failed for account "${cfg.accountLabel}", mailbox "${path}": ${String(error)}`
+          );
+        }
+      }
+
+      if (failedMailboxes.length === paths.length) {
+        throw new Error(
+          `IMAP ${listMode ? "list" : "search"} failed in every requested mailbox for account ${cfg.accountLabel}: ${failedMailboxes.join(", ")}.`
+        );
+      }
+
+      let ordered = fetched;
+      if (unscopedSearch) {
+        ordered = fetched
+          .slice()
+          .sort((a, b) => messageDateEpoch(b.message) - messageDateEpoch(a.message));
+        const unique = new Map<string, FetchedMailboxMessage>();
+        for (const entry of ordered) {
+          const key = messageIdentity(entry);
+          if (!unique.has(key)) unique.set(key, entry);
+        }
+        ordered = [...unique.values()].slice(offset, offset + limit);
+      } else {
+        ordered = fetched.slice(offset, offset + limit);
+      }
+
+      const rows = ordered.map(({ message, path }) => formatRow(message, cfg.accountLabel, path));
+      const messages = ordered.map(({ message, path }) =>
+        structuredRow(message, cfg.accountLabel, path)
+      );
+      const partial = failedMailboxes.length > 0;
+      const failureNote = partial
+        ? `\n\nPartial result. Could not search mailbox(es): ${failedMailboxes.map((path) => `"${path}"`).join(", ")}.`
+        : "";
+      const verb = listMode ? "listed" : "matched";
+      const scope = unscopedSearch
+        ? allMailboxCount === 1
+          ? `mailbox "${paths[0]}"`
+          : `${allMailboxCount} selectable mailboxes`
+        : `mailbox "${paths[0]}"`;
+
+      if (messages.length === 0) {
+        return {
+          text: `No messages found via IMAP in ${scope} (account ${cfg.accountLabel}).${failureNote}`,
+          messages,
+          count: 0,
+          partial,
+          failedMailboxes,
+        };
+      }
+
+      const text =
+        `Found ${rows.length} message(s) via IMAP (server-side, account ${cfg.accountLabel}, ${scope}; ${totalMatched} total ${verb}):\n` +
+        rows.join("\n") +
+        `\n\nNote: these IMAP IDs (imap:…) work with get-message and the message mutations (mark/flag/move/delete-message), which route back to IMAP.` +
+        failureNote;
+      return { text, messages, count: messages.length, partial, failedMailboxes };
     },
     true
   );

--- a/src/services/imapMultiAccount.test.ts
+++ b/src/services/imapMultiAccount.test.ts
@@ -7,7 +7,6 @@ import {
   partitionAccountsForCounts,
   planCountSources,
   fanOutImapMessages,
-  isGmailHost,
   formatMergedRows,
   type MessageRow,
 } from "@/services/imapMultiAccount.js";
@@ -36,7 +35,7 @@ function makeClient(uids: number[], messageIdByUid?: Record<number, string>): Im
       }
     },
     fetchOne: async () => false,
-    list: async () => [],
+    list: async () => [{ path: "[Gmail]/All Mail", name: "All Mail", specialUse: "\\All" }],
     status: async (path: string) => ({ path, messages: 0, unseen: 0, recent: 0 }),
     download: async () => ({ meta: {}, content: (async function* () {})() }),
     mailboxCreate: async (path: string) => ({ path, created: true }),
@@ -146,6 +145,7 @@ describe("fanOutImapMessages", () => {
     expect(seen.sort()).toEqual(["Personal", "Work"]);
     expect(res.accountsQueried.sort()).toEqual(["Personal", "Work"]);
     expect(res.accountsFailed).toEqual([]);
+    expect(res.failedMailboxes).toEqual([]);
     expect(res.rows).toHaveLength(2);
     expect(res.rows.map((r) => r.account).sort()).toEqual(["Personal", "Work"]);
   });
@@ -167,19 +167,23 @@ describe("fanOutImapMessages", () => {
     expect(res.rows).toHaveLength(1);
   });
 
-  it("defaults the mailbox PER HOST when none is pinned (Gmail→All Mail, others→INBOX)", async () => {
-    // Regression guard: a no-mailbox search must NOT fan Gmail's "[Gmail]/All Mail"
-    // out to a non-Gmail account (e.g. iCloud), where that SELECT fails and the
-    // account silently drops from the merged results.
-    const selectedPath: Record<string, string> = {};
+  it("lets each server resolve an omitted search mailbox from its advertised hierarchy", async () => {
+    const selectedPaths: Record<string, string[]> = {};
     await fanOutImapMessages(
       { query: "x", limit: 10 }, // no mailbox pinned
       "search",
       {
         connect: async (cfg) => {
           const client = makeClient([1]);
+          client.list = async () =>
+            cfg.accountLabel === "Personal"
+              ? [{ path: "[Gmail]/All Mail", name: "All Mail", specialUse: "\\All" }]
+              : [
+                  { path: "INBOX", name: "INBOX" },
+                  { path: "Archive", name: "Archive" },
+                ];
           client.getMailboxLock = async (path: string) => {
-            selectedPath[cfg.accountLabel] = path;
+            (selectedPaths[cfg.accountLabel] ??= []).push(path);
             return { release: () => undefined };
           };
           return client;
@@ -187,8 +191,8 @@ describe("fanOutImapMessages", () => {
       },
       [cfgA, cfgB] // cfgA host=imap.gmail.com, cfgB host=imap.work.com
     );
-    expect(selectedPath.Personal).toBe("[Gmail]/All Mail"); // Gmail host → All Mail
-    expect(selectedPath.Work).toBe("INBOX"); // non-Gmail host → universal INBOX
+    expect(selectedPaths.Personal).toEqual(["[Gmail]/All Mail"]);
+    expect(selectedPaths.Work).toEqual(["INBOX", "Archive"]);
   });
 
   it("honors an explicitly pinned mailbox for every account (no per-host override)", async () => {
@@ -210,16 +214,6 @@ describe("fanOutImapMessages", () => {
     );
     expect(selectedPath.Personal).toBe("INBOX");
     expect(selectedPath.Work).toBe("INBOX");
-  });
-});
-
-describe("isGmailHost", () => {
-  it("matches gmail.com and its subdomains (Workspace), not look-alikes", () => {
-    expect(isGmailHost("imap.gmail.com")).toBe(true);
-    expect(isGmailHost("gmail.com")).toBe(true);
-    expect(isGmailHost("imap.mail.me.com")).toBe(false); // iCloud
-    expect(isGmailHost("imap.work.com")).toBe(false);
-    expect(isGmailHost("notgmail.com.evil.com")).toBe(false);
   });
 });
 

--- a/src/services/imapMultiAccount.ts
+++ b/src/services/imapMultiAccount.ts
@@ -122,11 +122,6 @@ export function mergeMessages(
   return limit >= 0 ? merged.slice(0, limit) : merged;
 }
 
-/** Gmail/Workspace IMAP host? Its `[Gmail]/All Mail` virtual mailbox is Gmail-only. */
-export function isGmailHost(host: string): boolean {
-  return /(^|\.)gmail\.com$/i.test(host.trim());
-}
-
 /**
  * Fan an IMAP message query out over EVERY configured IMAP account and return
  * the concatenated structured rows (not yet merged with AppleScript, not yet
@@ -142,20 +137,22 @@ export async function fanOutImapMessages(
   kind: "search" | "list",
   deps: Omit<ImapDeps, "config" | "account"> = {},
   configs: ImapConfig[] = resolveImapConfigs()
-): Promise<{ rows: MessageRow[]; accountsQueried: string[]; accountsFailed: string[] }> {
+): Promise<{
+  rows: MessageRow[];
+  accountsQueried: string[];
+  accountsFailed: string[];
+  failedMailboxes: string[];
+}> {
   const rows: MessageRow[] = [];
   const accountsQueried: string[] = [];
   const accountsFailed: string[] = [];
+  const failedMailboxes: string[] = [];
   for (const config of configs) {
-    // Default-mailbox resolution is PER-ACCOUNT: the single-account search default
-    // ("[Gmail]/All Mail") is Gmail-only, so fanning it out to a non-Gmail account
-    // (e.g. iCloud) makes that SELECT fail and the account silently drops from the
-    // merged results. When the caller pinned no mailbox, give Gmail hosts their
-    // All-Mail default (undefined → resolved downstream) and every other host a
-    // universal "INBOX". (limit is applied AFTER the cross-account merge so the
-    // global newest-N is correct even when one account dominates.)
-    const mailbox = args.mailbox ?? (isGmailHost(config.host) ? undefined : "INBOX");
-    const perAccountArgs: ImapSearchArgs = { ...args, account: undefined, mailbox };
+    // Keep an omitted mailbox omitted. The per-account search discovers an RFC
+    // 6154 `\\All` mailbox when available (Gmail), otherwise it searches every
+    // selectable mailbox (iCloud/generic IMAP). Hostname heuristics cannot tell
+    // us what a server actually exposes.
+    const perAccountArgs: ImapSearchArgs = { ...args, account: undefined };
     try {
       const res =
         kind === "search"
@@ -163,12 +160,15 @@ export async function fanOutImapMessages(
           : await imapListMessages(perAccountArgs, { ...deps, config });
       rows.push(...res.messages);
       accountsQueried.push(config.accountLabel);
+      failedMailboxes.push(
+        ...res.failedMailboxes.map((mailbox) => `${config.accountLabel} / ${mailbox}`)
+      );
     } catch (e) {
       accountsFailed.push(config.accountLabel);
       console.error(`IMAP fan-out failed for account "${config.accountLabel}": ${String(e)}`);
     }
   }
-  return { rows, accountsQueried, accountsFailed };
+  return { rows, accountsQueried, accountsFailed, failedMailboxes };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #199.

## What changed

- make an omitted IMAP search mailbox provider-neutral instead of resolving it to Gmail's hard-coded `[Gmail]/All Mail`;
- discover and use a server-advertised RFC 6154 `\\All` mailbox when available;
- otherwise search every selectable mailbox, skipping `\\Noselect` hierarchy containers;
- merge the newest candidates globally, de-duplicate copies by Message-ID, then apply offset/limit;
- surface per-mailbox failures through `partial`, `failedMailboxes`, and the existing merged-search coverage diagnostics;
- remove the hostname-based Gmail/non-Gmail fan-out workaround, since the server's advertised mailbox metadata is authoritative;
- bump the shipped/plugin version to 2.17.1 and rebuild the committed bundle.

## Regression guard

The new guard was run before the implementation and failed in three places: the provider-neutral fallback was still `[Gmail]/All Mail`, an iCloud-like server selected only that path instead of its selectable mailboxes, and a failed folder was not reported as partial coverage.

After the implementation:

- `vitest run`: 50 files, 710 tests passed;
- focused IMAP + output-schema tests: 146 passed;
- TypeScript typecheck: passed;
- ESLint: passed with the 10 existing warnings, 0 errors;
- Prettier check: passed;
- committed build and plugin-version sync checks: passed.

## Live iCloud verification

A read-only search against a configured iCloud account searched 115 selectable mailboxes, found the known message in `Deleted Messages`, and returned `partial: false` with no failed mailboxes. The full 115-folder scan took about 75 seconds on that account; the implementation deliberately retains the project's single pooled IMAP connection instead of multiplying connection usage. No message mutation was performed.
