### PR TITLE
fix(batch): verify the resolved message's id before mutating it (2.18.1)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.18.0",
+      "version": "2.18.1",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.18.0",
+      "version": "2.18.1",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.18.0",
+      "version": "2.18.1",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## [Unreleased]
 
+## [2.18.1] - 2026-09-10
+
+### Fixed
+- By-id batch and single mutations now verify that the message AppleScript
+  resolved is actually the one requested, before deleting or moving it.
+  `whose id is N` is **not an exact match** — Mail *rounds*. Measured against a
+  real store on 2026-09-10: `whose id is 78364.6` resolves to id **78365**, a
+  different, adjacent message. So an id that reaches AppleScript with any
+  imprecision does not fail; it silently selects a neighbour, and the walk then
+  mutates it. Both resolution sites — the mailbox-scoped path and the unscoped
+  fallback walk — now compare the resolved message's own id against the
+  requested one and report `notfound` on a mismatch instead of acting.
+  Defence in depth for the still-unexplained #155 residual (messages whose ids
+  were never passed being affected); it makes that class of mis-resolution a
+  safe no-op rather than a wrong-message delete. **It is not a diagnosis of
+  #155**, which remains open pending the reporter's data.
+
 ## [2.18.0] - 2026-09-10
 
 ### Added

--- a/build/index.js
+++ b/build/index.js
@@ -84613,12 +84613,31 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             set _out to _out & ((item _k of _gpos) as string) & "${FIELD_SEP}error:source mailbox \\"${mbInProse}\\" not found in account \\"${acctInProse}\\"${RECORD_SEP}"
           end repeat
         else${instrument ? `${this.countFragment("_cb")}${this.snapshotFragment("before", acctLit, mbLit, "_cb")}` : ""}
+          -- WARNING: "whose id is N" is NOT an exact match -- Mail ROUNDS.
+          -- Measured on Mail 2026-09-10 against a real store: "whose id is
+          -- 78364.6" resolves to id 78365, a DIFFERENT, ADJACENT message that
+          -- was never asked for (78364.0-.5 -> 78364, 78364.6-.0 -> 78365). So
+          -- an id reaching AppleScript with the slightest imprecision does not
+          -- fail; it silently selects a neighbour, and this loop then DELETES
+          -- or MOVES it. That is exactly the #155 residual: "two adjacent
+          -- messages that were NOT in the id list got deleted instead."
+          --
+          -- Reachable whenever an id survives JS's 2^53 safe-integer range or
+          -- renders in exponential form -- both change the value before Mail
+          -- sees it. Rather than enumerate those paths, refuse to act on any
+          -- message whose OWN id is not the one requested: a mis-resolution
+          -- becomes a safe notfound instead of a wrong-message mutation.
+          -- Compared numerically, never as strings -- see canonicalNumericId
+          -- for why the string forms cannot be trusted.
+          --
+          -- NB: no backticks anywhere in this comment. A backtick inside an
+          -- AppleScript comment terminates the enclosing TS template literal.
           repeat with _k from 1 to (count of _gids)
             set _idx to item _k of _gpos
             set _pre to ""
             try
               set _m to (messages of _tmb whose id is (item _k of _gids))
-              if (count of _m) > 0 then
+              if (count of _m) > 0 and ((id of (item 1 of _m)) is (item _k of _gids)) then
                 set _msg to item 1 of _m${pre}
                 ${operation}
                 set _out to _out & (_idx as string) & "${FIELD_SEP}ok" & _pre & "${RECORD_SEP}"
@@ -84648,7 +84667,7 @@ ${this.errorEmit("              ")}
             repeat with _k from 1 to _ucount
               try
                 set _m to (messages of mb whose id is (item _k of _uids))
-                if (count of _m) > 0 then
+                if (count of _m) > 0 and ((id of (item 1 of _m)) is (item _k of _uids)) then
                   set item _k of _uhit to ((item _k of _uhit) + 1)
                   if (item _k of _uhit) is 1 then set item _k of _umsg to (item 1 of _m)
                   set item _k of _unames to ((item _k of _unames) & (name of acct) & "/" & (name of mb) & ", ")

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.18.0"
+        "apple-mail-mcp@2.18.1"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleMailManager.batchScope.test.ts
+++ b/src/services/appleMailManager.batchScope.test.ts
@@ -91,6 +91,33 @@ describe("#152 — by-id mutations are scoped to the source mailbox", () => {
     expect(s).not.toContain("set _m to (messages of mb whose id is _theId)");
   });
 
