### PR TITLE
fix: preserve clean SMTP delivery for IMAP replies

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.7",
+      "version": "2.17.8",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.7",
+      "version": "2.17.8",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.7",
+  "version": "2.17.8",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.antigravity-plugin/skills/apple-mail/SKILL.md
+++ b/.antigravity-plugin/skills/apple-mail/SKILL.md
@@ -251,3 +251,16 @@ User: "Check my work email"
 → 1. list-accounts to find work account name
 → 2. list-messages with account="Work Exchange"
 ```
+
+
+### Preserve reply threading and delivery format
+
+Use `reply-to-message` with the original message id for replies. `send-email`
+creates a new conversation; a `Re:` subject alone does not create threading
+headers. For clean sending, use `transport: "smtp"` on reply/forward (requires
+SMTP setup). Composite `imap:` sources are read directly, without Mail.app
+synchronization. Once SMTP is selected, errors do not silently switch delivery
+backends. Explicit `transport: "applescript"` keeps the native alternative,
+including its known quote-wrapping limitation. For drafts, use `send: false`
+with transport omitted or `applescript`, not `smtp`. Read the returned
+`transport`; SMTP success may also include the sent `messageId`.

--- a/.antigravity-plugin/skills/apple-mail/SKILL.md
+++ b/.antigravity-plugin/skills/apple-mail/SKILL.md
@@ -42,7 +42,7 @@ Use this skill when the user:
 | `unflag-message` | Remove flag from a message |
 | `delete-message` | Move a message to Trash |
 | `move-message` | Move a message to a different mailbox |
-| `resolve-message-id` | Convert `imap:` ids to numeric Mail.app ids — needed **only** for `reply-to-message` / `forward-message`, which are numeric-id only. **Not** for flag colors: since 2.10.0 `flag-message`/`batch-flag-messages` write the color over IMAP directly |
+| `resolve-message-id` | Convert `imap:` ids to numeric Mail.app ids for the AppleScript reply/forward path. Direct SMTP replies and forwards accept `imap:` ids without conversion. **Not** needed for flag colors: since 2.10.0 `flag-message`/`batch-flag-messages` write the color over IMAP directly |
 | `list-attachments` | List a message's attachments (name, MIME type, size) |
 | `save-attachment` | Save an attachment to disk |
 | `fetch-attachment` | Fetch an attachment's bytes inline as base64 |
@@ -264,3 +264,9 @@ backends. Explicit `transport: "applescript"` keeps the native alternative,
 including its known quote-wrapping limitation. For drafts, use `send: false`
 with transport omitted or `applescript`, not `smtp`. Read the returned
 `transport`; SMTP success may also include the sent `messageId`.
+
+SMTP forwards need a readable plain-text original. HTML-only IMAP messages and
+failed Mail.app body reads are rejected before sending, so the original content
+cannot silently disappear. Explicit AppleScript forwarding remains available;
+do not retry through it automatically. Original attachments are not reattached
+by the plain-text SMTP forward path.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.17.7",
+  "version": "2.17.8",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.17.7",
+      "version": "2.17.8",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.7",
+  "version": "2.17.8",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   mailbox lock on success and failure. Decoded IMAP subjects are preserved.
 - Reply routing has executable regression coverage, including rendered MIME:
   the new body stays unquoted and the original thread headers reach SMTP.
+- SMTP forwards reject originals without a readable plain-text body, including
+  HTML-only IMAP messages and failed Mail.app body reads, instead of silently
+  dropping the original content. Explicit AppleScript forwarding remains available.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 ## [Unreleased]
 
+## [2.17.8] - 2026-09-04
+
+### Fixed
+
+- SMTP replies and forwards now read composite `imap:` IDs directly from their
+  encoded account/mailbox/UID instead of passing them to a numeric AppleScript
+  source lookup. This prevents the clean SMTP path from falling back merely
+  because IMAP supplied the id. Reads are bounded to 25 MiB and release the
+  mailbox lock on success and failure. Decoded IMAP subjects are preserved.
+- Reply routing has executable regression coverage, including rendered MIME:
+  the new body stays unquoted and the original thread headers reach SMTP.
+
+### Changed
+
+- Replies and forwards accept an explicit `smtp`/`applescript` transport and
+  report the selected transport (plus the SMTP message id when available).
+  **Breaking failure behavior:** once SMTP is selected, configuration/source
+  failures, missing reply headers, and send failures are returned rather than
+  silently falling back to AppleScript. Explicit AppleScript remains available;
+  omitted transport still uses it when SMTP is unconfigured or saving a draft.
+  SMTP with `send: false` is rejected before composing.
+- The newly enabled IMAP-to-SMTP compose route rejects unrelated source-account
+  identities. The IMAP login must match the SMTP login, From, or an explicitly
+  configured allowed identity. Configured aliases are excluded from reply-all.
+
 ## [2.17.7] - 2026-09-03
 
 ### Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,14 +141,14 @@ The `to`, `cc`, and `bcc` parameters must always be arrays:
 - Set `replyAll: true` to reply to all recipients
 - Set `send: false` to save as draft instead of sending immediately
 - Default behavior: reply to sender only, send immediately
-- **Transport (v2.5.0):** when SMTP is configured, sends via **clean direct SMTP**, threading the reply with proper RFC 5322 `In-Reply-To`/`References` headers (built from the original) so it stays in the same conversation. Falls back to Mail.app's AppleScript `reply … without opening window` when SMTP isn't configured (or the original lacks the headers needed to thread). The `without opening window` path opens no compose window, which ensures reliable body delivery from background processes (see [Known Issues](#known-issue-resolved-reply--forward-empty-body-from-background-processes) below)
+- **Transport (v2.5.0):** when SMTP is configured, sends via **clean direct SMTP**, threading the reply with proper RFC 5322 `In-Reply-To`/`References` headers (built from the original) so it stays in the same conversation. Reads `imap:` sources directly over IMAP. `transport: "smtp"` requires clean delivery; a selected SMTP path returns configuration, source, and threading failures rather than silently falling back. With transport omitted, Mail.app's AppleScript `reply … without opening window` is used only when SMTP is unconfigured or `send: false`. Explicit `transport: "applescript"` remains available. The `without opening window` path opens no compose window, which ensures reliable body delivery from background processes (see [Known Issues](#known-issue-resolved-reply--forward-empty-body-from-background-processes) below)
 
 ### forward-message
 
 - Requires message `id` and `to` array
 - Optional `body` to prepend a message
 - Set `send: false` to save as draft
-- **Transport (v2.5.0):** when SMTP is configured, sends via **clean direct SMTP** (a forward starts a new conversation — no threading headers). Falls back to AppleScript `forward … without opening window` when SMTP isn't configured — same background-process fix as reply-to-message
+- **Transport (v2.5.0):** when SMTP is configured, sends via **clean direct SMTP** (a forward starts a new conversation — no threading headers). Reads `imap:` sources directly over IMAP. A selected SMTP path never silently falls back. With transport omitted, uses AppleScript `forward … without opening window` when SMTP is unconfigured or a draft is requested — same background-process fix as reply-to-message
 
 ### Multi-account
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,12 @@ The `to`, `cc`, and `bcc` parameters must always be arrays:
 
 ### Multi-account
 
+SMTP forwarding requires a readable plain-text original: HTML-only IMAP messages
+and failed Mail.app body reads return an error before sending. Explicit
+`transport: "applescript"` can forward these with Mail.app; do not switch
+transports automatically after an SMTP error. The plain-text SMTP forward path
+does not reattach original attachments.
+
 - Default account is Mail.app's configured default send account
 - `search-messages` searches all accounts when no `account` is specified
 - Use `list-accounts` to see available accounts

--- a/README.md
+++ b/README.md
@@ -793,6 +793,8 @@ Forward a message to new recipients.
 
 **Delivery:** uses the same source lookup, transport selection, 25 MiB source limit, account-identity check, and failure behavior as `reply-to-message`. A forward deliberately starts a new conversation, so it has no `In-Reply-To` or `References` headers. The existing plain-text forwarding behavior is unchanged: original attachments are not reattached. See [SMTP transport](#smtp-transport).
 
+SMTP forwarding requires a readable plain-text original. HTML-only IMAP messages and failed Mail.app body reads return an error before sending instead of silently omitting the original content. Explicitly select `transport: "applescript"` to forward these with Mail.app; no automatic fallback occurs. An intentionally empty plain-text message is still valid.
+
 **⚠️ Safety:** With the default `send: true`, sends real mail immediately and cannot be unsent. Confirm the recipients, subject, and body with the user before calling (or pass `send: false` to save a draft for review).
 
 ---

--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ Return an attachment's bytes as base64 (the read counterpart to inline-base64 se
 
 #### `resolve-message-id`
 
-Map `imap:` message IDs to their numeric Mail.app IDs, via each message's RFC 5322 `Message-ID` (the join key both backends share). Needed only for the two tools that are numeric-ID-only — `reply-to-message` and `forward-message`. Numeric IDs pass through unchanged.
+Map `imap:` message IDs to their numeric Mail.app IDs, via each message's RFC 5322 `Message-ID` (the join key both backends share). Needed for the AppleScript reply/forward path; direct SMTP replies and forwards read `imap:` IDs without numeric conversion. Numeric IDs pass through unchanged.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -747,6 +747,7 @@ Reply to an existing message.
 | `body` | string | Yes | Reply body |
 | `replyAll` | boolean | No | Reply to all recipients (default: false) |
 | `send` | boolean | No | Send immediately (default: true, false = save as draft) |
+| `transport` | string | No | `smtp` or `applescript`; omitted prefers configured SMTP when sending. Drafts use AppleScript. |
 
 **Example - Reply to sender only:**
 ```json
