### PR TITLE
fix(smart-mailbox): use PlistBuddy Merge instead of crashing plutil -insert

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.2",
+      "version": "2.17.3",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.2",
+      "version": "2.17.3",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.17.2",
+      "version": "2.17.3",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## [Unreleased]
 
+## [2.17.3] - 2026-08-30
+
+### Fixed
+
+- `create-smart-mailbox` always failed on macOS 15: `plutil -insert <index> -json`
+  crashes with an `NSRangeException` when the target plist has an array root and
+  the keypath is a bare numeric index — exactly the shape of
+  `SyncedSmartMailboxes.plist`. `delete-smart-mailbox` looked broken too, but only
+  because its test created the entry first; its own PlistBuddy path was never at
+  fault. The insert now goes through `/usr/libexec/PlistBuddy`'s `Merge` command
+  instead, which appends to an array root and preserves the `date`/`data` values
+  `plutil -convert json` can't represent, matching what `delete-smart-mailbox`
+  already used. The failure was always safe — `commitSmartPlist` discarded the
+  edited copy and the original plist was untouched — but the feature was
+  unusable. (#205, thanks @Zome59)
+
 ### Documentation
 
 - Added regression tests pinning that mailbox scoping resolves by

--- a/build/index.js
+++ b/build/index.js
@@ -82817,11 +82817,36 @@ ${this.errorEmit("              ")}
     }
     const entry = this.buildSmartMailboxEntry(name, fromContains, subjectContains, bodyContains);
     const temp = this.prepareSmartPlistWrite(plistPath);
