### PR TITLE
fix(security): float transitive qs override to >=6.16.0 <7

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   hono: ^4.12.34
   js-yaml: ^4.3.1
   postcss: ^8.5.23
+  qs: '>=6.16.0 <7'
 
 importers:
 
@@ -1369,8 +1370,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -2204,7 +2205,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -2467,7 +2468,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
@@ -2906,7 +2907,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,3 +76,10 @@ overrides:
   # vite's own range happened to pull it forward. Matches apple-notes/apple-photos.
   # Development scope only (vitest -> vite -> postcss), not in the shipped bundle.
   postcss: ^8.5.23
+  # GHSA-4mjr-xmp4-gh2g (medium, DoS via attacker-controlled isBuffer) + GHSA-x5fp-wj9c-mxmx
+  # (medium, array-limit bypass via bracket-key comma parsing), both fixed in qs 6.16.0.
+  # Reached via @modelcontextprotocol/sdk -> express -> body-parser/express-rate-limit.
+  # qs@6.16.0 published 2026-08-29T23:50:15Z; deferred until the 7-day minimumReleaseAge
+  # soak above cleared naturally on 2026-09-05T23:50:15Z. Two-sided range per the fast-uri
+  # precedent above — never an exact pin, which becomes a ceiling for the next advisory.
+  qs: ">=6.16.0 <7"


### PR DESCRIPTION
Closes the two open qs Dependabot alerts (GHSA-x5fp-wj9c-mxmx, GHSA-4mjr-xmp4-gh2g) by raising the transitive floor, now that the 7-day minimumReleaseAge soak on qs@6.16.0 has cleared. qs is reached via @modelcontextprotocol/sdk → express → body-parser/express-rate-limit; exposure was near-zero (stdio-only transport, HTTP path never entered) but the floor still needed raising to close the alerts. Two-sided range per repo convention (see fast-uri precedent) — an exact pin would become a ceiling blocking the next advisory.

No version bump: build/ bytes are unchanged after rebuild (qs is not part of the shipped bundle), so version-guard's bump requirement does not apply.