@@ -766,7 +767,13 @@ Reply to an existing message.
 }
 ```
 
-> **Transport (v2.5.0):** when SMTP is configured, `reply-to-message` sends via **clean SMTP**, threading the reply with proper RFC 5322 `In-Reply-To`/`References` headers (built from the original message) so it lands in the same conversation. When SMTP is not configured (or the original lacks the headers needed to thread), it falls back to Mail.app's AppleScript `reply … without opening window` — same reliable-from-background-process path as before. See [SMTP transport](#smtp-transport).
+**Delivery:** `imap:` IDs are read directly from their encoded account, mailbox, and UID. Numeric IDs are read through Mail.app. With SMTP configured, replies use clean MIME with the original `Message-ID` in `In-Reply-To` and the full `References` chain. Only the original plain-text body is quoted; the new text is not. Pass `transport: "smtp"` to require this path, or `transport: "applescript"` to use Mail.app explicitly.
+
+**Failure behavior:** once SMTP is selected, a missing password, unreadable source, missing reply address or `Message-ID`, or SMTP failure returns an error. It does not silently switch to AppleScript or create an unthreaded new message. With SMTP unconfigured and transport omitted, AppleScript remains available. `send: false` saves a Mail.app draft; combining it with `transport: "smtp"` is rejected before composing.
+
+The direct IMAP source read is bounded to 25 MiB, including MIME attachments. Its account login must match the SMTP login, configured From, or an explicitly configured `APPLE_MAIL_MCP_SMTP_ALLOWED_FROM` identity; otherwise the call fails rather than sending from an unrelated account. The SMTP configuration still represents a single sending identity, not a per-account SMTP registry.
+
+Success includes `transport` and, for SMTP when returned by the server, the new `messageId`. SMTP submission does not add a local Sent copy; server-side Sent-folder behavior is unchanged. `send-email` is for **new conversations**: adding `Re:` to its subject does not add threading headers. Use this reply tool with the original id instead.
 
 **⚠️ Safety:** With the default `send: true`, sends real mail immediately and cannot be unsent. Confirm the recipients, subject, and body with the user before calling (or pass `send: false` to save a draft for review).
 
@@ -782,8 +789,9 @@ Forward a message to new recipients.
 | `to` | string[] | Yes | Recipients to forward to |
 | `body` | string | No | Message to prepend |
 | `send` | boolean | No | Send immediately (default: true, false = save as draft) |
+| `transport` | string | No | `smtp` or `applescript`; omitted prefers configured SMTP when sending. Drafts use AppleScript. |
 
-> **Transport (v2.5.0):** when SMTP is configured, `forward-message` sends via **clean SMTP** (a fresh message with the original quoted, no threading headers — a forward starts a new conversation). When SMTP is not configured it falls back to Mail.app's AppleScript `forward … without opening window`. See [SMTP transport](#smtp-transport).
+**Delivery:** uses the same source lookup, transport selection, 25 MiB source limit, account-identity check, and failure behavior as `reply-to-message`. A forward deliberately starts a new conversation, so it has no `In-Reply-To` or `References` headers. The existing plain-text forwarding behavior is unchanged: original attachments are not reattached. See [SMTP transport](#smtp-transport).
 
 **⚠️ Safety:** With the default `send: true`, sends real mail immediately and cannot be unsent. Confirm the recipients, subject, and body with the user before calling (or pass `send: false` to save a draft for review).
 
@@ -1838,7 +1846,7 @@ Prior to v1.4.0, `reply-to-message` and `forward-message` would send messages wi
 
 **Fix:** Replaced `with opening window` with `without opening window` for both `reply` and `forward` commands. With this approach, `set content` works immediately and reliably from background processes. `In-Reply-To` and `References` headers are still set correctly by Mail.app, and no GUI compose window is opened.
 
-**Update (v2.5.0):** when SMTP is configured, `reply-to-message` and `forward-message` now prefer **clean direct SMTP** instead of AppleScript — the same prefer-direct model as `send-email`. Replies are threaded with RFC 5322 `In-Reply-To`/`References` headers built from the original message; forwards start a new conversation. The AppleScript `without opening window` path above remains the fallback when SMTP is not configured (or, for replies, when the original message lacks the headers needed to thread).
+**Update (v2.5.0):** when SMTP is configured, `reply-to-message` and `forward-message` now prefer **clean direct SMTP** instead of AppleScript — the same prefer-direct model as `send-email`. Replies are threaded with RFC 5322 `In-Reply-To`/`References` headers built from the original message; forwards start a new conversation. With transport omitted, the AppleScript `without opening window` path above is used only when SMTP is not configured or a draft is requested. Since v2.17.8, a selected SMTP path returns source/configuration/threading errors instead of silently falling back; explicit `transport: "applescript"` remains available.
 
 See [#7](https://github.com/sweetrb/apple-mail-mcp/issues/7) for full details and the list of approaches that were tested.
 

--- a/build/index.js
+++ b/build/index.js
@@ -84179,123 +84179,6 @@ async function sendSerialViaSmtp(recipients, subject, body, config2, opts = {}) 
   return results;
 }
 
-// src/services/replyForward.ts
-function extractAddresses(headerValue) {
-  if (!headerValue.trim()) return [];
-  return headerValue.split(",").map((part) => {
-    const angle = part.match(/<([^>]+)>/);
-    return (angle ? angle[1] : part).trim();
-  }).filter((addr) => addr.includes("@"));
-}
-function parseOriginalHeaders(raw) {
-  const headerBlock = raw.split(/\r?\n\r?\n/)[0] ?? "";
-  const lines = [];
-  for (const line of headerBlock.split(/\r?\n/)) {
-    if (/^[ \t]/.test(line) && lines.length > 0) {
-      lines[lines.length - 1] += " " + line.trim();
-    } else {
-      lines.push(line);
-    }
-  }
-  const get = (name) => {
-    const prefix = `${name.toLowerCase()}:`;
-    const found = lines.find((l) => l.toLowerCase().startsWith(prefix));
-    return found ? found.slice(found.indexOf(":") + 1).trim() : void 0;
-  };
-  const rawMessageId = get("Message-ID");
-  const messageId = rawMessageId?.match(/<[^>]+>/)?.[0] ?? rawMessageId ?? void 0;
-  const references = `${get("References") ?? ""} ${get("In-Reply-To") ?? ""}`.match(/<[^>]+>/g) ?? [];
-  return {
-    messageId,
-    references,
-    from: extractAddresses(get("From") ?? ""),
-    replyTo: extractAddresses(get("Reply-To") ?? ""),
-    to: extractAddresses(get("To") ?? ""),
-    cc: extractAddresses(get("Cc") ?? ""),
-    subject: get("Subject") ?? "",
-    date: get("Date")
-  };
-}
-function dedupe(addrs) {
-  const seen = /* @__PURE__ */ new Set();
-  const out = [];
-  for (const a of addrs) {
-    const k = a.toLowerCase();
-    if (!seen.has(k)) {
-      seen.add(k);
-      out.push(a);
-    }
-  }
-  return out;
-}
-function withSubjectPrefix(subject, prefix) {
-  const s = subject.trim();
-  const present = prefix === "Re:" ? /^re:/i : /^(fwd?|fw):/i;
-  return present.test(s) ? s : `${prefix} ${s}`;
-}
-function quoteBody(plainText) {
-  return plainText.replace(/\s+$/, "").split(/\r?\n/).map((l) => l ? `> ${l}` : ">").join("\n");
-}
-function buildReplyOptions(args) {
-  const { original, originalPlainText, body, replyAll, self, from } = args;
-  const selfSet = new Set(self.filter(Boolean).map((s) => s.toLowerCase()));
-  const to = dedupe((original.replyTo.length ? original.replyTo : original.from).filter(Boolean));
-  const toSet = new Set(to.map((t) => t.toLowerCase()));
-  let cc;
-  if (replyAll) {
-    const extra = dedupe(
-      [...original.to, ...original.cc].filter(
-        (a) => !selfSet.has(a.toLowerCase()) && !toSet.has(a.toLowerCase())
-      )
-    );
-    cc = extra.length ? extra : void 0;
-  }
-  const attribution = buildAttribution(original);
-  const quoted = originalPlainText.trim() ? `
-
-${attribution}${quoteBody(originalPlainText)}` : "";
-  const references = dedupe(
-    original.messageId ? [...original.references, original.messageId] : original.references
-  );
-  return {
-    to,
-    cc,
-    subject: withSubjectPrefix(original.subject, "Re:"),
-    body: `${body}${quoted}`,
-    inReplyTo: original.messageId,
-    references: references.length ? references : void 0,
-    from
-  };
-}
-function buildAttribution(original) {
-  const who = original.from[0] ?? original.replyTo[0] ?? "the sender";
-  return original.date ? `On ${original.date}, ${who} wrote:
-` : `${who} wrote:
-`;
-}
-function buildForwardOptions(args) {
-  const { original, originalPlainText, to, body, from } = args;
-  const headerBlock = [
-    "---------- Forwarded message ----------",
-    original.from.length ? `From: ${original.from.join(", ")}` : "",
-    original.date ? `Date: ${original.date}` : "",
-    `Subject: ${original.subject}`,
-    original.to.length ? `To: ${original.to.join(", ")}` : "",
-    original.cc.length ? `Cc: ${original.cc.join(", ")}` : ""
-  ].filter(Boolean).join("\n");
-  const prefix = body?.trim() ? `${body}
-
-` : "";
-  return {
-    to: dedupe(to),
-    subject: withSubjectPrefix(original.subject, "Fwd:"),
-    body: `${prefix}${headerBlock}
-
-${originalPlainText}`,
-    from
-  };
-}
-
 // src/services/imapClient.ts
 var import_imapflow = __toESM(require_imap_flow(), 1);
 var IMAP_ENV = {
@@ -85058,6 +84941,34 @@ async function withMailbox(path, deps, fn) {
     }
   });
 }
+var MAX_COMPOSE_SOURCE_BYTES = 25 * 1024 * 1024;
+async function imapGetMessageSource(id, deps = {}) {
+  const ref = decodeImapId(id);
+  if (!ref) throw new Error(`Not an IMAP message id: "${id}".`);
+  return withClient(depsForMessageRef(ref, deps), async (client, cfg) => {
+    const lock = await client.getMailboxLock(ref.path);
+    try {
+      const msg = await client.fetchOne(
+        String(ref.uid),
+        {
+          envelope: true,
+          // One extra byte distinguishes an exact-limit source from truncation.
+          source: { start: 0, maxLength: MAX_COMPOSE_SOURCE_BYTES + 1 }
+        },
+        { uid: true }
+      );
+      if (!msg) throw new Error(`IMAP message UID ${ref.uid} not found in "${ref.path}".`);
+      if (!msg.source || !msg.source.length)
+        throw new Error("IMAP returned no original message source.");
+      if (Buffer.byteLength(msg.source) > MAX_COMPOSE_SOURCE_BYTES) {
+        throw new Error("Original message source exceeds the 25 MiB reply/forward limit.");
+      }
+      return { raw: msg.source.toString(), subject: msg.envelope?.subject, accountUser: cfg.user };
+    } finally {
+      lock.release();
+    }
+  });
+}
 async function imapGetMessage(id, preferHtml, deps = {}) {
   const ref = decodeImapId(id);
   if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
@@ -85552,6 +85463,123 @@ async function imapThread(id, deps = {}, limit = 50) {
   );
 }
 
+// src/services/replyForward.ts
+function extractAddresses(headerValue) {
+  if (!headerValue.trim()) return [];
+  return headerValue.split(",").map((part) => {
+    const angle = part.match(/<([^>]+)>/);
+    return (angle ? angle[1] : part).trim();
+  }).filter((addr) => addr.includes("@"));
+}
+function parseOriginalHeaders(raw) {
+  const headerBlock = raw.split(/\r?\n\r?\n/)[0] ?? "";
+  const lines = [];
+  for (const line of headerBlock.split(/\r?\n/)) {
+    if (/^[ \t]/.test(line) && lines.length > 0) {
+      lines[lines.length - 1] += " " + line.trim();
+    } else {
+      lines.push(line);
+    }
+  }
+  const get = (name) => {
+    const prefix = `${name.toLowerCase()}:`;
+    const found = lines.find((l) => l.toLowerCase().startsWith(prefix));
+    return found ? found.slice(found.indexOf(":") + 1).trim() : void 0;
+  };
+  const rawMessageId = get("Message-ID");
+  const messageId = rawMessageId?.match(/<[^>]+>/)?.[0] ?? rawMessageId ?? void 0;
+  const references = `${get("References") ?? ""} ${get("In-Reply-To") ?? ""}`.match(/<[^>]+>/g) ?? [];
+  return {
+    messageId,
+    references,
+    from: extractAddresses(get("From") ?? ""),
+    replyTo: extractAddresses(get("Reply-To") ?? ""),
+    to: extractAddresses(get("To") ?? ""),
+    cc: extractAddresses(get("Cc") ?? ""),
+    subject: get("Subject") ?? "",
+    date: get("Date")
+  };
+}
+function dedupe(addrs) {
+  const seen = /* @__PURE__ */ new Set();
+  const out = [];
+  for (const a of addrs) {
+    const k = a.toLowerCase();
+    if (!seen.has(k)) {
+      seen.add(k);
+      out.push(a);
+    }
+  }
+  return out;
+}
+function withSubjectPrefix(subject, prefix) {
+  const s = subject.trim();
+  const present = prefix === "Re:" ? /^re:/i : /^(fwd?|fw):/i;
+  return present.test(s) ? s : `${prefix} ${s}`;
+}
+function quoteBody(plainText) {
+  return plainText.replace(/\s+$/, "").split(/\r?\n/).map((l) => l ? `> ${l}` : ">").join("\n");
+}
+function buildReplyOptions(args) {
+  const { original, originalPlainText, body, replyAll, self, from } = args;
+  const selfSet = new Set(self.filter(Boolean).map((s) => s.toLowerCase()));
+  const to = dedupe((original.replyTo.length ? original.replyTo : original.from).filter(Boolean));
+  const toSet = new Set(to.map((t) => t.toLowerCase()));
+  let cc;
+  if (replyAll) {
+    const extra = dedupe(
+      [...original.to, ...original.cc].filter(
+        (a) => !selfSet.has(a.toLowerCase()) && !toSet.has(a.toLowerCase())
+      )
+    );
+    cc = extra.length ? extra : void 0;
+  }
+  const attribution = buildAttribution(original);
+  const quoted = originalPlainText.trim() ? `
+
+${attribution}${quoteBody(originalPlainText)}` : "";
+  const references = dedupe(
+    original.messageId ? [...original.references, original.messageId] : original.references
+  );
+  return {
+    to,
+    cc,
+    subject: withSubjectPrefix(original.subject, "Re:"),
+    body: `${body}${quoted}`,
+    inReplyTo: original.messageId,
+    references: references.length ? references : void 0,
+    from
+  };
+}
+function buildAttribution(original) {
+  const who = original.from[0] ?? original.replyTo[0] ?? "the sender";
+  return original.date ? `On ${original.date}, ${who} wrote:
+` : `${who} wrote:
+`;
+}
+function buildForwardOptions(args) {
+  const { original, originalPlainText, to, body, from } = args;
+  const headerBlock = [
+    "---------- Forwarded message ----------",
+    original.from.length ? `From: ${original.from.join(", ")}` : "",
+    original.date ? `Date: ${original.date}` : "",
+    `Subject: ${original.subject}`,
+    original.to.length ? `To: ${original.to.join(", ")}` : "",
+    original.cc.length ? `Cc: ${original.cc.join(", ")}` : ""
+  ].filter(Boolean).join("\n");
+  const prefix = body?.trim() ? `${body}
+
+` : "";
+  return {
+    to: dedupe(to),
+    subject: withSubjectPrefix(original.subject, "Fwd:"),
+    body: `${prefix}${headerBlock}
+
+${originalPlainText}`,
+    from
+  };
+}
+
 // src/tools/respond.ts
 import { AsyncLocalStorage } from "node:async_hooks";
 
@@ -85642,6 +85670,113 @@ function withErrorHandling(handler, errorPrefix) {
       });
     });
   };
+}
+
+// src/tools/compose.ts
+async function readOriginal(deps, id, cfg) {
+  if (decodeImapId(id)) {
+    const source = await deps.imapSource(id);
+    const identities = [cfg.user, cfg.from, ...cfg.allowedFrom ?? []].map(
+      (s) => s.trim().toLowerCase()
+    );
+    if (!identities.includes(source.accountUser.trim().toLowerCase())) {
+      throw new Error(
+        "The source IMAP account does not match the configured SMTP identity. Configure SMTP for that account or explicitly select transport=applescript."
+      );
+    }
+    const original = parseOriginalHeaders(source.raw);
+    if (source.subject !== void 0) original.subject = source.subject;
+    return { original, plainText: extractTextBody(source.raw) ?? "" };
+  }
+  const raw = deps.mail.getRawSource(id);
+  if (!raw)
+    throw new Error(
+      "Cannot read the original message source. Re-list the intended mailbox and retry with its message id."
+    );
+  const content = deps.mail.getMessageContent(id);
+  return { original: parseOriginalHeaders(raw), plainText: content?.plainText ?? "" };
+}
+async function runCompose(deps, args) {
+  const { id, send, transport: transport2 } = args;
+  const verb = args.kind === "reply" ? "reply to" : "forward";
+  if (!send && transport2 === "smtp") {
+    return errorResponse(
+      "SMTP cannot save a Mail.app draft. Omit transport or use transport=applescript with send=false."
+    );
+  }
+  const smtp = send && transport2 !== "applescript" && (transport2 === "smtp" || deps.smtpConfigured());
+  if (smtp) {
+    try {
+      const cfg = deps.smtpConfig();
+      const { original, plainText } = await readOriginal(deps, id, cfg);
+      if (args.kind === "reply") {
+        if (!original.messageId)
+          throw new Error(
+            "The original message has no Message-ID; a threaded SMTP reply cannot be constructed."
+          );
+        if (!original.replyTo.length && !original.from.length)
+          throw new Error("The original message has no reply address.");
+      }
+      const opts = args.kind === "reply" ? buildReplyOptions({
+        original,
+        originalPlainText: plainText,
+        body: args.body,
+        replyAll: args.replyAll,
+        self: [cfg.from, cfg.user, ...cfg.allowedFrom ?? []],
+        from: cfg.from
+      }) : buildForwardOptions({
+        original,
+        originalPlainText: plainText,
+        to: args.to,
+        body: args.body,
+        from: cfg.from
+      });
+      const result = await deps.smtpSend(opts, cfg);
+      if (!result.success)
+        return errorResponse(
+          `Failed to ${verb} message "${id}" via SMTP: ${result.error ?? "unknown SMTP error"}`
+        );
+      return successResponse(
+        args.kind === "reply" ? "Reply sent via SMTP" : `Message forwarded via SMTP to ${args.to.join(", ")}`,
+        {
+          ok: true,
+          sent: true,
+          id,
+          transport: "smtp",
+          messageId: result.messageId,
+          ...args.kind === "forward" ? { recipients: args.to } : {}
+        }
+      );
+    } catch (error2) {
+      return errorResponse(
+        `Failed to ${verb} message "${id}" via SMTP: ${error2 instanceof Error ? error2.message : String(error2)} No AppleScript fallback was attempted.`
+      );
+    }
+  }
+  const resolved = await deps.numericId(id);
+  if (!resolved.numericId)
+    return errorResponse(
+      `Failed to ${verb} message "${id}": ${resolved.error ?? "message not found"}`
+    );
+  const outcome = args.kind === "reply" ? deps.mail.replyToMessage(resolved.numericId, args.body, args.replyAll, send) : deps.mail.forwardMessage(resolved.numericId, args.to, args.body, send);
+  if (!outcome.success)
+    return errorResponse(
+      `Failed to ${verb} message "${id}": ${outcome.error ?? "Mail.app compose failed"}`
+    );
+  const text = args.kind === "reply" ? send ? "Reply sent via AppleScript" : "Reply saved as draft" : send ? `Message forwarded to ${args.to.join(", ")}` : "Forward saved as draft";
+  return successResponse(text, {
+    ok: true,
+    sent: send,
+    id,
+    transport: "applescript",
+    ...args.kind === "forward" ? { recipients: args.to } : {}
+  });
+}
+function runReply(deps, args) {
+  return runCompose(deps, { ...args, kind: "reply" });
+}
+function runForward(deps, args) {
+  return runCompose(deps, { ...args, kind: "forward" });
 }
 
 // src/tools/mailboxListing.ts
@@ -87115,88 +87250,37 @@ async function toNumericMailId(id) {
   }
   return { numericId };
 }
-async function sendReplyViaSmtp(id, body, replyAll) {
-  const cfg = resolveSmtpOrFallback();
-  if (!cfg) return { sent: false, fallback: true };
-  const raw = mailManager.getRawSource(id);
-  if (!raw) return { sent: false, fallback: true };
-  const original = parseOriginalHeaders(raw);
-  if (!original.messageId || original.from.length === 0) {
-    return { sent: false, fallback: true };
-  }
-  const content = mailManager.getMessageContent(id);
-  const opts = buildReplyOptions({
-    original,
-    originalPlainText: content?.plainText ?? "",
-    body,
-    replyAll,
-    self: [cfg.from, cfg.user],
-    from: cfg.from
-  });
-  const result = await sendViaSmtp(opts, cfg);
-  if (result.success) return { sent: true };
-  return { sent: false, fallback: false, error: result.error ?? "unknown SMTP error" };
-}
-async function sendForwardViaSmtp(id, to, body) {
-  const cfg = resolveSmtpOrFallback();
-  if (!cfg) return { sent: false, fallback: true };
-  const raw = mailManager.getRawSource(id);
-  if (!raw) return { sent: false, fallback: true };
-  const original = parseOriginalHeaders(raw);
-  const content = mailManager.getMessageContent(id);
-  const opts = buildForwardOptions({
-    original,
-    originalPlainText: content?.plainText ?? "",
-    to,
-    body,
-    from: cfg.from
-  });
-  const result = await sendViaSmtp(opts, cfg);
-  if (result.success) return { sent: true };
-  return { sent: false, fallback: false, error: result.error ?? "unknown SMTP error" };
-}
+var composeDeps = {
+  mail: mailManager,
+  imapSource: imapGetMessageSource,
+  numericId: toNumericMailId,
+  smtpConfigured: isSmtpConfigured,
+  smtpConfig: resolveSmtpConfig,
+  smtpSend: sendViaSmtp
+};
+var COMPOSE_TRANSPORT_SCHEMA = external_exports.enum(["applescript", "smtp"]).optional().describe(
+  "SMTP sends clean MIME and preserves reply threading; requires SMTP configuration. AppleScript uses Mail.app and may quote-wrap the new body on macOS 15+. Omit to prefer configured SMTP when sending; drafts use AppleScript. A selected SMTP transport never silently falls back. SMTP with send=false is rejected."
+);
 registerTool(
   "reply-to-message",
   {
     description: "Use when: replying to an existing message by id, preserving its threading headers. Set replyAll for all recipients; set send=false to save as a draft instead of sending.\nReturns: a confirmation that the reply was sent or saved as a draft.\nDo not use when: composing a brand-new message (use send-email / create-draft) or forwarding to new recipients (use forward-message).\nSafety: with the default send=true this SENDS real email immediately and cannot be unsent \u2014 require explicit user confirmation of the recipients and body, or pass send=false to let the user review.",
     inputSchema: {
       id: MESSAGE_ID_SCHEMA,
+      transport: COMPOSE_TRANSPORT_SCHEMA,
       body: external_exports.string().min(1, "Reply body is required"),
       replyAll: external_exports.boolean().optional().default(false).describe("Reply to all recipients"),
       send: external_exports.boolean().optional().default(true).describe("Send immediately (false = save as draft)")
     },
     outputSchema: {
+      transport: external_exports.enum(["smtp", "applescript"]).optional(),
+      messageId: external_exports.string().optional(),
       ok: external_exports.boolean().optional(),
       sent: external_exports.boolean().optional(),
       id: external_exports.string().optional()
     }
   },
-  withErrorHandling(async ({ id, body, replyAll, send }) => {
-    if (send && isSmtpConfigured()) {
-      const outcome2 = await sendReplyViaSmtp(id, body, replyAll);
-      if (outcome2.sent) {
-        return successResponse("Reply sent", { ok: true, sent: true, id });
-      }
-      if (!outcome2.fallback) {
-        return errorResponse(`Failed to reply to message "${id}" via SMTP: ${outcome2.error}`);
-      }
-    }
-    const resolvedReply = await toNumericMailId(id);
-    if (!resolvedReply.numericId) {
-      return errorResponse(`Failed to reply to message "${id}": ${resolvedReply.error}`);
-    }
-    const outcome = mailManager.replyToMessage(resolvedReply.numericId, body, replyAll, send);
-    if (!outcome.success) {
-      return errorResponse(
-        outcome.error ? `Failed to reply to message "${id}": ${outcome.error}` : `Failed to reply to message "${id}"`
-      );
-    }
-    return successResponse(send ? "Reply sent" : "Reply saved as draft", {
-      ok: true,
-      sent: send,
-      id
-    });
-  }, "Error replying to message")
+  withErrorHandling((args) => runReply(composeDeps, args), "Error replying to message")
 );
 registerTool(
   "forward-message",
@@ -87204,47 +87288,21 @@ registerTool(
     description: "Use when: forwarding an existing message (by id) to new recipients (to is an array), with an optional body to prepend. Set send=false to save as a draft.\nReturns: a confirmation that the message was forwarded or saved as a draft.\nDo not use when: replying to the sender/recipients (use reply-to-message) or composing a new message (use send-email / create-draft).\nSafety: with the default send=true this SENDS real email immediately and cannot be unsent \u2014 require explicit user confirmation of the recipients and any prepended body, or pass send=false to let the user review.",
     inputSchema: {
       id: MESSAGE_ID_SCHEMA,
+      transport: COMPOSE_TRANSPORT_SCHEMA,
       to: external_exports.array(external_exports.string()).min(1, "At least one recipient is required"),
       body: external_exports.string().optional().describe("Optional message to prepend"),
       send: external_exports.boolean().optional().default(true).describe("Send immediately (false = save as draft)")
     },
     outputSchema: {
+      transport: external_exports.enum(["smtp", "applescript"]).optional(),
+      messageId: external_exports.string().optional(),
       ok: external_exports.boolean().optional(),
       sent: external_exports.boolean().optional(),
       recipients: external_exports.array(external_exports.string()).optional(),
       id: external_exports.string().optional()
     }
   },
-  withErrorHandling(async ({ id, to, body, send }) => {
-    if (send && isSmtpConfigured()) {
-      const outcome2 = await sendForwardViaSmtp(id, to, body);
-      if (outcome2.sent) {
-        return successResponse(`Message forwarded to ${to.join(", ")}`, {
-          ok: true,
-          sent: true,
-          recipients: to,
-          id
-        });
-      }
-      if (!outcome2.fallback) {
-        return errorResponse(`Failed to forward message "${id}" via SMTP: ${outcome2.error}`);
-      }
-    }
-    const resolvedFwd = await toNumericMailId(id);
-    if (!resolvedFwd.numericId) {
-      return errorResponse(`Failed to forward message "${id}": ${resolvedFwd.error}`);
-    }
-    const outcome = mailManager.forwardMessage(resolvedFwd.numericId, to, body, send);
-    if (!outcome.success) {
-      return errorResponse(
-        outcome.error ? `Failed to forward message "${id}": ${outcome.error}` : `Failed to forward message "${id}"`
-      );
-    }
-    return successResponse(
-      send ? `Message forwarded to ${to.join(", ")}` : "Forward saved as draft",
-      { ok: true, sent: send, recipients: to, id }
-    );
-  }, "Error forwarding message")
+  withErrorHandling((args) => runForward(composeDeps, args), "Error forwarding message")
 );
 registerTool(
   "mark-as-read",

--- a/build/index.js
+++ b/build/index.js
@@ -85686,7 +85686,7 @@ async function readOriginal(deps, id, cfg) {
     }
     const original = parseOriginalHeaders(source.raw);
     if (source.subject !== void 0) original.subject = source.subject;
-    return { original, plainText: extractTextBody(source.raw) ?? "" };
+    return { original, plainText: extractTextBody(source.raw) };
   }
   const raw = deps.mail.getRawSource(id);
   if (!raw)
@@ -85694,7 +85694,7 @@ async function readOriginal(deps, id, cfg) {
       "Cannot read the original message source. Re-list the intended mailbox and retry with its message id."
     );
   const content = deps.mail.getMessageContent(id);
-  return { original: parseOriginalHeaders(raw), plainText: content?.plainText ?? "" };
+  return { original: parseOriginalHeaders(raw), plainText: content?.plainText ?? null };
 }
 async function runCompose(deps, args) {
   const { id, send, transport: transport2 } = args;
@@ -85709,6 +85709,10 @@ async function runCompose(deps, args) {
     try {
       const cfg = deps.smtpConfig();
       const { original, plainText } = await readOriginal(deps, id, cfg);
+      if (args.kind === "forward" && plainText === null)
+        throw new Error(
+          "The original message has no readable plain-text body. SMTP forwarding would omit its content; explicitly select transport=applescript to forward it with Mail.app."
+        );
       if (args.kind === "reply") {
         if (!original.messageId)
           throw new Error(
@@ -85719,14 +85723,14 @@ async function runCompose(deps, args) {
       }
       const opts = args.kind === "reply" ? buildReplyOptions({
         original,
-        originalPlainText: plainText,
+        originalPlainText: plainText ?? "",
         body: args.body,
         replyAll: args.replyAll,
         self: [cfg.from, cfg.user, ...cfg.allowedFrom ?? []],
         from: cfg.from
       }) : buildForwardOptions({
         original,
-        originalPlainText: plainText,
+        originalPlainText: plainText ?? "",
         to: args.to,
         body: args.body,
         from: cfg.from

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.7",
+  "version": "2.17.8",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.17.7"
+        "apple-mail-mcp@2.17.8"
       ]
     }
   }

--- a/codex/skills/apple-mail/SKILL.md
+++ b/codex/skills/apple-mail/SKILL.md
@@ -251,3 +251,16 @@ User: "Check my work email"
 → 1. list-accounts to find work account name
 → 2. list-messages with account="Work Exchange"
 ```
