### PR TITLE
fix(applescript): recognise en-GB "Not authorised" and the -1743 OSStatus as permission denials

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.9",
+      "version": "2.17.10",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.17.9",
+      "version": "2.17.10",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.9",
+  "version": "2.17.10",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.17.9",
+  "version": "2.17.10",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.17.9",
+      "version": "2.17.10",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.9",
+  "version": "2.17.10",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 ## [Unreleased]
 
+## [2.17.10] - 2026-09-09
+
+### Fixed
+
+- Permission-denied detection is no longer tied to the American spelling
+  (#218, reported by @jarrah31). macOS emits an Automation refusal in the
+  **system language**, so an en_GB/en_AU/en_IE Mac says *"Not authorised to
+  send Apple events to Mail. (-1743)"* — which `PERMISSION_DENIED_PATTERN`
+  never matched. Two things followed: `health-check`/`doctor` computed
+  `passed: !isPermError` as **true**, skipped the early `healthy: false`
+  return, and fell through to the accounts probe, so a genuine TCC denial
+  reported `permissions: ok` and told users with fully configured Mail to
+  *"Set up an account in Mail.app first."*; and because the same constant is
+  the first entry in the error mapping, the refusal was never normalised, so
+  **no tool anywhere in the server** offered an en-GB user any remediation.
+  The pattern now accepts both spellings **and** the `(-1743)`
+  (`errAEEventNotPermitted`) OSStatus, which AppleScript emits regardless of
+  system language and is therefore the only token that can match a fully
+  localised (fr/de/es) refusal.
+- Error normalisation now tests the OSStatus against the **raw** `osascript`
+  output. The execution-error parser strips a trailing `(-1743)` while
+  extracting the human-readable half, so a fully localised refusal would
+  otherwise still have reached the user as untranslated AppleScript text with
+  no remediation.
+
+### Documentation
+
+- README troubleshooting: named the localised wording of the Automation
+  refusal and the misleading "No Mail accounts found" symptom it produced
+  before this release.
+
 ## [2.17.9] - 2026-09-09
 ### Fixed
 - IMAP pipeline: upgraded `imapflow` to 1.7.8, which keeps the download

--- a/README.md
+++ b/README.md
@@ -1901,6 +1901,13 @@ In a JSON string literal, `\\` — two characters — denotes **one** literal ba
 - macOS needs automation permission
 - Go to System Settings > Privacy & Security > Automation
 - Ensure your terminal/Claude has permission to control Mail
+- **On a Mac that isn't set to US English**, macOS words this refusal in the system
+  language — `Not authorised to send Apple events to Mail. (-1743)` on en-GB/en-AU/en-IE,
+  and fully translated on fr/de/es. Before **v2.17.10** the server didn't recognise
+  those spellings, so `health-check`/`doctor` reported `permissions: ok` and then blamed
+  missing accounts (*"No Mail accounts found. Set up an account in Mail.app first."*).
+  If you see that on a Mac whose Mail accounts are already configured, upgrade and
+  re-run `doctor`.
 
 ### "Message not found"
 - Message may have been deleted or moved

--- a/build/index.js
+++ b/build/index.js
@@ -79222,7 +79222,7 @@ function sleep(ms) {
     }
   }
 }
