### PR TITLE
chore(deps): floor hono 4.13.5 / js-yaml 4.3.2 (security)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ overrides:
   brace-expansion@>=5.0.0 <5.0.9: 5.0.9
   fast-uri: '>=3.1.6 <4'
   ip-address: ^10.3.1
-  hono: ^4.12.34
-  js-yaml: ^4.3.1
+  hono: ^4.13.5
+  js-yaml: ^4.3.2
   postcss: ^8.5.23
   qs: '>=6.16.0 <7'
 
@@ -305,7 +305,7 @@ packages:
     resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4.12.34
+      hono: ^4.13.5
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -973,8 +973,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
+  hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -1063,8 +1063,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1850,7 +1850,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -1865,9 +1865,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@hono/node-server@2.0.10(hono@4.13.1)':
+  '@hono/node-server@2.0.10(hono@4.13.5)':
     dependencies:
-      hono: 4.13.1
+      hono: 4.13.5
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -1896,7 +1896,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.10(hono@4.13.1)
+      '@hono/node-server': 2.0.10(hono@4.13.5)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -1906,7 +1906,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.2(express@5.2.1)
-      hono: 4.13.1
+      hono: 4.13.5
       jose: 6.2.8
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -2565,7 +2565,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.13.1: {}
+  hono@4.13.5: {}
 
   html-escaper@2.0.2: {}
 
@@ -2644,7 +2644,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,18 @@ overrides:
   # the 24h minimumReleaseAge soak — it missed by 41 minutes. No
   # minimumReleaseAgeExclude carve-out was ever added; the soak is the point.
   # It matured at 2026-08-04T02:36:40Z and is floored here now.
-  hono: ^4.12.34
+  # 2026-09-09: three further advisories, all fixed in 4.13.5 (vulnerable range
+  # < 4.13.5) — GHSA-gqvv-2mrq-wpjv (incomplete fix for CVE-2026-39408: toSSG()
+  # still writes files outside the output directory), GHSA-g6gw-c38x-mqfc
+  # (unbounded dot-notation nesting in parseBody() -> memory exhaustion), and
+  # GHSA-crvj-82cr-hjcx (the query parser reads parameters after the URL
+  # fragment -> cache-key / proxy interpretation differentials). Reached via
+  # @modelcontextprotocol/sdk -> @hono/node-server, and NOT in the shipped
+  # bundle: the HTTP transports are tree-shaken out of this stdio server.
+  # Floor raised ^4.12.34 -> ^4.13.5. 4.13.6/4.13.7 (published 2026-09-04) are
+  # still inside the 7-day soak above, so resolution lands on 4.13.5 — expected,
+  # not a stale floor. Still a caret floor, never an exact pin (see fast-uri).
+  hono: ^4.13.5
   # GHSA-5p4m-2wfm-xmqj (high): quadratic CPU consumption resolving !!omap,
   # fixed in 4.3.1 — the CVE-2026-59870 fix was never backported to the 3.x line.
   # This entry already existed as `^4.2.0`, a floor for an earlier advisory, and
@@ -68,7 +79,12 @@ overrides:
   # protects against, because the caret only stops the tree going *backwards*.
   # Dev scope (js-yaml reaches the tree via eslint) and absent from the shipped
   # bundle, so nothing vulnerable was published.
-  js-yaml: ^4.3.1
+  # 2026-09-09: GHSA-2883-xcg3-v3hh (vulnerable range >= 4.0.0 < 4.3.2) —
+  # maxTotalMergeKeys does not bound CPU use for empty merge sources, fixed in
+  # 4.3.2. Same reachability chain (eslint -> @eslint/eslintrc -> js-yaml),
+  # still development scope only and still absent from the shipped bundle.
+  # Floor raised ^4.3.1 -> ^4.3.2.
+  js-yaml: ^4.3.2
   # GHSA-fxqj-rqcc-2cmp (moderate): incomplete fix of GHSA-6g55-p6wh-862q — an
   # attacker-controlled sourceMappingURL can read arbitrary .map files when `from`
   # is unset. Patched in 8.5.23. This floor read `^8.5.15` — below the fix — so it


### PR DESCRIPTION
Raises two existing `overrides:` floors in `pnpm-workspace.yaml` to clear four advisories. Both remain **caret ranges, never exact pins** — the `fast-uri` comment in that file records the incident where an exact security floor silently became a ceiling.

## hono: `^4.12.34` → `^4.13.5`

Three advisories, all with vulnerable range `< 4.13.5`:

- **GHSA-gqvv-2mrq-wpjv** — incomplete fix for CVE-2026-39408: `toSSG()` still writes files outside the output directory.
- **GHSA-g6gw-c38x-mqfc** — unbounded dot-notation nesting in `parseBody()`, leading to memory exhaustion.
- **GHSA-crvj-82cr-hjcx** — the query parser reads parameters occurring after the URL fragment, producing cache-key / proxy interpretation differentials.

Reachability: `@modelcontextprotocol/sdk` → `@hono/node-server` → `hono`. **Not in the shipped bundle** — the HTTP transports are tree-shaken out of this stdio server.

Resolution lands on **4.13.5**, not 4.13.6/4.13.7: those were published 2026-09-04 and are still inside this repo's 7-day `minimumReleaseAge` soak. That is the intended behaviour, and no `minimumReleaseAgeExclude` carve-out was added — 4.13.5 (2026-08-26) is fully patched and mature.

## js-yaml: `^4.3.1` → `^4.3.2`

- **GHSA-2883-xcg3-v3hh** (vulnerable range `>= 4.0.0, < 4.3.2`) — `maxTotalMergeKeys` does not bound CPU use for empty merge sources.

Reachability: `eslint` → `@eslint/eslintrc` → `js-yaml`. **Development scope only, absent from the shipped bundle.**

## No version bump owed

`pnpm run build` after the install produces a **byte-identical `build/`** (`git diff --stat build/` is empty), which is expected since neither package is in the shipped bundle. Per the `qs` precedent from 2026-09-06 in this repo family, no version bump and no CHANGELOG entry: nothing vulnerable was ever published, so there are no shipped bytes to re-release. `## [Unreleased]` is left empty for `version-guard.yml`.

`@hono/node-server: 2.0.10` is untouched. vitest is already at 4.1.11, so GHSA-82fw-gwwq-j7x9 does not apply here.

## Gates

`lint` (0 errors), `typecheck`, `test` (748 passed / 52 files), `format:check` — all green locally.