+
+
+### Preserve reply threading and delivery format
+
+Use `reply-to-message` with the original message id for replies. `send-email`
+creates a new conversation; a `Re:` subject alone does not create threading
+headers. For clean sending, use `transport: "smtp"` on reply/forward (requires
+SMTP setup). Composite `imap:` sources are read directly, without Mail.app
+synchronization. Once SMTP is selected, errors do not silently switch delivery
+backends. Explicit `transport: "applescript"` keeps the native alternative,
+including its known quote-wrapping limitation. For drafts, use `send: false`
+with transport omitted or `applescript`, not `smtp`. Read the returned
+`transport`; SMTP success may also include the sent `messageId`.

--- a/codex/skills/apple-mail/SKILL.md
+++ b/codex/skills/apple-mail/SKILL.md
@@ -42,7 +42,7 @@ Use this skill when the user:
 | `unflag-message` | Remove flag from a message |
 | `delete-message` | Move a message to Trash |
 | `move-message` | Move a message to a different mailbox |
-| `resolve-message-id` | Convert `imap:` ids to numeric Mail.app ids — needed **only** for `reply-to-message` / `forward-message`, which are numeric-id only. **Not** for flag colors: since 2.10.0 `flag-message`/`batch-flag-messages` write the color over IMAP directly |
+| `resolve-message-id` | Convert `imap:` ids to numeric Mail.app ids for the AppleScript reply/forward path. Direct SMTP replies and forwards accept `imap:` ids without conversion. **Not** needed for flag colors: since 2.10.0 `flag-message`/`batch-flag-messages` write the color over IMAP directly |
 | `list-attachments` | List a message's attachments (name, MIME type, size) |
 | `save-attachment` | Save an attachment to disk |
 | `fetch-attachment` | Fetch an attachment's bytes inline as base64 |