-var PERMISSION_DENIED_PATTERN = /not authorized|not permitted|access.*denied/i;
+var PERMISSION_DENIED_PATTERN = /not author(?:i[sz])ed|not permitted|access.*denied|\(-1743\)/i;
 var PERMISSION_DENIED_MESSAGE = "Permission denied. Grant automation access in System Settings > Privacy & Security > Automation.";
 function isPermissionDenied(error2) {
   if (!error2) return false;
@@ -79285,6 +79285,9 @@ function parseErrorMessage(errorOutput) {
   const executionError = errorOutput.match(/execution error: (.+?)(?:\s*\(-?\d+\))?$/m);
   if (executionError) {
     coreError = executionError[1].trim();
+  }
+  if (PERMISSION_DENIED_PATTERN.test(errorOutput)) {
+    return PERMISSION_DENIED_MESSAGE;
   }
   for (const { pattern, message } of ERROR_MAPPINGS) {
     const match = coreError.match(pattern);

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.17.9",
+  "version": "2.17.10",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.17.9"
+        "apple-mail-mcp@2.17.10"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.17.9",
+  "version": "2.17.10",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleMailManager.health.test.ts
+++ b/src/services/appleMailManager.health.test.ts
@@ -8,9 +8,9 @@
  * denial was reported as `passed: true`, skipping the early `healthy: false`
  * return. The check shared a NAME with the real thing but not a code path.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const h = vi.hoisted(() => ({ denyAll: true }));
+const h = vi.hoisted(() => ({ denyAll: true, denialText: null as string | null }));
 
 vi.mock("@/utils/applescript.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/utils/applescript.js")>();
@@ -24,7 +24,9 @@ vi.mock("@/utils/applescript.js", async (importOriginal) => {
     executeAppleScript: (script: string) => {
       if (!h.denyAll) return { success: true, output: script.includes('return "ok"') ? "ok" : "" };
       if (script.includes('return "ok"')) return { success: true, output: "ok" };
-      return { success: false, error: actual.PERMISSION_DENIED_MESSAGE };
+      // `denialText` lets a test supply the RAW, locale-specific refusal macOS
+      // actually emits, instead of the already-normalised message.
+      return { success: false, error: h.denialText ?? actual.PERMISSION_DENIED_MESSAGE };
     },
   };
 });
@@ -53,4 +55,56 @@ describe("healthCheck under a TCC denial", () => {
     expect(r.checks.some((c) => c.name === "accounts")).toBe(false);
     expect(JSON.stringify(r)).not.toMatch(/Set up an account in Mail\.app first/);
   });
+});
+/**
+ * The locale half of the same failure mode (#218, reported by @jarrah31).
+ *
+ * macOS emits the TCC refusal in the SYSTEM language. The classifier knew only
+ * the American "not authorized", so on an en_GB/en_AU/en_IE Mac `isPermError`
+ * was false, `passed: !isPermError` reported the permissions check as PASSED,
+ * the early `healthy: false` return never fired, and the run fell through to
+ * the accounts probe — telling a user whose Mail is fully configured to go set
+ * up an account. Same constant, same silent-pass symptom 2.11.1 was written to
+ * fix; only the axis changed, from normalisation to locale.
+ *
+ * This guard exists so the classifier and the health check cannot drift apart
+ * on locale the way they previously drifted on normalisation.
+ */
+describe("healthCheck under a LOCALISED TCC denial", () => {
+  const LOCALISED_REFUSALS: [string, string][] = [
+    ["en-GB", "27:44: execution error: Not authorised to send Apple events to Mail. (-1743)"],
+    ["en-AU", "27:44: execution error: Not authorised to send Apple events to Mail. (-1743)"],
+    [
+      "fr (OSStatus only)",
+      "27:44: execution error: Non autoris\u00e9 \u00e0 envoyer des \u00e9v\u00e9nements Apple \u00e0 Mail. (-1743)",
+    ],
+  ];
+
+  beforeEach(() => {
+    h.denyAll = true;
+  });
+
+  afterEach(() => {
+    h.denialText = null;
+  });
+
+  it.each(LOCALISED_REFUSALS)(
+    "fails the permissions check and returns early: %s",
+    (_locale, refusal) => {
+      h.denialText = refusal;
+
+      const r = new AppleMailManager().healthCheck();
+
+      const perms = r.checks.find((c) => c.name === "permissions");
+      expect(perms).toBeDefined();
+      // Pre-fix this was `true` — a genuine denial reporting `permissions: ok`.
+      expect(perms!.passed).toBe(false);
+      expect(perms!.message).toMatch(/System Settings > Privacy & Security > Automation/);
+      expect(r.healthy).toBe(false);
+
+      // The early return has to fire, or the misleading accounts advice returns.
+      expect(r.checks.some((c) => c.name === "accounts")).toBe(false);
+      expect(JSON.stringify(r)).not.toMatch(/Set up an account in Mail\.app first/);
+    }
+  );
 });

--- a/src/utils/applescript.test.ts
+++ b/src/utils/applescript.test.ts
@@ -11,6 +11,7 @@ import {
   executeAppleScript,
   isPermissionDenied,
   PERMISSION_DENIED_MESSAGE,
+  PERMISSION_DENIED_PATTERN,
 } from "./applescript.js";
 
 // Mock the child_process module