-    const ins = spawnSync2(
-      "plutil",
-      ["-insert", String(entries.length), "-json", JSON.stringify(entry), temp],
-      { encoding: "utf8" }
-    );
+    const entryJson = `${temp}.entry.json`;
+    const entryPlist = `${temp}.entry.plist`;
+    const cleanupEntryFiles = () => {
+      for (const f of [entryJson, entryPlist]) {
+        try {
+          unlinkSync(f);
+        } catch {
+        }
+      }
+    };
+    writeFileSync3(entryJson, JSON.stringify([entry]), "utf8");
+    const conv = spawnSync2("plutil", ["-convert", "xml1", "-o", entryPlist, entryJson], {
+      encoding: "utf8"
+    });
+    if (conv.status !== 0) {
+      cleanupEntryFiles();
+      try {
+        unlinkSync(temp);
+      } catch {
+      }
+      return {
+        created: false,
+        alreadyExisted: false,
+        error: (conv.stderr || "plutil could not encode the smart mailbox entry").trim()
+      };
+    }
+    const ins = spawnSync2("/usr/libexec/PlistBuddy", ["-c", `Merge ${entryPlist} :`, temp], {
+      encoding: "utf8"
+    });
+    cleanupEntryFiles();
     if (ins.status !== 0) {
       try {
         unlinkSync(temp);
@@ -82830,7 +82855,7 @@ ${this.errorEmit("              ")}
       return {
         created: false,
         alreadyExisted: false,
-        error: (ins.stderr || "plutil insert failed").trim()
+        error: (ins.stderr || "PlistBuddy merge failed").trim()
       };
     }
     if (!this.commitSmartPlist(temp, plistPath)) {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.17.2"
+        "apple-mail-mcp@2.17.3"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -5422,11 +5422,47 @@ ${this.errorEmit("              ")}
     }
     const entry = this.buildSmartMailboxEntry(name, fromContains, subjectContains, bodyContains);
     const temp = this.prepareSmartPlistWrite(plistPath);
-    const ins = spawnSync(
-      "plutil",
-      ["-insert", String(entries.length), "-json", JSON.stringify(entry), temp],
-      { encoding: "utf8" }
-    );
+    // macOS 15 regression: `plutil -insert <index>` with a bare numeric keypath at
+    // an ARRAY root crashes with an NSRangeException
+    // ("substringToIndex: Index 18446744073709551615 out of bounds") instead of
+    // appending, so every create failed and the entry never reached the plist.
+    // Reproduce outside this project:
+    //   plutil -insert 1 -json '{"b":"y"}' <array-rooted.plist>   # crashes
+    // PlistBuddy's `Merge` appends an array's items to an array root and preserves
+    // the nested structure, and the delete path below already uses PlistBuddy, so
+    // this keeps both halves on one tool.
+    const entryJson = `${temp}.entry.json`;
+    const entryPlist = `${temp}.entry.plist`;
+    const cleanupEntryFiles = (): void => {
+      for (const f of [entryJson, entryPlist]) {
+        try {
+          unlinkSync(f);
+        } catch {
+          // best effort
+        }
+      }
+    };
+    writeFileSync(entryJson, JSON.stringify([entry]), "utf8");
+    const conv = spawnSync("plutil", ["-convert", "xml1", "-o", entryPlist, entryJson], {
+      encoding: "utf8",
+    });
+    if (conv.status !== 0) {
+      cleanupEntryFiles();
+      try {
+        unlinkSync(temp);
+      } catch {
+        // best effort
+      }
+      return {
+        created: false,
+        alreadyExisted: false,
+        error: (conv.stderr || "plutil could not encode the smart mailbox entry").trim(),
+      };
+    }
+    const ins = spawnSync("/usr/libexec/PlistBuddy", ["-c", `Merge ${entryPlist} :`, temp], {
+      encoding: "utf8",
+    });
+    cleanupEntryFiles();
     if (ins.status !== 0) {
       try {
         unlinkSync(temp);
@@ -5436,7 +5472,7 @@ ${this.errorEmit("              ")}
       return {
         created: false,
         alreadyExisted: false,
-        error: (ins.stderr || "plutil insert failed").trim(),
+        error: (ins.stderr || "PlistBuddy merge failed").trim(),
       };
     }
     if (!this.commitSmartPlist(temp, plistPath)) {


### PR DESCRIPTION
Fixes #205.

## Why

`plutil -insert <index> -json ... <plist>` crashes on macOS 15 when the plist has
an **array** root and the keypath is a bare number:

```
plutil -insert 1 -json '{"b":"y"}' array-rooted.plist
*** NSRangeException: -[NSTaggedPointerString substringToIndex:]:
    Index 18446744073709551615 out of bounds; string length 1
```

Reproducible outside the project — the two commands are in #205. The same call
with a named keypath on a dict root works, so it is the bare numeric keypath at an
array root that breaks, and that is exactly the shape of
`SyncedSmartMailboxes.plist`.

Effect: every `create-smart-mailbox` failed. It failed *safely* — `commitSmartPlist`
discarded the edited copy and the original plist was left untouched — but the
feature was unusable, and `delete-smart-mailbox` looked broken too because its test
creates the entry first. Its own PlistBuddy path was never at fault.

## How

`PlistBuddy`'s `Merge` appends an array's items to an array root and preserves
nested structure, including the `date`/`data` values the module's own comments note
that `plutil -convert json` rejects. The entry is written as a one-element array to
a temp JSON file, converted to `xml1`, merged, and both temp files are removed on
every path — including the two early-return branches.

`deleteSmartMailboxAtPath` already uses PlistBuddy, so both halves of the feature
now sit on one tool.

## Testing

- The 3 previously failing `appleMailManager.smartMailbox.test.ts` cases pass.
- Full suite **714/714** (was 711/714 on a clean checkout on macOS 15).
- `tsc --noEmit` clean; `build/index.js` regenerated as the repo convention expects.

No new dependency, no API change. The only behavior change beyond "it works" is the
fallback error string, from `plutil insert failed` to `PlistBuddy merge failed`,
plus a distinct message if the entry cannot be encoded at all.

## Note

I did not add a regression test — the existing cases already pin this and were red
on a clean checkout for exactly this reason. Happy to add one that asserts the crash
signature if you would rather have it explicit.