@@ -264,3 +264,9 @@ backends. Explicit `transport: "applescript"` keeps the native alternative,
 including its known quote-wrapping limitation. For drafts, use `send: false`
 with transport omitted or `applescript`, not `smtp`. Read the returned
 `transport`; SMTP success may also include the sent `messageId`.
+
+SMTP forwards need a readable plain-text original. HTML-only IMAP messages and
+failed Mail.app body reads are rejected before sending, so the original content
+cannot silently disappear. Explicit AppleScript forwarding remains available;
+do not retry through it automatically. Original attachments are not reattached
+by the plain-text SMTP forward path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.17.7",
+  "version": "2.17.8",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/skills/apple-mail/SKILL.md
+++ b/skills/apple-mail/SKILL.md
@@ -251,3 +251,16 @@ User: "Check my work email"
 → 1. list-accounts to find work account name
 → 2. list-messages with account="Work Exchange"
 ```
+
+
+### Preserve reply threading and delivery format
+
+Use `reply-to-message` with the original message id for replies. `send-email`
+creates a new conversation; a `Re:` subject alone does not create threading
+headers. For clean sending, use `transport: "smtp"` on reply/forward (requires
+SMTP setup). Composite `imap:` sources are read directly, without Mail.app
+synchronization. Once SMTP is selected, errors do not silently switch delivery
+backends. Explicit `transport: "applescript"` keeps the native alternative,
+including its known quote-wrapping limitation. For drafts, use `send: false`
+with transport omitted or `applescript`, not `smtp`. Read the returned
+`transport`; SMTP success may also include the sent `messageId`.

--- a/skills/apple-mail/SKILL.md
+++ b/skills/apple-mail/SKILL.md
@@ -42,7 +42,7 @@ Use this skill when the user:
 | `unflag-message` | Remove flag from a message |
 | `delete-message` | Move a message to Trash |
 | `move-message` | Move a message to a different mailbox |
-| `resolve-message-id` | Convert `imap:` ids to numeric Mail.app ids — needed **only** for `reply-to-message` / `forward-message`, which are numeric-id only. **Not** for flag colors: since 2.10.0 `flag-message`/`batch-flag-messages` write the color over IMAP directly |
+| `resolve-message-id` | Convert `imap:` ids to numeric Mail.app ids for the AppleScript reply/forward path. Direct SMTP replies and forwards accept `imap:` ids without conversion. **Not** needed for flag colors: since 2.10.0 `flag-message`/`batch-flag-messages` write the color over IMAP directly |
 | `list-attachments` | List a message's attachments (name, MIME type, size) |
 | `save-attachment` | Save an attachment to disk |
 | `fetch-attachment` | Fetch an attachment's bytes inline as base64 |
@@ -264,3 +264,9 @@ backends. Explicit `transport: "applescript"` keeps the native alternative,
 including its known quote-wrapping limitation. For drafts, use `send: false`
 with transport omitted or `applescript`, not `smtp`. Read the returned
 `transport`; SMTP success may also include the sent `messageId`.
+
+SMTP forwards need a readable plain-text original. HTML-only IMAP messages and
+failed Mail.app body reads are rejected before sending, so the original content
+cannot silently disappear. Explicit AppleScript forwarding remains available;
+do not retry through it automatically. Original attachments are not reattached
+by the plain-text SMTP forward path.

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,11 +44,7 @@ import {
   resolveSmtpConfig,
   type SmtpConfig,
 } from "@/services/smtpMailer.js";
-import {
-  buildReplyOptions,
-  buildForwardOptions,
-  parseOriginalHeaders,
-} from "@/services/replyForward.js";
+import { runReply, runForward, type ComposeDeps } from "@/tools/compose.js";
 import {
   isImapAccount,
   shouldUseImap,
@@ -72,6 +68,7 @@ import {
   imapDeleteMailbox,
   imapRenameMailbox,
   imapGetMessage,
+  imapGetMessageSource,
   imapMarkRead,
   imapMarkUnread,
   imapFlagMessage,
@@ -1175,20 +1172,6 @@ registerTool(
   }, "Error creating draft")
 );
 
-/**
- * Outcome of a direct-SMTP reply/forward attempt (2.5.0 prefer-direct path).
- * - `sent`: the SMTP transaction succeeded.
- * - `fallback`: the direct path could not be used (SMTP not fully configured, the
- *   original couldn't be fetched, or — for replies — it has no `Message-ID` to
- *   thread on); the caller should use the Mail.app AppleScript path instead.
- * - `error` (only with `fallback: false`): the SMTP transaction itself failed —
- *   surface it rather than risk a double-send by also trying Mail.app.
- */
-type DirectSendOutcome =
-  | { sent: true }
-  | { sent: false; fallback: true }
-  | { sent: false; fallback: false; error: string };
-
 /** Resolve SMTP config, falling back (host/user set but no password) to Mail.app. */
 function resolveSmtpOrFallback(): SmtpConfig | null {
   try {
@@ -1198,7 +1181,6 @@ function resolveSmtpOrFallback(): SmtpConfig | null {
   }
 }
 
-/** Reply to a message over direct SMTP with RFC 5322 threading headers. */
 /**
  * Reply and forward drive Mail.app's `reply`/`forward` verbs, which take a
  * NUMERIC Mail.app id — `findMessageScript` interpolates `Number(id)`, so an
@@ -1233,64 +1215,24 @@ async function toNumericMailId(id: string): Promise<{ numericId?: string; error?
   return { numericId };
 }
 
-async function sendReplyViaSmtp(
-  id: string,
-  body: string,
-  replyAll: boolean
-): Promise<DirectSendOutcome> {
-  const cfg = resolveSmtpOrFallback();
-  if (!cfg) return { sent: false, fallback: true };
+const composeDeps: ComposeDeps = {
+  mail: mailManager,
+  imapSource: imapGetMessageSource,
+  numericId: toNumericMailId,
+  smtpConfigured: isSmtpConfigured,
+  smtpConfig: resolveSmtpConfig,
+  smtpSend: sendViaSmtp,
+};
 
-  const raw = mailManager.getRawSource(id);
-  if (!raw) return { sent: false, fallback: true };
-
-  const original = parseOriginalHeaders(raw);
-  // Without a Message-ID we can't thread; let Mail.app's reply handle it.
-  if (!original.messageId || original.from.length === 0) {
-    return { sent: false, fallback: true };
-  }
-
-  const content = mailManager.getMessageContent(id);
-  const opts = buildReplyOptions({
-    original,
-    originalPlainText: content?.plainText ?? "",
-    body,
-    replyAll,
-    self: [cfg.from, cfg.user],
-    from: cfg.from,
-  });
-
-  const result = await sendViaSmtp(opts, cfg);
-  if (result.success) return { sent: true };
-  return { sent: false, fallback: false, error: result.error ?? "unknown SMTP error" };
-}
-
-/** Forward a message over direct SMTP (clean MIME, new thread). */
-async function sendForwardViaSmtp(
-  id: string,
-  to: string[],
-  body: string | undefined
-): Promise<DirectSendOutcome> {
-  const cfg = resolveSmtpOrFallback();
-  if (!cfg) return { sent: false, fallback: true };
-
-  const raw = mailManager.getRawSource(id);
-  if (!raw) return { sent: false, fallback: true };
-
-  const original = parseOriginalHeaders(raw);
-  const content = mailManager.getMessageContent(id);
-  const opts = buildForwardOptions({
-    original,
-    originalPlainText: content?.plainText ?? "",
-    to,
-    body,
-    from: cfg.from,
-  });
-
-  const result = await sendViaSmtp(opts, cfg);
-  if (result.success) return { sent: true };
-  return { sent: false, fallback: false, error: result.error ?? "unknown SMTP error" };
-}
+const COMPOSE_TRANSPORT_SCHEMA = z
+  .enum(["applescript", "smtp"])
+  .optional()
+  .describe(
+    "SMTP sends clean MIME and preserves reply threading; requires SMTP configuration. " +
+      "AppleScript uses Mail.app and may quote-wrap the new body on macOS 15+. " +
+      "Omit to prefer configured SMTP when sending; drafts use AppleScript. " +
+      "A selected SMTP transport never silently falls back. SMTP with send=false is rejected."
+  );
 
 // --- reply-to-message ---
 
@@ -1301,6 +1243,7 @@ registerTool(
       "Use when: replying to an existing message by id, preserving its threading headers. Set replyAll for all recipients; set send=false to save as a draft instead of sending.\nReturns: a confirmation that the reply was sent or saved as a draft.\nDo not use when: composing a brand-new message (use send-email / create-draft) or forwarding to new recipients (use forward-message).\nSafety: with the default send=true this SENDS real email immediately and cannot be unsent — require explicit user confirmation of the recipients and body, or pass send=false to let the user review.",
     inputSchema: {
       id: MESSAGE_ID_SCHEMA,
+      transport: COMPOSE_TRANSPORT_SCHEMA,
       body: z.string().min(1, "Reply body is required"),
       replyAll: z.boolean().optional().default(false).describe("Reply to all recipients"),
       send: z
@@ -1310,47 +1253,14 @@ registerTool(
         .describe("Send immediately (false = save as draft)"),
     },
     outputSchema: {
+      transport: z.enum(["smtp", "applescript"]).optional(),
+      messageId: z.string().optional(),
       ok: z.boolean().optional(),
       sent: z.boolean().optional(),
       id: z.string().optional(),
     },
   },
-  withErrorHandling(async ({ id, body, replyAll, send }) => {
-    // 2.5.0: prefer direct SMTP (clean, correctly threaded MIME) when configured
-    // and actually sending. Drafts (send=false) and the not-configured /
-    // unthreadable cases fall through to the Mail.app AppleScript path.
-    if (send && isSmtpConfigured()) {
-      const outcome = await sendReplyViaSmtp(id, body, replyAll);
-      if (outcome.sent) {
-        return successResponse("Reply sent", { ok: true, sent: true, id });
-      }
-      if (!outcome.fallback) {
-        return errorResponse(`Failed to reply to message "${id}" via SMTP: ${outcome.error}`);
-      }
-    }
-
-    const resolvedReply = await toNumericMailId(id);
-    if (!resolvedReply.numericId) {
-      return errorResponse(`Failed to reply to message "${id}": ${resolvedReply.error}`);
-    }
-    const outcome = mailManager.replyToMessage(resolvedReply.numericId, body, replyAll, send);
-
-    if (!outcome.success) {
-      // Surface Mail's own reason. An ambiguous id names its candidate
-      // mailboxes and tells the caller to re-list; a bare failure did not.
-      return errorResponse(
-        outcome.error
-          ? `Failed to reply to message "${id}": ${outcome.error}`
-          : `Failed to reply to message "${id}"`
-      );
-    }
-
-    return successResponse(send ? "Reply sent" : "Reply saved as draft", {
-      ok: true,
-      sent: send,
-      id,
-    });
-  }, "Error replying to message")
+  withErrorHandling((args) => runReply(composeDeps, args), "Error replying to message")
 );
 
 // --- forward-message ---
@@ -1362,6 +1272,7 @@ registerTool(
       "Use when: forwarding an existing message (by id) to new recipients (to is an array), with an optional body to prepend. Set send=false to save as a draft.\nReturns: a confirmation that the message was forwarded or saved as a draft.\nDo not use when: replying to the sender/recipients (use reply-to-message) or composing a new message (use send-email / create-draft).\nSafety: with the default send=true this SENDS real email immediately and cannot be unsent — require explicit user confirmation of the recipients and any prepended body, or pass send=false to let the user review.",
     inputSchema: {
       id: MESSAGE_ID_SCHEMA,
+      transport: COMPOSE_TRANSPORT_SCHEMA,
       to: z.array(z.string()).min(1, "At least one recipient is required"),
       body: z.string().optional().describe("Optional message to prepend"),
       send: z
@@ -1371,48 +1282,15 @@ registerTool(
         .describe("Send immediately (false = save as draft)"),
     },
     outputSchema: {
+      transport: z.enum(["smtp", "applescript"]).optional(),
+      messageId: z.string().optional(),
       ok: z.boolean().optional(),
       sent: z.boolean().optional(),
       recipients: z.array(z.string()).optional(),
       id: z.string().optional(),
     },
   },
-  withErrorHandling(async ({ id, to, body, send }) => {
-    // 2.5.0: prefer direct SMTP (clean MIME) when configured and actually sending.
-    if (send && isSmtpConfigured()) {
-      const outcome = await sendForwardViaSmtp(id, to, body);
-      if (outcome.sent) {
-        return successResponse(`Message forwarded to ${to.join(", ")}`, {
-          ok: true,
-          sent: true,
-          recipients: to,
-          id,
-        });
-      }
-      if (!outcome.fallback) {
-        return errorResponse(`Failed to forward message "${id}" via SMTP: ${outcome.error}`);
-      }
-    }
-
-    const resolvedFwd = await toNumericMailId(id);
-    if (!resolvedFwd.numericId) {
-      return errorResponse(`Failed to forward message "${id}": ${resolvedFwd.error}`);
-    }
-    const outcome = mailManager.forwardMessage(resolvedFwd.numericId, to, body, send);
-
-    if (!outcome.success) {
-      return errorResponse(
-        outcome.error
-          ? `Failed to forward message "${id}": ${outcome.error}`
-          : `Failed to forward message "${id}"`
-      );
-    }
-
-    return successResponse(
-      send ? `Message forwarded to ${to.join(", ")}` : "Forward saved as draft",
-      { ok: true, sent: send, recipients: to, id }
-    );
-  }, "Error forwarding message")
+  withErrorHandling((args) => runForward(composeDeps, args), "Error forwarding message")
 );
 
 // --- mark-as-read ---

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -15,6 +15,8 @@ import {
   imapFetchMessageId,
   normalizeMessageId,
   imapGetMessage,
+  imapGetMessageSource,
+  MAX_COMPOSE_SOURCE_BYTES,
   imapMarkRead,
   imapMarkUnread,
   imapFlagMessage,
@@ -2096,5 +2098,79 @@ describe("#181 IMAP batch operations reconcile the source mailbox count", () => 
       connect: async () => countingClient(0),
     });
     expect(unflag.countDelta).toBeUndefined();
+  });
+});
+
+describe("imapGetMessageSource", () => {
+  const id = encodeImapId(cfg.accountLabel, "Archive/Inbox", 42);
+  const raw = "Message-ID: <parent@example.com>\r\nSubject: Hello\r\n\r\nOriginal body";
+  function sourceClient(source: Buffer | string = raw) {
+    const release = vi.fn();
+    const client = {
+      ...makeClient([], {}),
+      getMailboxLock: vi.fn(async () => ({ release })),
+      fetchOne: vi.fn(async () => ({ uid: 42, source, envelope: { subject: "Hello" } })),
+    };
+    const connect = vi.fn(async () => client);
+    return { client, release, connect, deps: { config: cfg, connect } };
+  }
+
+  it("fetches the exact mailbox and UID with a bounded source query", async () => {
+    const d = sourceClient(Buffer.from(raw));
+    expect(await imapGetMessageSource(id, d.deps)).toEqual({
+      raw,
+      subject: "Hello",
+      accountUser: cfg.user,
+    });
+    expect(d.connect).toHaveBeenCalledWith(cfg);
+    expect(d.client.getMailboxLock).toHaveBeenCalledWith("Archive/Inbox");
+    expect(d.client.fetchOne).toHaveBeenCalledWith(
+      "42",
+      { envelope: true, source: { start: 0, maxLength: MAX_COMPOSE_SOURCE_BYTES + 1 } },
+      { uid: true }
+    );
+    expect(d.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects non-IMAP ids without connecting", async () => {
+    const d = sourceClient();
+    await expect(imapGetMessageSource("42", d.deps)).rejects.toThrow("Not an IMAP");
+    expect(d.connect).not.toHaveBeenCalled();
+  });
+
+  it("rejects a mismatched account selector before connecting", async () => {
+    const d = sourceClient();
+    await expect(imapGetMessageSource(id, { ...d.deps, account: "Other" })).rejects.toThrow(
+      "belongs to account"
+    );
+    expect(d.connect).not.toHaveBeenCalled();
+  });
+
+  it("releases the mailbox after fetch failure", async () => {
+    const d = sourceClient();
+    d.client.fetchOne.mockRejectedValue(new Error("connection reset"));
+    await expect(imapGetMessageSource(id, d.deps)).rejects.toThrow("connection reset");
+    expect(d.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports missing messages and releases the lock", async () => {
+    const d = sourceClient();
+    d.client.fetchOne.mockResolvedValue(false);
+    await expect(imapGetMessageSource(id, d.deps)).rejects.toThrow("not found");
+    expect(d.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a missing source rather than forwarding an empty body", async () => {
+    const d = sourceClient("");
+    await expect(imapGetMessageSource(id, d.deps)).rejects.toThrow("no original message source");
+    expect(d.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts the exact limit but refuses a truncated oversized source", async () => {
+    const exact = sourceClient(Buffer.alloc(MAX_COMPOSE_SOURCE_BYTES, 65));
+    expect((await imapGetMessageSource(id, exact.deps)).raw.length).toBe(MAX_COMPOSE_SOURCE_BYTES);
+    const tooBig = sourceClient(Buffer.alloc(MAX_COMPOSE_SOURCE_BYTES + 1, 65));
+    await expect(imapGetMessageSource(id, tooBig.deps)).rejects.toThrow("25 MiB");
+    expect(tooBig.release).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -1474,6 +1474,48 @@ async function withMailbox<T>(
   });
 }
 
+/** Source needed to compose a reply without relying on Mail.app synchronization. */
+export interface ImapMessageSource {
+  raw: string;
+  subject?: string;
+  accountUser: string;
+}
+
+/** Maximum raw source fetched for a reply/forward, including MIME attachments. */
+export const MAX_COMPOSE_SOURCE_BYTES = 25 * 1024 * 1024;
+
+/** Fetch headers and body together from the exact account/mailbox/UID in an IMAP id. */
+export async function imapGetMessageSource(
+  id: string,
+  deps: ImapDeps = {}
+): Promise<ImapMessageSource> {
+  const ref = decodeImapId(id);
+  if (!ref) throw new Error(`Not an IMAP message id: "${id}".`);
+  return withClient(depsForMessageRef(ref, deps), async (client, cfg) => {
+    const lock = await client.getMailboxLock(ref.path);
+    try {
+      const msg = await client.fetchOne(
+        String(ref.uid),
+        {
+          envelope: true,
+          // One extra byte distinguishes an exact-limit source from truncation.
+          source: { start: 0, maxLength: MAX_COMPOSE_SOURCE_BYTES + 1 },
+        },
+        { uid: true }
+      );
+      if (!msg) throw new Error(`IMAP message UID ${ref.uid} not found in "${ref.path}".`);
+      if (!msg.source || !msg.source.length)
+        throw new Error("IMAP returned no original message source.");
+      if (Buffer.byteLength(msg.source) > MAX_COMPOSE_SOURCE_BYTES) {
+        throw new Error("Original message source exceeds the 25 MiB reply/forward limit.");
+      }
+      return { raw: msg.source.toString(), subject: msg.envelope?.subject, accountUser: cfg.user };
+    } finally {
+      lock.release();
+    }
+  });
+}
+
 /** Read a message by composite IMAP id; returns "Subject: …\n\n<body>". */
 export async function imapGetMessage(
   id: string,

--- a/src/tools/compose.test.ts
+++ b/src/tools/compose.test.ts
@@ -128,6 +128,55 @@ describe("reply and forward transport routing", () => {
     expect(d.mail.replyToMessage).not.toHaveBeenCalled();
   });
 
+  it("refuses an HTML-only IMAP forward instead of silently omitting its body", async () => {
+    const d = fixture();
+    d.imapSource.mockResolvedValue({
+      raw: raw.replace("text/plain", "text/html"),
+      subject: "Project update",
+      accountUser: cfg.user,
+    });
+    const result = await runForward(d, {
+      id,
+      to: ["colleague@example.com"],
+      body: "For review.",
+      send: true,
+    });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result)).toContain("no readable plain-text body");
+    expect(d.smtpSend).not.toHaveBeenCalled();
+    expectNoApple(d);
+  });
+
+  it("refuses a numeric forward when Mail.app cannot return its body", async () => {
+    const d = fixture();
+    d.mail.getRawSource.mockReturnValue(raw);
+    const result = await runForward(d, {
+      id: "42",
+      to: ["colleague@example.com"],
+      send: true,
+    });
+    expect(result.isError).toBe(true);
+    expect(d.smtpSend).not.toHaveBeenCalled();
+    expect(d.mail.forwardMessage).not.toHaveBeenCalled();
+  });
+
+  it("allows a genuinely empty plain-text forward", async () => {
+    const d = fixture();
+    d.imapSource.mockResolvedValue({
+      raw: raw.replace("Original =E2=9C=93 body.", ""),
+      subject: "Project update",
+      accountUser: cfg.user,
+    });
+    const result = await runForward(d, {
+      id,
+      to: ["colleague@example.com"],
+      send: true,
+    });
+    expect(result.isError).not.toBe(true);
+    expect(d.smtpSend).toHaveBeenCalledTimes(1);
+    expectNoApple(d);
+  });
+
   it.each(["reply", "forward"] as const)(
     "does not fall back after a %s source fetch error",
     async (kind) => {

--- a/src/tools/compose.test.ts
+++ b/src/tools/compose.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi } from "vitest";
+import nodemailer from "nodemailer";
+import { runReply, runForward, type ComposeDeps, type ReplyArgs } from "@/tools/compose.js";
+import { encodeImapId } from "@/services/imapClient.js";
+import { sendViaSmtp, type SmtpConfig, type SmtpSendOptions } from "@/services/smtpMailer.js";
+import { extractTextBody } from "@/utils/mimeParse.js";
+
+const cfg: SmtpConfig = {
+  host: "smtp.example.test",
+  port: 587,
+  secure: false,
+  user: "me@example.com",
+  pass: "fixture",
+  from: "me@example.com",
+  allowedFrom: ["alias@example.com"],
+};
+const id = encodeImapId("Personal", "Archive/Inbox", 42);
+const raw = [
+  "From: sender@example.com",
+  "Reply-To: reply@example.com",
+  "To: me@example.com, alias@example.com, teammate@example.com",
+  "Subject: Project update",
+  "Message-ID: <parent@example.com>",
+  "References: <root@example.com>",
+  "\t<earlier@example.com>",
+  "Content-Type: text/plain; charset=utf-8",
+  "Content-Transfer-Encoding: quoted-printable",
+  "",
+  "Original =E2=9C=93 body.",
+].join("\r\n");
+const args: ReplyArgs = {
+  id,
+  body: "New first line.\n\nNew second paragraph.",
+  replyAll: false,
+  send: true,
+};
+
+function fixture() {
+  return {
+    mail: {
+      getRawSource: vi.fn(() => null),
+      getMessageContent: vi.fn(() => null),
+      replyToMessage: vi.fn(() => ({ success: true })),
+      forwardMessage: vi.fn(() => ({ success: true })),
+    },
+    imapSource: vi.fn(async () => ({ raw, subject: "Project update", accountUser: cfg.user })),
+    numericId: vi.fn(async () => ({ numericId: "84" })),
+    smtpConfigured: vi.fn(() => true),
+    smtpConfig: vi.fn(() => cfg),
+    smtpSend: vi.fn(async (_opts: SmtpSendOptions, _cfg: SmtpConfig) => ({
+      success: true,
+      messageId: "<sent@example.com>",
+    })),
+  } satisfies ComposeDeps;
+}
+
+function expectNoApple(d: ReturnType<typeof fixture>) {
+  expect(d.mail.getRawSource).not.toHaveBeenCalled();
+  expect(d.mail.getMessageContent).not.toHaveBeenCalled();
+  expect(d.numericId).not.toHaveBeenCalled();
+  expect(d.mail.replyToMessage).not.toHaveBeenCalled();
+  expect(d.mail.forwardMessage).not.toHaveBeenCalled();
+}
+
+describe("reply and forward transport routing", () => {
+  it("replies to an IMAP id over SMTP without any Mail.app lookup", async () => {
+    const d = fixture();
+    const result = await runReply(d, args);
+    expect(result.structuredContent).toMatchObject({
+      ok: true,
+      transport: "smtp",
+      id,
+      messageId: "<sent@example.com>",
+    });
+    expect(d.imapSource).toHaveBeenCalledWith(id);
+    expect(d.smtpSend).toHaveBeenCalledTimes(1);
+    expect(d.smtpSend.mock.calls[0][0]).toMatchObject({
+      to: ["reply@example.com"],
+      subject: "Re: Project update",
+      inReplyTo: "<parent@example.com>",
+      references: ["<root@example.com>", "<earlier@example.com>", "<parent@example.com>"],
+    });
+    expect(d.smtpSend.mock.calls[0][0].body).toMatch(/^New first line\.\n\nNew second paragraph\./);
+    expect(d.smtpSend.mock.calls[0][0].body).toContain("> Original ✓ body.");
+    expectNoApple(d);
+  });
+
+  it("uses the decoded IMAP subject and excludes configured aliases from reply-all", async () => {
+    const d = fixture();
+    d.imapSource.mockResolvedValue({ raw, subject: "Résumé update", accountUser: cfg.user });
+    await runReply(d, { ...args, replyAll: true });
+    expect(d.smtpSend.mock.calls[0][0]).toMatchObject({
+      subject: "Re: Résumé update",
+      cc: ["teammate@example.com"],
+    });
+  });
+
+  it("forwards an IMAP source without adding reply-thread headers", async () => {
+    const d = fixture();
+    const result = await runForward(d, {
+      id,
+      to: ["colleague@example.com"],
+      body: "For review.",
+      send: true,
+    });
+    expect(result.structuredContent).toMatchObject({
+      ok: true,
+      transport: "smtp",
+      recipients: ["colleague@example.com"],
+    });
+    const opts = d.smtpSend.mock.calls[0][0];
+    expect(opts.subject).toBe("Fwd: Project update");
+    expect(opts.body).toContain("Original ✓ body.");
+    expect(opts.inReplyTo).toBeUndefined();
+    expect(opts.references).toBeUndefined();
+    expectNoApple(d);
+  });
+
+  it("reads numeric sources through Mail.app but still delivers over SMTP", async () => {
+    const d = fixture();
+    d.mail.getRawSource.mockReturnValue(raw);
+    d.mail.getMessageContent.mockReturnValue({ plainText: "Numeric original." });
+    const result = await runReply(d, { ...args, id: "42" });
+    expect(result.structuredContent?.transport).toBe("smtp");
+    expect(d.mail.getRawSource).toHaveBeenCalledWith("42");
+    expect(d.imapSource).not.toHaveBeenCalled();
+    expect(d.numericId).not.toHaveBeenCalled();
+    expect(d.mail.replyToMessage).not.toHaveBeenCalled();
+  });
+
+  it.each(["reply", "forward"] as const)(
+    "does not fall back after a %s source fetch error",
+    async (kind) => {
+      const d = fixture();
+      d.imapSource.mockRejectedValue(new Error("IMAP connection reset"));
+      const result =
+        kind === "reply"
+          ? await runReply(d, args)
+          : await runForward(d, { id, to: ["colleague@example.com"], send: true });
+      expect(result).toMatchObject({ isError: true });
+      expect(JSON.stringify(result)).toContain("IMAP connection reset");
+      expect(d.smtpSend).not.toHaveBeenCalled();
+      expectNoApple(d);
+    }
+  );
+
+  it("does not hide a missing SMTP password behind an AppleScript send", async () => {
+    const d = fixture();
+    d.smtpConfig.mockImplementation(() => {
+      throw new Error("No SMTP password found");
+    });
+    expect(await runReply(d, args)).toMatchObject({ isError: true });
+    expect(d.imapSource).not.toHaveBeenCalled();
+    expect(d.smtpSend).not.toHaveBeenCalled();
+    expectNoApple(d);
+  });
+
+  it("refuses a reply without Message-ID instead of sending an unthreaded message", async () => {
+    const d = fixture();
+    d.imapSource.mockResolvedValue({
+      raw: raw.replace("Message-ID: <parent@example.com>\r\n", ""),
+      accountUser: cfg.user,
+    });
+    const result = await runReply(d, args);
+    expect(result).toMatchObject({ isError: true });
+    expect(JSON.stringify(result)).toContain("Message-ID");
+    expect(d.smtpSend).not.toHaveBeenCalled();
+    expectNoApple(d);
+  });
+
+  it("refuses an original without a reply address", async () => {
+    const d = fixture();
+    d.imapSource.mockResolvedValue({
+      raw: "Message-ID: <parent@example.com>\r\n\r\nBody",
+      accountUser: cfg.user,
+    });
+    expect(await runReply(d, args)).toMatchObject({ isError: true });
+    expect(d.smtpSend).not.toHaveBeenCalled();
+    expectNoApple(d);
+  });
+
+  it("does not send another IMAP account's message from the SMTP default", async () => {
+    const d = fixture();
+    d.imapSource.mockResolvedValue({ raw, accountUser: "other@example.com" });
+    expect(await runReply(d, args)).toMatchObject({ isError: true });
+    expect(d.smtpSend).not.toHaveBeenCalled();
+    expectNoApple(d);
+  });
+
+  it("accepts an explicitly configured identity alias", async () => {
+    const d = fixture();
+    d.imapSource.mockResolvedValue({ raw, accountUser: "ALIAS@example.com" });
+    expect((await runReply(d, args)).structuredContent?.transport).toBe("smtp");
+  });
+
+  it.each(["returned", "thrown"])(
+    "never tries a second transport after a %s SMTP error",
+    async (mode) => {
+      const d = fixture();
+      if (mode === "returned")
+        d.smtpSend.mockResolvedValue({ success: false, error: "SMTP rejected" });
+      else d.smtpSend.mockRejectedValue(new Error("connection lost after DATA"));
+      expect(await runReply(d, args)).toMatchObject({ isError: true });
+      expect(d.smtpSend).toHaveBeenCalledTimes(1);
+      expectNoApple(d);
+    }
+  );
+
+  it("reports an unreadable numeric source without composing anything", async () => {
+    const d = fixture();
+    expect(await runReply(d, { ...args, id: "42" })).toMatchObject({ isError: true });
+    expect(d.smtpSend).not.toHaveBeenCalled();
+    expect(d.numericId).not.toHaveBeenCalled();
+    expect(d.mail.replyToMessage).not.toHaveBeenCalled();
+  });
+
+  it.each(["reply", "forward"] as const)(
+    "keeps %s drafts on AppleScript even with SMTP configured",
+    async (kind) => {
+      const d = fixture();
+      const result =
+        kind === "reply"
+          ? await runReply(d, { ...args, send: false })
+          : await runForward(d, { id, to: ["colleague@example.com"], send: false });
+      expect(result.structuredContent).toMatchObject({ sent: false, transport: "applescript" });
+      expect(d.numericId).toHaveBeenCalledWith(id);
+      expect(d.smtpConfig).not.toHaveBeenCalled();
+      expect(d.smtpSend).not.toHaveBeenCalled();
+      expect(d.imapSource).not.toHaveBeenCalled();
+      if (kind === "reply")
+        expect(d.mail.replyToMessage).toHaveBeenCalledWith("84", args.body, false, false);
+      else
+        expect(d.mail.forwardMessage).toHaveBeenCalledWith(
+          "84",
+          ["colleague@example.com"],
+          undefined,
+          false
+        );
+    }
+  );
+
+  it("honors explicit AppleScript without resolving SMTP credentials", async () => {
+    const d = fixture();
+    expect(
+      (await runReply(d, { ...args, transport: "applescript" })).structuredContent?.transport
+    ).toBe("applescript");
+    expect(d.smtpConfig).not.toHaveBeenCalled();
+    expect(d.imapSource).not.toHaveBeenCalled();
+  });
+
+  it("keeps the unconfigured default on AppleScript", async () => {
+    const d = fixture();
+    d.smtpConfigured.mockReturnValue(false);
+    expect((await runReply(d, args)).structuredContent?.transport).toBe("applescript");
+    expect(d.smtpSend).not.toHaveBeenCalled();
+  });
+
+  it("honors explicit SMTP even when the automatic config check is false", async () => {
+    const d = fixture();
+    d.smtpConfigured.mockReturnValue(false);
+    expect((await runReply(d, { ...args, transport: "smtp" })).structuredContent?.transport).toBe(
+      "smtp"
+    );
+    expectNoApple(d);
+  });
+
+  it("rejects SMTP drafts before fetching or composing", async () => {
+    const d = fixture();
+    expect(await runReply(d, { ...args, transport: "smtp", send: false })).toMatchObject({
+      isError: true,
+    });
+    expect(d.smtpSend).not.toHaveBeenCalled();
+    expect(d.imapSource).not.toHaveBeenCalled();
+    expectNoApple(d);
+  });
+
+  it("preserves the numeric resolver's error and does not compose", async () => {
+    const d = fixture();
+    d.numericId.mockResolvedValue({ error: "not synchronized" });
+    const result = await runReply(d, { ...args, transport: "applescript" });
+    expect(result).toMatchObject({ isError: true });
+    expect(JSON.stringify(result)).toContain("not synchronized");
+    expect(d.mail.replyToMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("rendered SMTP reply MIME", () => {
+  it("keeps new paragraphs unquoted and carries the full parent chain on the wire", async () => {
+    const d = fixture();
+    let mime = "";
+    const createTransport = () => {
+      const transport = nodemailer.createTransport({ streamTransport: true, buffer: true });
+      const send = transport.sendMail.bind(transport);
+      transport.sendMail = async (opts) => {
+        const result = await send(opts);
+        mime = result.message.toString();
+        return result;
+      };
+      return transport;
+    };
+    d.smtpSend.mockImplementation((opts, config) =>
+      sendViaSmtp(opts, config, createTransport as typeof nodemailer.createTransport)
+    );
+    const result = await runReply(d, args);
+    expect(result.structuredContent?.ok).toBe(true);
+    const headers = mime.split(/\r?\n\r?\n/)[0].replace(/\r?\n[ \t]+/g, " ");
+    expect(headers).toContain("In-Reply-To: <parent@example.com>");
+    expect(headers).toContain(
+      "References: <root@example.com> <earlier@example.com> <parent@example.com>"
+    );
+    const text = extractTextBody(mime)?.replace(/\r\n/g, "\n");
+    expect(text).toMatch(/^New first line\.\n\nNew second paragraph\./);
+    expect(text).toContain("> Original ✓ body.");
+    expect(mime).not.toMatch(/<blockquote|Apple-Mail-URLShareWrapperClass/i);
+    expectNoApple(d);
+  });
+});

--- a/src/tools/compose.ts
+++ b/src/tools/compose.ts
@@ -1,0 +1,173 @@
+/** Reply/forward routing, kept separate from server startup for regression tests. */
+import { decodeImapId, type ImapMessageSource } from "@/services/imapClient.js";
+import type { AppleMailManager } from "@/services/appleMailManager.js";
+import type { SmtpConfig, SmtpSendOptions, SmtpSendResult } from "@/services/smtpMailer.js";
+import {
+  buildReplyOptions,
+  buildForwardOptions,
+  parseOriginalHeaders,
+} from "@/services/replyForward.js";
+import { extractTextBody } from "@/utils/mimeParse.js";
+import { successResponse, errorResponse, type ToolResponse } from "@/tools/respond.js";
+
+export interface ComposeDeps {
+  mail: Pick<
+    AppleMailManager,
+    "getRawSource" | "getMessageContent" | "replyToMessage" | "forwardMessage"
+  >;
+  imapSource: (id: string) => Promise<ImapMessageSource>;
+  numericId: (id: string) => Promise<{ numericId?: string; error?: string }>;
+  smtpConfigured: () => boolean;
+  smtpConfig: () => SmtpConfig;
+  smtpSend: (opts: SmtpSendOptions, config: SmtpConfig) => Promise<SmtpSendResult>;
+}
+
+export interface ReplyArgs {
+  id: string;
+  body: string;
+  replyAll: boolean;
+  send: boolean;
+  transport?: "smtp" | "applescript";
+}
+
+export interface ForwardArgs {
+  id: string;
+  to: string[];
+  body?: string;
+  send: boolean;
+  transport?: "smtp" | "applescript";
+}
+
+type ComposeArgs = (ReplyArgs & { kind: "reply" }) | (ForwardArgs & { kind: "forward" });
+
+/** Read composite IDs over IMAP; never pass them to a numeric AppleScript lookup. */
+async function readOriginal(deps: ComposeDeps, id: string, cfg: SmtpConfig) {
+  if (decodeImapId(id)) {
+    const source = await deps.imapSource(id);
+    // SMTP is a single configured identity. Do not activate the newly working
+    // IMAP route by silently sending another account's mail from that identity.
+    const identities = [cfg.user, cfg.from, ...(cfg.allowedFrom ?? [])].map((s) =>
+      s.trim().toLowerCase()
+    );
+    if (!identities.includes(source.accountUser.trim().toLowerCase())) {
+      throw new Error(
+        "The source IMAP account does not match the configured SMTP identity. Configure SMTP for that account or explicitly select transport=applescript."
+      );
+    }
+    const original = parseOriginalHeaders(source.raw);
+    // The IMAP envelope supplies the decoded subject, unlike the raw MIME header.
+    if (source.subject !== undefined) original.subject = source.subject;
+    return { original, plainText: extractTextBody(source.raw) ?? "" };
+  }
+  const raw = deps.mail.getRawSource(id);
+  if (!raw)
+    throw new Error(
+      "Cannot read the original message source. Re-list the intended mailbox and retry with its message id."
+    );
+  const content = deps.mail.getMessageContent(id);
+  return { original: parseOriginalHeaders(raw), plainText: content?.plainText ?? "" };
+}
+
+async function runCompose(deps: ComposeDeps, args: ComposeArgs): Promise<ToolResponse> {
+  const { id, send, transport } = args;
+  const verb = args.kind === "reply" ? "reply to" : "forward";
+  if (!send && transport === "smtp") {
+    return errorResponse(
+      "SMTP cannot save a Mail.app draft. Omit transport or use transport=applescript with send=false."
+    );
+  }
+  const smtp =
+    send && transport !== "applescript" && (transport === "smtp" || deps.smtpConfigured());
+  if (smtp) {
+    try {
+      const cfg = deps.smtpConfig();
+      const { original, plainText } = await readOriginal(deps, id, cfg);
+      if (args.kind === "reply") {
+        if (!original.messageId)
+          throw new Error(
+            "The original message has no Message-ID; a threaded SMTP reply cannot be constructed."
+          );
+        if (!original.replyTo.length && !original.from.length)
+          throw new Error("The original message has no reply address.");
+      }
+      const opts =
+        args.kind === "reply"
+          ? buildReplyOptions({
+              original,
+              originalPlainText: plainText,
+              body: args.body,
+              replyAll: args.replyAll,
+              self: [cfg.from, cfg.user, ...(cfg.allowedFrom ?? [])],
+              from: cfg.from,
+            })
+          : buildForwardOptions({
+              original,
+              originalPlainText: plainText,
+              to: args.to,
+              body: args.body,
+              from: cfg.from,
+            });
+      const result = await deps.smtpSend(opts, cfg);
+      if (!result.success)
+        return errorResponse(
+          `Failed to ${verb} message "${id}" via SMTP: ${result.error ?? "unknown SMTP error"}`
+        );
+      return successResponse(
+        args.kind === "reply"
+          ? "Reply sent via SMTP"
+          : `Message forwarded via SMTP to ${args.to.join(", ")}`,
+        {
+          ok: true,
+          sent: true,
+          id,
+          transport: "smtp",
+          messageId: result.messageId,
+          ...(args.kind === "forward" ? { recipients: args.to } : {}),
+        }
+      );
+    } catch (error) {
+      // Once SMTP is selected, failures must not change the sender/format or
+      // risk a second delivery through a different transport.
+      return errorResponse(
+        `Failed to ${verb} message "${id}" via SMTP: ${error instanceof Error ? error.message : String(error)} No AppleScript fallback was attempted.`
+      );
+    }
+  }
+
+  const resolved = await deps.numericId(id);
+  if (!resolved.numericId)
+    return errorResponse(
+      `Failed to ${verb} message "${id}": ${resolved.error ?? "message not found"}`
+    );
+  const outcome =
+    args.kind === "reply"
+      ? deps.mail.replyToMessage(resolved.numericId, args.body, args.replyAll, send)
+      : deps.mail.forwardMessage(resolved.numericId, args.to, args.body, send);
+  if (!outcome.success)
+    return errorResponse(
+      `Failed to ${verb} message "${id}": ${outcome.error ?? "Mail.app compose failed"}`
+    );
+  const text =
+    args.kind === "reply"
+      ? send
+        ? "Reply sent via AppleScript"
+        : "Reply saved as draft"
+      : send
+        ? `Message forwarded to ${args.to.join(", ")}`
+        : "Forward saved as draft";
+  return successResponse(text, {
+    ok: true,
+    sent: send,
+    id,
+    transport: "applescript",
+    ...(args.kind === "forward" ? { recipients: args.to } : {}),
+  });
+}
+
+export function runReply(deps: ComposeDeps, args: ReplyArgs): Promise<ToolResponse> {
+  return runCompose(deps, { ...args, kind: "reply" });
+}
+
+export function runForward(deps: ComposeDeps, args: ForwardArgs): Promise<ToolResponse> {
+  return runCompose(deps, { ...args, kind: "forward" });
+}

--- a/src/tools/compose.ts
+++ b/src/tools/compose.ts
@@ -57,7 +57,7 @@ async function readOriginal(deps: ComposeDeps, id: string, cfg: SmtpConfig) {
     const original = parseOriginalHeaders(source.raw);
     // The IMAP envelope supplies the decoded subject, unlike the raw MIME header.
     if (source.subject !== undefined) original.subject = source.subject;
-    return { original, plainText: extractTextBody(source.raw) ?? "" };
+    return { original, plainText: extractTextBody(source.raw) };
   }
   const raw = deps.mail.getRawSource(id);
   if (!raw)
@@ -65,7 +65,7 @@ async function readOriginal(deps: ComposeDeps, id: string, cfg: SmtpConfig) {
       "Cannot read the original message source. Re-list the intended mailbox and retry with its message id."
     );
   const content = deps.mail.getMessageContent(id);
-  return { original: parseOriginalHeaders(raw), plainText: content?.plainText ?? "" };
+  return { original: parseOriginalHeaders(raw), plainText: content?.plainText ?? null };
 }
 
 async function runCompose(deps: ComposeDeps, args: ComposeArgs): Promise<ToolResponse> {
@@ -82,6 +82,10 @@ async function runCompose(deps: ComposeDeps, args: ComposeArgs): Promise<ToolRes
     try {
       const cfg = deps.smtpConfig();
       const { original, plainText } = await readOriginal(deps, id, cfg);
+      if (args.kind === "forward" && plainText === null)
+        throw new Error(
+          "The original message has no readable plain-text body. SMTP forwarding would omit its content; explicitly select transport=applescript to forward it with Mail.app."
+        );
       if (args.kind === "reply") {
         if (!original.messageId)
           throw new Error(
@@ -94,7 +98,7 @@ async function runCompose(deps: ComposeDeps, args: ComposeArgs): Promise<ToolRes
         args.kind === "reply"
           ? buildReplyOptions({
               original,
-              originalPlainText: plainText,
+              originalPlainText: plainText ?? "",
               body: args.body,
               replyAll: args.replyAll,
               self: [cfg.from, cfg.user, ...(cfg.allowedFrom ?? [])],
@@ -102,7 +106,7 @@ async function runCompose(deps: ComposeDeps, args: ComposeArgs): Promise<ToolRes
             })
           : buildForwardOptions({
               original,
-              originalPlainText: plainText,
+              originalPlainText: plainText ?? "",
               to: args.to,
               body: args.body,
               from: cfg.from,


### PR DESCRIPTION
## Fix

Composite imap: IDs were passed to a numeric AppleScript source lookup, silently returning SMTP replies to the body-wrapping path in #12.

Read originals from their IMAP account/mailbox/UID with a 25 MiB bound. Preserve reply headers and unquoted new text. Add explicit SMTP/AppleScript selection, account-identity checks, and no silent fallback after selecting SMTP. Drafts retain AppleScript. SMTP forwards without a readable plain-text original now fail before sending; HTML-only originals require explicit AppleScript forwarding. Version 2.17.8, docs, manifests, skills and committed bundle are synchronized.

## Verification

748 unit tests across 52 files; lint, typecheck, formatting, eight built-server schema tests, and deterministic double build passed. Regression tests fail when IMAP routing or In-Reply-To is removed. Real Nodemailer MIME tested without delivery. Additional regression tests reproduced silent body omission for HTML-only IMAP messages and failed Mail.app body reads on the original head; both pass with the correction.

Original-head run: https://github.com/jjoanna2-debug/apple-mail-mcp/actions/runs/33915613764

Correction: 73a8a417401bcf353a9b6f12f7c6d130ece0f02d. Local lint (zero errors, ten existing warnings), typecheck, formatting, all unit tests, eight built-server schema tests, skill/version synchronization, and deterministic rebuild passed. Current-head [CI](https://github.com/sweetrb/apple-mail-mcp/actions/runs/33937852710), [CodeQL](https://github.com/sweetrb/apple-mail-mcp/actions/runs/33937852722), and [version guard](https://github.com/sweetrb/apple-mail-mcp/actions/runs/33937852651) passed.

Two commits on current upstream main; no workflow changes. No live configured Mail.app or provider SMTP delivery was run. Selected-SMTP failures now return errors rather than falling back; this compatibility change is documented. Apple's underlying compose bug and local SMTP Sent-copy behavior are unchanged.

Related: #12.