@@ -530,10 +531,50 @@ describe("permission-denied classification", () => {
     // This is what a caller actually receives, and it contains none of the raw
     // substrings — which is exactly why the old string test could never match.
     expect(PERMISSION_DENIED_MESSAGE).not.toMatch(/not authorized|not permitted/i);
+    // Widening the pattern for #218 must not accidentally make the normalised
+    // message self-matching: it still shares NO raw marker — not the British
+    // spelling, not the OSStatus — so `isPermissionDenied` can only be reaching
+    // `true` below via the explicit `.includes(PERMISSION_DENIED_MESSAGE)`
+    // branch. That is the whole point of the original assertion; keep it true.
+    expect(PERMISSION_DENIED_MESSAGE).not.toMatch(/not author(?:i[sz])ed|\(-1743\)/i);
+    expect(PERMISSION_DENIED_PATTERN.test(PERMISSION_DENIED_MESSAGE)).toBe(false);
     expect(isPermissionDenied(PERMISSION_DENIED_MESSAGE)).toBe(true);
     expect(isPermissionDenied(`Permission check returned: ${PERMISSION_DENIED_MESSAGE}`)).toBe(
       true
     );
+  });
+
+  // #218 (@jarrah31): macOS emits the refusal in the SYSTEM language. The
+  // pattern only knew the American spelling, so on an en_GB/en_AU/en_IE Mac
+  // `isPermissionDenied` returned false — `healthCheck` then reported
+  // `permissions: ok` and blamed missing accounts, and `parseErrorMessage`
+  // handed the user raw AppleScript with no remediation.
+  it("classifies the en-GB/en-AU/en-IE spelling 'Not authorised'", () => {
+    expect(isPermissionDenied("Not authorised to send Apple events to Mail. (-1743)")).toBe(true);
+    expect(
+      isPermissionDenied("27:44: execution error: Not authorised to send Apple events to Mail.")
+    ).toBe(true);
+    // Both spellings, one pattern — the American form must not regress.
+    expect(isPermissionDenied("Not authorized to send Apple events to Mail.")).toBe(true);
+  });
+
+  it("classifies a FULLY LOCALISED refusal on the OSStatus alone", () => {
+    // No English substring to match here. -1743 is errAEEventNotPermitted,
+    // which AppleScript emits regardless of system language — it is the only
+    // token an English regex can ever catch on a fr/de/es Mac.
+    expect(isPermissionDenied("Non autorisé à envoyer des événements Apple à Mail. (-1743)")).toBe(
+      true
+    );
+    expect(isPermissionDenied("Nicht berechtigt, Apple-Events an Mail zu senden. (-1743)")).toBe(
+      true
+    );
+    expect(isPermissionDenied("No autorizado para enviar eventos Apple a Mail. (-1743)")).toBe(
+      true
+    );
+    // Sanity: it really is the OSStatus doing the work, not stray English.
+    expect(
+      PERMISSION_DENIED_PATTERN.test("Non autorisé à envoyer des événements Apple à Mail.")
+    ).toBe(false);
   });
 
   it("does not fire on unrelated errors", () => {
@@ -541,5 +582,62 @@ describe("permission-denied classification", () => {
     expect(isPermissionDenied("")).toBe(false);
     expect(isPermissionDenied("Mail.app is not responding.")).toBe(false);
     expect(isPermissionDenied("Message not found")).toBe(false);
+    // A different OSStatus must not be swept up by the -1743 alternative.
+    expect(isPermissionDenied('Can\'t get message 1 of mailbox "INBOX". (-1728)')).toBe(false);
+  });
+});
+
+describe("permission-denied normalisation across locales", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * The SECOND consequence @jarrah31 traced in #218: PERMISSION_DENIED_PATTERN
+   * is also ERROR_MAPPINGS[0], so a locale the pattern misses is a locale
+   * `parseErrorMessage` never normalises — meaning no tool anywhere in the
+   * server tells that user to grant Automation access. They get raw osascript
+   * text and no remediation.
+   */
+  const expectNormalised = (rawStderr: string) => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error(rawStderr);
+    });
+    const result = executeAppleScript('tell application "Mail" to get name of account 1');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(PERMISSION_DENIED_MESSAGE);
+    // A denial is not transient: it must not burn the retry budget.
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+  };
+
+  it("normalises the en-GB refusal to the remediation message", () => {
+    expectNormalised(
+      "Command failed: osascript -e '...'\n27:44: execution error: Not authorised to send Apple events to Mail. (-1743)"
+    );
+  });
+
+  it("normalises the American refusal to the remediation message", () => {
+    expectNormalised(
+      "Command failed: osascript -e '...'\n27:44: execution error: Not authorized to send Apple events to Mail. (-1743)"
+    );
+  });
+
+  it("normalises a fully localised refusal via the OSStatus", () => {
+    // Regression guard for a subtlety that would otherwise make the -1743
+    // alternative dead code here: parseErrorMessage's execution-error regex
+    // STRIPS the trailing "(-1743)" when extracting the core message, so the
+    // OSStatus must be tested against the raw output, not the parsed core.
+    expectNormalised(
+      "Command failed: osascript -e '...'\n27:44: execution error: Non autorisé à envoyer des événements Apple à Mail. (-1743)"
+    );
+  });
+
+  it("leaves unrelated AppleScript errors alone", () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('27:44: execution error: Can\'t get mailbox "Nope". (-1728)');
+    });
+    const result = executeAppleScript('tell application "Mail" to get mailbox "Nope"');
+    expect(result.error).not.toBe(PERMISSION_DENIED_MESSAGE);
+    expect(result.error).toMatch(/not found/i);
   });
 });