+  it("re-checks the resolved message's own id before mutating it (#155)", () => {
+    // "whose id is N" is NOT an exact match — Mail ROUNDS. Measured against a
+    // real store on 2026-09-10: "whose id is 78364.6" resolves to id 78365, a
+    // DIFFERENT, ADJACENT message. Without a re-check the walk then deletes it,
+    // which is the #155 residual verbatim: "two adjacent messages that were NOT
+    // in the id list got deleted instead." Counting the matches is therefore not
+    // enough; the message must be asked whether it is the one requested.
+    mgr.batchDeleteMessages(["75816", "75791"]);
+    const s = lastScript();
+
+    expect(s).toContain("(id of (item 1 of _m)) is (item _k of _gids)");
+    // The count-only condition must not survive on its own.
+    expect(s).not.toMatch(/if \(count of _m\) > 0 then\s*\n\s*set _msg to item 1 of _m/);
+  });
+
+  it("re-checks the id on the unscoped fallback walk too (#155)", () => {
+    // The location cache misses for an id never listed this session, and that
+    // path resolves in a different loop. A guard on only one of the two leaves
+    // the destructive path unprotected exactly when the caller knows least.
+    mgr.batchDeleteMessages(["999999"]);
+    const s = lastScript();
+
+    if (s.includes("whose id is (item _k of _uids)")) {
+      expect(s).toContain("(id of (item 1 of _m)) is (item _k of _uids)");
+    }
+  });
+
   it("batch move scopes the SOURCE lookup while still resolving the destination", () => {
     mgr.batchMoveMessages(["75816"], "Archive", "me@example.com");
     const s = lastScript();

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -4317,12 +4317,31 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
             ? `${this.countFragment("_cb")}${this.snapshotFragment("before", acctLit, mbLit, "_cb")}`
             : ""
         }
+          -- WARNING: "whose id is N" is NOT an exact match -- Mail ROUNDS.
+          -- Measured on Mail 2026-09-10 against a real store: "whose id is
+          -- 78364.6" resolves to id 78365, a DIFFERENT, ADJACENT message that
+          -- was never asked for (78364.0-.5 -> 78364, 78364.6-.0 -> 78365). So
+          -- an id reaching AppleScript with the slightest imprecision does not
+          -- fail; it silently selects a neighbour, and this loop then DELETES
+          -- or MOVES it. That is exactly the #155 residual: "two adjacent
+          -- messages that were NOT in the id list got deleted instead."
+          --
+          -- Reachable whenever an id survives JS's 2^53 safe-integer range or
+          -- renders in exponential form -- both change the value before Mail
+          -- sees it. Rather than enumerate those paths, refuse to act on any
+          -- message whose OWN id is not the one requested: a mis-resolution
+          -- becomes a safe notfound instead of a wrong-message mutation.
+          -- Compared numerically, never as strings -- see canonicalNumericId
+          -- for why the string forms cannot be trusted.
+          --
+          -- NB: no backticks anywhere in this comment. A backtick inside an
+          -- AppleScript comment terminates the enclosing TS template literal.
           repeat with _k from 1 to (count of _gids)
             set _idx to item _k of _gpos
             set _pre to ""
             try
               set _m to (messages of _tmb whose id is (item _k of _gids))
-              if (count of _m) > 0 then
+              if (count of _m) > 0 and ((id of (item 1 of _m)) is (item _k of _gids)) then
                 set _msg to item 1 of _m${pre}
                 ${operation}
                 set _out to _out & (_idx as string) & "${FIELD_SEP}ok" & _pre & "${RECORD_SEP}"
@@ -4362,7 +4381,7 @@ ${this.errorEmit("              ")}
             repeat with _k from 1 to _ucount
               try
                 set _m to (messages of mb whose id is (item _k of _uids))
-                if (count of _m) > 0 then
+                if (count of _m) > 0 and ((id of (item 1 of _m)) is (item _k of _uids)) then
                   set item _k of _uhit to ((item _k of _uhit) + 1)
                   if (item _k of _uhit) is 1 then set item _k of _umsg to (item 1 of _m)
                   set item _k of _unames to ((item _k of _unames) & (name of acct) & "/" & (name of mb) & ", ")


### PR DESCRIPTION
Investigating the #155 residual against a real Mail store turned up a concrete mechanism that produces its exact symptom. This hardens against it. **This is deliberately not a resolution of that issue** — see the last section.

## `whose id is N` is not an exact match — Mail rounds

Measured against a live store, 2026-09-10:

| requested | resolves to |
|---|---|
| `78364.0` – `78364.5` | id 78364 |
| **`78364.6`** – `78365.0` | **id 78365 — a different, adjacent message** |

So an id reaching AppleScript with the slightest imprecision does **not** fail to match. It silently selects a **neighbour**, and the batch walk then deletes or moves it.

Confirmed end to end with two disposable drafts holding adjacent ids (78403, 78404):

```
OLD (count only)     : WOULD ACT ON id 78404 (ZZ155g-2)   ← never requested
NEW (identity check) : no match -> safe notfound
```

That is #155's residual symptom verbatim — *"two adjacent messages that were NOT in the id list got deleted instead."*

## The fix

Both resolution sites — the mailbox-scoped grouped path and the unscoped fallback walk — now ask the resolved message for its **own** id and compare it against the requested one, reporting `notfound` on a mismatch rather than acting. Compared numerically, never as strings (see `canonicalNumericId` for why the string forms can't be trusted).

Reachable whenever an id survives JS's 2^53 safe-integer range or renders in exponential form, both of which change the value before Mail ever sees it. Rather than enumerate those paths, the guard refuses to act on any message that isn't the one asked for — turning the whole class from a wrong-message mutation into a safe no-op.

## What this does NOT establish

I could not reproduce #155's actual report. On this store, a faithful replay of the batch walk — resolve `whose id is` and delete inside one loop, passing 2 of 6 ids — deleted **exactly** the two requested, with survivor ids unshifted. So the "Mail re-indexes ids mid-batch" candidate did **not** reproduce here.

The rounding mechanism matches the symptom, but whether it is what bit the reporter depends on their id magnitudes, which are still unknown. Per #155's own standing instruction not to resolve it by inventing a mechanism, that issue stays open on data, and this PR intentionally carries no closing keyword.

## Gates
lint (0 errors, 10 pre-existing warnings) · typecheck · **778 tests** (2 new, verified to fail without the guard) · prettier · bundle rebuilt


---

> **Note:** an earlier revision of this description contained the phrase *"does not claim to close #155"*. GitHub matches the bare keyword and **ignores the negation in front of it**, so it closed the issue on merge anyway. Reopened, and the phrasing removed. Worth knowing: a disclaimer is not a safe place to write a closing keyword.