### PR TITLE
docs: document the coverage-diagnostics fields on search/list results

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.6",
+      "version": "2.17.7",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.6",
+      "version": "2.17.7",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.6",
+  "version": "2.17.7",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.17.6",
+  "version": "2.17.7",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.17.6",
+      "version": "2.17.7",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.6",
+  "version": "2.17.7",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## [Unreleased]
 
+## [2.17.7] - 2026-09-03
+
+### Documentation
+
+- Documented the **coverage-diagnostics fields** that `search-messages` and
+  `list-messages` already return (`partial`, `skippedLargeMailboxes`,
+  `notSearchedMailboxes`, `timedOutAccounts`, `failedMailboxes`) in the README's
+  "Large mailboxes & partial results" section, with each field's type, its
+  `"Account / Mailbox (count)"` formatting, and the fact that all five are
+  omitted when coverage was complete. The behaviour and the human-readable
+  `⚠️ Partial results` warning were documented; the structured fields a
+  programmatic caller actually reads were not, so the ability to tell "nothing
+  matched" apart from "I did not look everywhere" was discoverable only by
+  observing a live response. No code change. (#203, thanks @nh4p7qcxkj-cyber for
+  reporting that `skippedLargeMailboxes` was undocumented after finding it
+  empirically)
+
 ## [2.17.6] - 2026-09-03
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -256,6 +256,25 @@ To search inside a large mailbox, scope the call with `mailbox` (and ideally a
 to disable the guard and attempt every mailbox regardless of size).
 ([#24](https://github.com/sweetrb/apple-mail-mcp/issues/24))
 
+**Coverage diagnostics (structured fields).** The warning above is prose for a
+human reader; the same information is also returned as structured fields on
+`search-messages` and `list-messages`, so a caller can tell *"nothing matched"*
+apart from *"I did not look everywhere"* without parsing the text:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `partial` | boolean | Coverage was incomplete — **the result is not a confirmed "no such mail"**. True whenever any field below is non-empty. |
+| `skippedLargeMailboxes` | string[] | Mailboxes never scanned because their message count exceeded `APPLE_MAIL_MAX_SEARCH_MAILBOX`, formatted `"Account / Mailbox (count)"` — e.g. `"iCloud / Archive (90694)"`. |
+| `notSearchedMailboxes` | string[] | Mailboxes that *were* reached but timed out or errored mid-scan, formatted `"Account / Mailbox"`. Also carries the IMAP path's `failedMailboxes`. |
+| `timedOutAccounts` | string[] | Accounts whose whole-account AppleScript was killed by the per-account time budget — nothing from that account was searched. |
+| `failedMailboxes` | string[] | IMAP-backend mailboxes that errored. These are merged into `notSearchedMailboxes` as well; read that field unless you need to attribute the failure to the IMAP path specifically. |
+
+Treat a non-empty `skippedLargeMailboxes` as actionable rather than
+informational: re-run scoped to the named mailbox with a `dateFrom`/`dateTo`
+window, or configure the [IMAP backend](#imap-backend--opt-in), which searches
+those mailboxes server-side. All five fields are optional and are omitted when
+coverage was complete.
+
 ---
 
 #### `get-message`

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.6",
+  "version": "2.17.7",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.17.6"
+        "apple-mail-mcp@2.17.7"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.17.6",
+  "version": "2.17.7",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",


### PR DESCRIPTION
`search-messages` and `list-messages` have always returned `partial`,
`skippedLargeMailboxes`, `notSearchedMailboxes`, `timedOutAccounts` and
`failedMailboxes` alongside their rows, but the README documented only the
*behaviour* and the human-readable `⚠️ Partial results` warning text — never the
structured fields themselves.

So a programmatic caller had no documented way to tell **"nothing matched"** apart
from **"I did not look everywhere."** The reporter on #203 found
`skippedLargeMailboxes` only by observing a live response, and asked for it to be
called out:

> that same unscoped call returned `skippedLargeMailboxes: ["iCloud / Archive (90694)"]`
> … Naming what was skipped is a significant improvement — the caller can now tell
> "no matches" from "did not look there," which was previously indistinguishable.
> Worth calling out in release notes if it is not already.

It was not.

## What this adds

A field table in the README's "Large mailboxes & partial results" section giving
each field's type and meaning, the `"Account / Mailbox (count)"` formatting, and
the fact that all five are omitted when coverage was complete. It also records
that `failedMailboxes` (IMAP path) is merged into `notSearchedMailboxes`, so
callers read the latter unless they need to attribute a failure to the IMAP
backend specifically.

Field set verified against `LIST_OUTPUT_SCHEMA` (`src/index.ts:192`) and
`SearchDiagnostics` (`src/types.ts:82`) rather than transcribed from the issue.

## Not a code change

Docs only. Version bumped to 2.17.7 with the CHANGELOG entry under a real
heading (not `[Unreleased]`, which the release path does not fold in).

Refs #203.