--- a/src/utils/applescript.ts
+++ b/src/utils/applescript.ts
@@ -211,8 +211,26 @@ function sleep(ms: number): void {
  * REPLACED — so `isPermError` was unreachable, a genuine denial reported
  * `passed: true`, and the early `healthy: false` return never fired. The check
  * shared a NAME with the real thing but not a code path.
+ *
+ * The same constant then went locale-fragile (#218). macOS emits the refusal in
+ * the SYSTEM LANGUAGE, so an en_GB/en_AU/en_IE Mac says "Not authorised to send
+ * Apple events to Mail. (-1743)" — the British spelling an American-only
+ * `not authorized` cannot match. `isPermissionDenied` returned false, so
+ * `healthCheck` reported `permissions: ok` and fell through to the accounts
+ * probe ("No Mail accounts found. Set up an account in Mail.app first."), and
+ * `parseErrorMessage` never normalised the refusal either — leaving every tool
+ * in the server with raw AppleScript text and no remediation to offer.
+ *
+ * DO NOT "simplify" the `(-1743)` alternative away. It is `errAEEventNotPermitted`,
+ * the OSStatus AppleScript emits alongside the message REGARDLESS OF SYSTEM
+ * LANGUAGE, and it is the only part of a fully localised refusal ("Non autorisé
+ * à envoyer des événements Apple à Mail. (-1743)") that any English regex can
+ * ever match. `not author(?:i[sz])ed` only buys us the English locales; the
+ * OSStatus is what makes this check locale-independent. See `parseErrorMessage`
+ * for why the OSStatus must be tested against the RAW osascript output.
  */
-export const PERMISSION_DENIED_PATTERN = /not authorized|not permitted|access.*denied/i;
+export const PERMISSION_DENIED_PATTERN =
+  /not author(?:i[sz])ed|not permitted|access.*denied|\(-1743\)/i;
 
 /** The normalised text a permission failure is reported to callers as. */
 export const PERMISSION_DENIED_MESSAGE =
@@ -301,6 +319,17 @@ function parseErrorMessage(errorOutput: string): string {
   const executionError = errorOutput.match(/execution error: (.+?)(?:\s*\(-?\d+\))?$/m);
   if (executionError) {
     coreError = executionError[1].trim();
+  }
+
+  // The OSStatus is NOT part of `coreError`: the execution-error regex above
+  // strips a trailing "(-1743)" while extracting the human-readable half. Test
+  // the RAW output so a fully localised refusal — where the OSStatus is the only
+  // matchable token — is still normalised into actionable remediation instead of
+  // being handed to the user as untranslated AppleScript text. Hoisted rather
+  // than folded into the loop because permission denial is already
+  // ERROR_MAPPINGS[0], so this preserves that priority exactly. (#218)
+  if (PERMISSION_DENIED_PATTERN.test(errorOutput)) {
+    return PERMISSION_DENIED_MESSAGE;
   }
 
   // Try to match against known error patterns for user-friendly messages


### PR DESCRIPTION
Reported by @jarrah31 in #218, with a root-cause trace that landed on the exact line.

## The bug

`PERMISSION_DENIED_PATTERN` in `src/utils/applescript.ts` matched only the **American** spelling:

```ts
/not authorized|not permitted|access.*denied/i
```

macOS emits an Automation refusal in the **system language**. On an `en_GB`/`en_AU`/`en_IE` Mac that is:

```
27:44: execution error: Not authorised to send Apple events to Mail. (-1743)
```

The pattern missed it entirely, and two things followed.

### 1. `health-check` / `doctor` reported a genuine TCC denial as healthy

`isPermissionDenied()` returned `false`, so in `healthCheck` (`src/services/appleMailManager.ts`) `isPermError` was false, `passed: !isPermError` evaluated to **`true`**, and the early `return { healthy: false, checks }` never fired. The run fell through to the accounts probe and told the user:

> No Mail accounts found. Set up an account in Mail.app first.

— i.e. a user whose Mail is fully configured was sent off to create accounts they already have, while the actual problem was one Automation grant. That is verbatim the symptom **2.11.1** was written to fix. The doc comment above this very constant warns that the old check "shared a NAME with the real thing but not a code path"; the constant then went locale-fragile in the same shape, just on a different axis.

### 2. No tool anywhere in the server offered en-GB users any remediation

The same constant is the **first entry in `ERROR_MAPPINGS`**, so `parseErrorMessage` never normalised the refusal to `PERMISSION_DENIED_MESSAGE`. Every tool in the server handed en-GB users raw AppleScript text with no hint that Automation access was the fix.

## The fix

```ts
export const PERMISSION_DENIED_PATTERN =
  /not author(?:i[sz])ed|not permitted|access.*denied|\(-1743\)/i;
```

Adopting @jarrah31's suggested `-1743` alternative. `-1743` is `errAEEventNotPermitted`, which AppleScript emits **regardless of system language** — so it is the only token that can ever match a fully localised refusal (`Non autorisé à envoyer des événements Apple à Mail. (-1743)`), which no English regex can reach. `not author(?:i[sz])ed` only buys the English locales; the OSStatus is what makes the check locale-independent. The doc comment now records that explicitly so a future reader doesn't "simplify" it away.

### One extra change the regex alone needed

`parseErrorMessage` extracts the human-readable half with `/execution error: (.+?)(?:\s*\(-?\d+\))?$/m`, which **strips the trailing `(-1743)`**. So in the mapping path the OSStatus alternative would have been dead code on precisely the localised systems it exists to cover. The permission test is now hoisted to run against the **raw** `osascript` output before the `ERROR_MAPPINGS` loop — hoisted rather than folded into the loop because permission denial is already `ERROR_MAPPINGS[0]`, so priority is unchanged. Verified load-bearing: removing it alone turns the French normalisation test red.

## Tests

`src/utils/applescript.test.ts:524` previously pinned only the American string, which is exactly why this survived — it passes under both the old and the new pattern. Added:

- classifier: `Not authorised … (-1743)` and the bare en-GB core message → `true`, American form still `true`
- classifier: fully localised fr / de / es refusals matching **on the OSStatus alone**, plus a sanity assertion that the same French string *without* the OSStatus does **not** match — proving it really is `-1743` doing the work
- negative: a different OSStatus (`-1728`, "Can't get message…") is **not** swept up
- end-to-end normalisation through `executeAppleScript`: en-GB, en-US and fr raw stderr all map to `PERMISSION_DENIED_MESSAGE`, and a denial doesn't burn the retry budget
- `healthCheck` guard (`src/services/appleMailManager.health.test.ts`) over en-GB, en-AU and fr refusals asserting `passed: false`, the remediation message, **and** the early `healthy: false` return with no `accounts` check — so the classifier and the health check cannot drift apart on locale the way they previously drifted on normalisation

All 7 new assertions were confirmed **red** against the old pattern before the fix.

The existing assertion that `PERMISSION_DENIED_MESSAGE` shares no raw marker is **strengthened, not weakened**: it now also pins that the widened pattern does not match the normalised message, so `isPermissionDenied` still reaches `true` there only via the explicit `.includes(PERMISSION_DENIED_MESSAGE)` branch — which was the original point of that assertion.

No permission was revoked to test this; the whole surface of the change is the regex against the exact literal strings macOS emits.

## Docs

README troubleshooting now names the localised wording and the misleading "No Mail accounts found" symptom, so anyone hitting it on an older version can recognise it. `CLAUDE.md` and `docs/` document the normalised "Permission denied" symptom, which is what every locale now gets — no change needed there.

Version bumped to **2.17.10** with a CHANGELOG entry.

Fixes #218.