### PR TITLE
fix(imap): resolve mailbox aliases via SPECIAL-USE, not a Gmail-only map

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.3",
+      "version": "2.17.4",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.3",
+      "version": "2.17.4",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.17.3",
+      "version": "2.17.4",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## [Unreleased]
 
+## [2.17.4] - 2026-09-01
+
+### Fixed
+
+- **`resolveMailboxPath` applied Gmail's `[Gmail]/…` folder paths to every IMAP
+  account, regardless of provider.** On an iCloud (or any non-Gmail) account,
+  requesting the genuinely-existing `Junk` or `Drafts` mailbox got silently
+  rewritten to `[Gmail]/Spam` / `[Gmail]/Drafts` — paths that cannot exist
+  there — and the search/list/unread-count call failed outright, naming the
+  wrong path in the error. Resolution is now three-tiered: (1) a literal real
+  mailbox — full path or a single leaf-name match from `client.list()` —
+  always wins, so an account's own `Junk`/`Drafts` are never shadowed; (2) a
+  well-known alias (`trash`, `drafts`, `sent`, …) resolves via the
+  connection's own IMAP SPECIAL-USE flags (RFC 6154), so `trash` finds
+  Exchange's `Deleted Items` or iCloud's `Deleted Messages` exactly as
+  reliably as Gmail's; (3) the legacy Gmail-only static map remains the last
+  resort, for when LIST itself fails or (for `[Gmail]/Important` and
+  `[Gmail]/Starred`, which have no SPECIAL-USE equivalent) nothing else could
+  match. (#207, thanks @ficklma1 for the root-cause trace and reproduction
+  matrix)
+
 ## [2.17.3] - 2026-08-30
 
 ### Fixed

--- a/build/index.js
+++ b/build/index.js
@@ -84154,8 +84154,18 @@ var defaultConnect = async (cfg) => {
   }
   return client;
 };
-function resolveMailboxPath(mailbox, _mode) {
-  if (!mailbox) return "INBOX";
+var SPECIAL_USE_ALIASES = {
+  "all mail": "\\all",
+  archive: "\\archive",
+  drafts: "\\drafts",
+  sent: "\\sent",
+  "sent mail": "\\sent",
+  trash: "\\trash",
+  spam: "\\junk",
+  junk: "\\junk",
+  starred: "\\flagged"
+};
+function staticMailboxAlias(mailbox) {
   const map = {
     "all mail": "[Gmail]/All Mail",
     "sent mail": "[Gmail]/Sent Mail",
@@ -84168,6 +84178,21 @@ function resolveMailboxPath(mailbox, _mode) {
     important: "[Gmail]/Important"
   };
   return map[mailbox.trim().toLowerCase()] ?? mailbox;
+}
+async function resolveMailboxPath(client, mailbox, _mode) {
+  if (!mailbox) return "INBOX";
+  try {
+    const resolved = await resolveMailbox(client, mailbox);
+    if (resolved.kind === "found") return resolved.path;
+    const flag = SPECIAL_USE_ALIASES[mailbox.trim().toLowerCase()];
+    if (flag) {
+      const boxes = await client.list();
+      const special = boxes.find((b) => b.specialUse?.toLowerCase() === flag);
+      if (special) return special.path;
+    }
+  } catch {
+  }
+  return staticMailboxAlias(mailbox);
 }
 function buildCriteria(a, listMode) {
   const c = {};
@@ -84277,7 +84302,7 @@ async function run(args, listMode, deps) {
           throw new Error(`No selectable IMAP mailboxes found for account ${cfg.accountLabel}.`);
         }
       } else {
-        paths = [resolveMailboxPath(args.mailbox, listMode ? "list" : "search")];
+        paths = [await resolveMailboxPath(client, args.mailbox, listMode ? "list" : "search")];
       }
       const limit = args.limit ?? 50;
       const offset = args.offset ?? 0;
@@ -84353,7 +84378,9 @@ function imapUnreadCount(mailbox, deps = {}) {
   return useClient(
     deps,
     async (client) => {
-      const s = await client.status(resolveMailboxPath(mailbox, "list"), { unseen: true });
+      const s = await client.status(await resolveMailboxPath(client, mailbox, "list"), {
+        unseen: true
+      });
       return s.unseen ?? 0;
     },
     true
@@ -84785,7 +84812,7 @@ async function imapMoveMessageById(id, destMailbox, deps = {}) {
         error: ambiguousMailboxError(destMailbox, dest.candidates, cfg.accountLabel)
       };
     }
-    const destPath = dest.kind === "found" ? dest.path : resolveMailboxPath(destMailbox, "list");
+    const destPath = dest.kind === "found" ? dest.path : await resolveMailboxPath(client, destMailbox, "list");
     const lock = await client.getMailboxLock(ref.path);
     try {
       const moved = assertMutated(
@@ -84822,7 +84849,7 @@ async function resolveTrashPath(client) {
     if (named) return named.path;
   } catch {
   }
-  if (!listed) return resolveMailboxPath("trash", "list");
+  if (!listed) return staticMailboxAlias("trash");
   try {
     const created = await client.mailboxCreate(FALLBACK_TRASH_PATH);
     return created?.path || FALLBACK_TRASH_PATH;
@@ -85076,7 +85103,7 @@ function imapBatchMove(ids, destMailbox, deps = {}) {
     ids,
     deps,
     async (c, uids) => {
-      const dest = await findMailboxPathOrThrow(c, destMailbox) ?? resolveMailboxPath(destMailbox, "list");
+      const dest = await findMailboxPathOrThrow(c, destMailbox) ?? await resolveMailboxPath(c, destMailbox, "list");
       assertMutated(
         await c.messageMove(uids, dest, { uid: true }),
         `IMAP move of ${uids.length} message(s) to "${dest}"`

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.17.3"
+        "apple-mail-mcp@2.17.4"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -388,15 +388,62 @@ describe("imapHealthCheck configured-gate (#138)", () => {
 });
 
 describe("resolveMailboxPath", () => {
-  it("uses the provider-neutral INBOX fallback when no path is pinned", () => {
-    expect(resolveMailboxPath(undefined, "search")).toBe("INBOX");
-    expect(resolveMailboxPath(undefined, "list")).toBe("INBOX");
+  const rec: Rec = {};
+  // Gmail-shaped account: no real mailbox literally named "Junk"/"Drafts"/etc.,
+  // so every alias falls through to SPECIAL-USE (or the static map for the two
+  // that have no SPECIAL-USE equivalent).
+  const GMAIL_BOXES = [
+    { path: "INBOX", name: "INBOX" },
+    { path: "[Gmail]/All Mail", name: "All Mail", specialUse: "\\All" },
+    { path: "[Gmail]/Sent Mail", name: "Sent Mail", specialUse: "\\Sent" },
+    { path: "[Gmail]/Trash", name: "Trash", specialUse: "\\Trash" },
+    { path: "[Gmail]/Drafts", name: "Drafts", specialUse: "\\Drafts" },
+    { path: "[Gmail]/Spam", name: "Spam", specialUse: "\\Junk" },
+  ];
+  const gmailClient = () => ({ ...makeClient([], rec), list: async () => GMAIL_BOXES });
+
+  it("uses the provider-neutral INBOX fallback when no path is pinned", async () => {
+    expect(await resolveMailboxPath(gmailClient(), undefined, "search")).toBe("INBOX");
+    expect(await resolveMailboxPath(gmailClient(), undefined, "list")).toBe("INBOX");
   });
-  it("maps common Gmail folder names", () => {
-    expect(resolveMailboxPath("All Mail", "search")).toBe("[Gmail]/All Mail");
-    expect(resolveMailboxPath("Sent Mail", "list")).toBe("[Gmail]/Sent Mail");
-    expect(resolveMailboxPath("INBOX", "list")).toBe("INBOX");
-    expect(resolveMailboxPath("MyCustomLabel", "list")).toBe("MyCustomLabel");
+  it("resolves common Gmail folder names via SPECIAL-USE, and the two without an equivalent via the static map", async () => {
+    expect(await resolveMailboxPath(gmailClient(), "All Mail", "search")).toBe("[Gmail]/All Mail");
+    expect(await resolveMailboxPath(gmailClient(), "Sent Mail", "list")).toBe("[Gmail]/Sent Mail");
+    expect(await resolveMailboxPath(gmailClient(), "INBOX", "list")).toBe("INBOX");
+    expect(await resolveMailboxPath(gmailClient(), "MyCustomLabel", "list")).toBe("MyCustomLabel");
+    expect(await resolveMailboxPath(gmailClient(), "Important", "list")).toBe("[Gmail]/Important");
+  });
+
+  // #207: Junk/Drafts are genuine iCloud folder names — a real mailbox match
+  // must win over the Gmail-shaped alias table.
+  it("a literal real mailbox wins over the alias table (#207)", async () => {
+    const iCloudClient = {
+      ...makeClient([], rec),
+      list: async () => [
+        { path: "INBOX", name: "INBOX" },
+        { path: "Archive", name: "Archive" },
+        { path: "Drafts", name: "Drafts" },
+        { path: "Junk", name: "Junk" },
+        { path: "Sent Messages", name: "Sent Messages", specialUse: "\\Sent" },
+        { path: "Deleted Messages", name: "Deleted Messages", specialUse: "\\Trash" },
+      ],
+    };
+    expect(await resolveMailboxPath(iCloudClient, "Junk", "search")).toBe("Junk");
+    expect(await resolveMailboxPath(iCloudClient, "Drafts", "search")).toBe("Drafts");
+    // Not a real mailbox name here, but SPECIAL-USE still finds it under its
+    // real iCloud name rather than guessing the Gmail path.
+    expect(await resolveMailboxPath(iCloudClient, "trash", "search")).toBe("Deleted Messages");
+    expect(await resolveMailboxPath(iCloudClient, "sent", "search")).toBe("Sent Messages");
+  });
+
+  it("falls back to the static Gmail guess when LIST itself fails", async () => {
+    const brokenClient = {
+      ...makeClient([], rec),
+      list: async (): Promise<never> => {
+        throw new Error("LIST failed");
+      },
+    };
+    expect(await resolveMailboxPath(brokenClient, "Junk", "search")).toBe("[Gmail]/Spam");
   });
 });
 

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -543,9 +543,32 @@ const defaultConnect: ImapConnect = async (cfg) => {
   return client as unknown as ImapClientLike;
 };
 
-/** Map common (Gmail) mailbox names to their IMAP paths. */
-export function resolveMailboxPath(mailbox: string | undefined, _mode: "search" | "list"): string {
-  if (!mailbox) return "INBOX";
+/**
+ * Well-known alias -> IMAP SPECIAL-USE flag (RFC 6154), lowercased. Used to find
+ * the real mailbox behind a generic name ("trash", "drafts", …) regardless of
+ * what the provider actually calls it — Exchange's "Deleted Items", iCloud's
+ * "Deleted Messages", Gmail's "[Gmail]/Trash" all advertise `\Trash`.
+ */
+const SPECIAL_USE_ALIASES: Record<string, string> = {
+  "all mail": "\\all",
+  archive: "\\archive",
+  drafts: "\\drafts",
+  sent: "\\sent",
+  "sent mail": "\\sent",
+  trash: "\\trash",
+  spam: "\\junk",
+  junk: "\\junk",
+  starred: "\\flagged",
+};
+
+/**
+ * Legacy Gmail-only path guesses — the ONLY resort when a mailbox can be
+ * resolved neither as a real mailbox nor via SPECIAL-USE (LIST failed, or the
+ * account has no such special-use mailbox and isn't Gmail's proprietary
+ * combined-mailbox layout). `[Gmail]/Important` and `[Gmail]/Starred` have no
+ * SPECIAL-USE equivalent, so they can only ever be reached this way.
+ */
+function staticMailboxAlias(mailbox: string): string {
   const map: Record<string, string> = {
     "all mail": "[Gmail]/All Mail",
     "sent mail": "[Gmail]/Sent Mail",
@@ -558,6 +581,46 @@ export function resolveMailboxPath(mailbox: string | undefined, _mode: "search" 
     important: "[Gmail]/Important",
   };
   return map[mailbox.trim().toLowerCase()] ?? mailbox;
+}
+
+/**
+ * Resolve a mailbox name to its real IMAP path, in three tiers:
+ *   1. An exact real mailbox — full path or a single leaf-name match, from
+ *      `client.list()` (#207: `Junk`/`Drafts` genuinely exist on iCloud;
+ *      resolving them as real mailboxes must win over any alias table, so a
+ *      non-Gmail account's own folders are never shadowed by Gmail's).
+ *   2. A well-known alias resolved via the connection's own SPECIAL-USE flags
+ *      — provider-neutral, so "trash" finds Exchange's "Deleted Items" or
+ *      iCloud's "Deleted Messages" as readily as Gmail's.
+ *   3. The legacy Gmail-only static map (`staticMailboxAlias`), as a last
+ *      resort when LIST failed or nothing above matched.
+ *
+ * A tier-1 match that is itself ambiguous (two mailboxes sharing a leaf name)
+ * falls through to tiers 2/3 rather than erroring: unlike a *move* destination
+ * (#137), guessing wrong here only scopes a read to a plausible mailbox, not
+ * a wrong destination for a mutation.
+ */
+export async function resolveMailboxPath(
+  client: ImapClientLike,
+  mailbox: string | undefined,
+  _mode: "search" | "list"
+): Promise<string> {
+  if (!mailbox) return "INBOX";
+  try {
+    const resolved = await resolveMailbox(client, mailbox);
+    if (resolved.kind === "found") return resolved.path;
+
+    const flag = SPECIAL_USE_ALIASES[mailbox.trim().toLowerCase()];
+    if (flag) {
+      const boxes = await client.list();
+      const special = boxes.find((b) => b.specialUse?.toLowerCase() === flag);
+      if (special) return special.path;
+    }
+  } catch {
+    // LIST failed — fall through to the static guess below, same as
+    // resolveTrashPath's own `!listed` fallback.
+  }
+  return staticMailboxAlias(mailbox);
 }
 
 function buildCriteria(a: ImapSearchArgs, listMode: boolean): Record<string, unknown> {
@@ -723,7 +786,7 @@ async function run(
           throw new Error(`No selectable IMAP mailboxes found for account ${cfg.accountLabel}.`);
         }
       } else {
-        paths = [resolveMailboxPath(args.mailbox, listMode ? "list" : "search")];
+        paths = [await resolveMailboxPath(client, args.mailbox, listMode ? "list" : "search")];
       }
 
       const limit = args.limit ?? 50;
@@ -840,7 +903,9 @@ export function imapUnreadCount(mailbox: string | undefined, deps: ImapDeps = {}
   return useClient(
     deps,
     async (client) => {
-      const s = await client.status(resolveMailboxPath(mailbox, "list"), { unseen: true });
+      const s = await client.status(await resolveMailboxPath(client, mailbox, "list"), {
+        unseen: true,
+      });
       return s.unseen ?? 0;
     },
     true
@@ -1595,7 +1660,8 @@ export async function imapMoveMessageById(
         error: ambiguousMailboxError(destMailbox, dest.candidates, cfg.accountLabel),
       };
     }
-    const destPath = dest.kind === "found" ? dest.path : resolveMailboxPath(destMailbox, "list");
+    const destPath =
+      dest.kind === "found" ? dest.path : await resolveMailboxPath(client, destMailbox, "list");
     const lock = await client.getMailboxLock(ref.path);
     try {
       const moved = assertMutated(
@@ -1652,7 +1718,9 @@ async function resolveTrashPath(client: ImapClientLike): Promise<string> {
     // best remaining guess. A wrong guess now fails loudly (#181) instead of
     // silently discarding the delete.
   }
-  if (!listed) return resolveMailboxPath("trash", "list");
+  // LIST just failed above, so a fresh resolveMailboxPath call would only fail
+  // the same way and fall back to this same static guess — skip straight to it.
+  if (!listed) return staticMailboxAlias("trash");
 
   // LIST succeeded and this account has no Trash mailbox of any kind. Returning
   // the Gmail default here is what made `delete-message` a SILENT NO-OP on every
@@ -2099,7 +2167,8 @@ export function imapBatchMove(
       // #137: throws on an ambiguous destination; imapBatch records it per group
       // as a failure rather than moving the batch somewhere the caller didn't name.
       const dest =
-        (await findMailboxPathOrThrow(c, destMailbox)) ?? resolveMailboxPath(destMailbox, "list");
+        (await findMailboxPathOrThrow(c, destMailbox)) ??
+        (await resolveMailboxPath(c, destMailbox, "list"));
       assertMutated(
         await c.messageMove(uids, dest, { uid: true }),
         `IMAP move of ${uids.length} message(s) to "${dest}"`


### PR DESCRIPTION
## Summary

- `resolveMailboxPath()` rewrote well-known names (`Junk`, `Drafts`, `Trash`, ...) to Gmail's `[Gmail]/...` paths **unconditionally**, regardless of the account's actual provider. On iCloud, that shadowed real `Junk`/`Drafts` folders with paths that could never exist there, and the call errored naming the wrong path.
- Resolution is now three-tiered: (1) a literal real mailbox from `client.list()` always wins — an account's own `Junk`/`Drafts` are never shadowed; (2) a well-known alias resolves via the connection's own IMAP SPECIAL-USE flags (RFC 6154), so `trash` finds Exchange's `Deleted Items` or iCloud's `Deleted Messages` as reliably as Gmail's; (3) the legacy Gmail-only static map is the last resort, for when LIST fails or (`Important`/`Starred`, which have no SPECIAL-USE equivalent) nothing else matches.
- Applied at every call site: scoped search/list, `get-unread-count`, single and batch message move, and the trash-path resolver's own already-existing fallback.

Fixes #207.

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm test` (716/716 passing, including new coverage for: literal-mailbox-wins on an iCloud-shaped client, SPECIAL-USE resolution under non-Gmail names, and the LIST-failure fallback)
- [x] `pnpm run format:check`
- [x] Version bumped 2.17.3 → 2.17.4, CHANGELOG entry added, `build/index.js` rebuilt and committed