### PR TITLE
feat: get-message-headers tool + dateSent/dateReceived on get-message (2.19.0)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.18.1",
+      "version": "2.19.0",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.18.1",
+      "version": "2.19.0",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.antigravity-plugin/skills/apple-mail/SKILL.md
+++ b/.antigravity-plugin/skills/apple-mail/SKILL.md
@@ -30,6 +30,7 @@ Use this skill when the user:
 | `list-messages` | List messages in a mailbox (all mailboxes if omitted) |
 | `search-messages` | Find messages by sender, subject, or content |
 | `get-message` | Read the full content of a message |
+| `get-message-headers` | Read a message's raw RFC 5322 headers (author's `Date:`, Message-ID, threading ids, `Received:` trace) without the body |
 | `get-thread` | Get the full conversation thread for a message |
 | `send-email` | Send a new email immediately |
 | `send-serial-email` | Send personalized copies to many recipients (mail merge with `{{Key}}` placeholders) |

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.18.1",
+      "version": "2.19.0",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 ## [Unreleased]
 
+## [2.19.0] - 2026-09-12
+
+### Added
+- `get-message-headers` tool (#224, requested by @j5pu): returns a message's raw
+  RFC 5322 header block **without fetching the body or attachments**, plus the
+  parsed fields chronological and threading work needs — `date` (ISO 8601, from
+  the `Date:` header), `dateHeader` verbatim, `dateReceived` (the mailbox
+  arrival time), `messageId`, `subject`/`from`/`to`/`cc`/`replyTo` with RFC 2047
+  encoded-words decoded, `inReplyTo`, `references[]`, `received[]` (the hop
+  trace, last hop first) and every header as ordered `{name, value}` pairs with
+  folding undone. Over IMAP it is a `BODY.PEEK[HEADER]` fetch; over AppleScript
+  it reads Mail's `all headers`, with the same mailbox-scoped fast path as
+  `get-message`.
+- `get-message` now returns `dateSent` and `dateReceived` in `structuredContent`
+  on both backends (#224). `dateSent` is the message's `Date:` header — Mail's
+  `date sent`, the IMAP ENVELOPE date — and is the author's send time.
+  `dateReceived` is arrival in the mailbox — Mail's `date received`, IMAP
+  `INTERNALDATE`. The distinction is the whole point: a migration or re-import
+  rewrites the arrival timestamp (the reporter's iCloud mailbox has clusters of
+  dozens of messages sharing one `INTERNALDATE` to the second while their real
+  send dates differ by years), so a caller doing chronology on such a mailbox
+  needs the header date, and `get-message` previously exposed neither. Either
+  field is omitted, never invented, when the backend cannot supply it.
+
+### Fixed
+- `get-message` over IMAP returned an **empty `rfcMessageId` for every message**
+  since the field was added in 2.2.0. The IMAP branch parsed the Message-ID out
+  of the tool's own `info` text, which is subject + body and never carried a
+  header block, so the extraction could not succeed. It now takes the Message-ID
+  from the IMAP ENVELOPE. Found by the live probe for #224, where
+  `get-message-headers` returned a `messageId` for a message whose `get-message`
+  said `""`. The AppleScript branch was unaffected.
+
+### Changed
+- The three AppleScript by-id reads (`getMessageContent`, `getRawSource` and the
+  new `getMessageHeaders`) now share one unscoped-scan script builder; the first
+  two previously carried byte-identical copies of it. No behaviour change.
+
+### Documentation
+- README: `get-message-headers` Tool Reference entry, the two-dates note on
+  `get-message`, and a "Read Headers" feature row. CLAUDE.md: when to trust
+  `dateSent` over `dateReceived`. `docs/IMAP-SETUP.md` and the bundled skill list
+  the new tool.
+
 ## [2.18.1] - 2026-09-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ does not reattach original attachments.
 - `search-messages` searches all accounts when no `account` is specified
 - Use `list-accounts` to see available accounts
 - Pass `account` parameter to target specific account
+- **Two dates, and they can disagree (2.19.0, #224).** `get-message` returns `dateSent` (the `Date:` header — the author's send time) and `dateReceived` (arrival in the mailbox: IMAP `INTERNALDATE` / Mail's `date received`). A migration or re-import resets the arrival time, so on such a mailbox dozens of messages share one `dateReceived` while their `dateSent` values span years — use `dateSent` for chronology there. `get-message-headers` returns the raw header block (Message-ID, In-Reply-To/References, the `Received:` trace, custom `X-` headers) without downloading the body.
 - **Reads prefer direct IMAP when configured (v2.6.0).** When any `APPLE_MAIL_MCP_IMAP_*` account is configured, the read tools (`search-messages`, `get-thread`, `list-messages`, `list-mailboxes`, `get-unread-count`, `get-mail-stats`) go to IMAP instead of AppleScript:
   - explicit IMAP `account` → that account over IMAP (fast, server-side);
   - explicit non-IMAP `account` → AppleScript;

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ tool, and troubleshooting. Verify any time by running the **`doctor`** tool.
 | **List Messages** | List messages with pagination, sender filter, date display |
 | **Search Messages** | Search by sender, subject, content, date range, read/flagged status — across all accounts |
 | **Read Messages** | Get full email content (plain text or HTML) |
+| **Read Headers** | Get a message's raw RFC 5322 headers — the author's `Date:`, Message-ID, threading ids, `Received:` trace — without downloading the body |
 | **Send Email** | Compose and send new emails (attach by file path or inline base64 content) |
 | **Send Serial Email** | Mail merge — send personalized emails to a list of recipients with {{placeholder}} support |
 | **Create Draft** | Save emails to Drafts folder (attach by file path or inline base64 content) |
@@ -288,7 +289,7 @@ Get the full content of a message.
 | `mailbox` | string | No | Mailbox holding the message (e.g. `"Sent Items"`). With `account`, opens that mailbox directly instead of scanning every mailbox — this is the fix for timeouts on large folders |
 | `account` | string | No | Account holding the message. Pair with `mailbox` to skip the cross-mailbox scan |
 
-**Returns:** Subject line and message body (plain text by default, HTML if `preferHtml` is true and HTML content is available).
+**Returns:** Subject line and message body (plain text by default, HTML if `preferHtml` is true and HTML content is available). `structuredContent` also carries `rfcMessageId` and, since 2.19.0, two dates: `dateSent` (the message's `Date:` header — Mail's `date sent`) and `dateReceived` (arrival in the mailbox — Mail's `date received` / IMAP `INTERNALDATE`). They differ legitimately by transit time; when they differ by **years**, the mailbox was migrated or re-imported and the arrival timestamp was reset — trust `dateSent` for chronology ([#224](https://github.com/sweetrb/apple-mail-mcp/issues/224)).
 
 > **Large messages / attachments:** reading a full message routes through
 > `osascript`, whose captured output buffer defaults to **64 MB**. Override it
@@ -296,6 +297,22 @@ Get the full content of a message.
 > work with messages whose raw MIME (e.g. a large embedded attachment) exceeds
 > that — a value below the message size makes the read fail with a buffer-overflow
 > error rather than truncating ([#27](https://github.com/sweetrb/apple-mail-mcp/issues/27)).
+
+---
+
+#### `get-message-headers`
+
+Return a message's raw RFC 5322 header block — without fetching the body or any attachment — plus the parsed fields chronological and threading work needs. Added in 2.19.0 for mailboxes whose arrival timestamps were reset by a migration ([#224](https://github.com/sweetrb/apple-mail-mcp/issues/224)): the `Date:` header is the author's send time and survives such moves; `INTERNALDATE` / `date received` does not.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | Yes | Message ID (numeric or `imap:…`) |
+| `mailbox` | string | No | Mailbox holding the message. With `account`, opens that mailbox directly instead of scanning every mailbox |
+| `account` | string | No | Account holding the message. Pair with `mailbox` to skip the cross-mailbox scan |
+
+**Returns:** The raw header block as text. `structuredContent` carries `raw`, every header as ordered `headers[]` (`{name, value}`, folded lines joined, duplicates such as `Received:` kept in wire order, values left RFC 2047-encoded), `headerCount`, and the decoded key fields: `date` (ISO 8601, from the `Date:` header), `dateHeader` (verbatim), `dateReceived` (mailbox arrival time — IMAP `INTERNALDATE` or Mail's `date received`), `messageId`, `subject`, `from`, `to`, `cc`, `replyTo`, `inReplyTo`, `references[]` and `received[]` (first entry = last hop). Fields the message does not carry are omitted.
+
+**Backends:** an `imap:` id fetches `BODY.PEEK[HEADER]` over IMAP (cheap even for a 20 MB message); a numeric id reads Mail's `all headers` property over AppleScript, with the same mailbox-scoped fast path as `get-message`.
 
 ---
 

--- a/build/cli.js
+++ b/build/cli.js
@@ -57771,6 +57771,18 @@ var init_mimeParse = __esm({
   }
 });
 
+// src/utils/headers.ts
+function isoOrUndefined(d) {
+  if (d === void 0 || d === "") return void 0;
+  const date = d instanceof Date ? d : new Date(d);
+  return Number.isNaN(date.getTime()) ? void 0 : date.toISOString();
+}
+var init_headers = __esm({
+  "src/utils/headers.ts"() {
+    "use strict";
+  }
+});
+
 // src/services/auditLog.ts
 function classifyCountStatus(readable, expected, observed) {
   if (!readable) return { status: "unknown", unknownReason: "count-unreadable" };
@@ -57812,6 +57824,7 @@ __export(imapClient_exports, {
   imapFetchMessageId: () => imapFetchMessageId,
   imapFlagMessage: () => imapFlagMessage,
   imapGetMessage: () => imapGetMessage,
+  imapGetMessageHeaders: () => imapGetMessageHeaders,
   imapGetMessageSource: () => imapGetMessageSource,
   imapHealthCheck: () => imapHealthCheck,
   imapListAttachments: () => imapListAttachments,
@@ -58604,7 +58617,10 @@ async function imapGetMessage(id, preferHtml, deps = {}) {
   return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
     const msg = await client.fetchOne(
       String(ref.uid),
-      { envelope: true, source: true },
+      // INTERNALDATE rides along so the read can report the server's arrival
+      // time beside the author's `Date:` header (#224). The envelope's `date`
+      // IS the `Date:` header — imapflow builds ENVELOPE from the header block.
+      { envelope: true, internalDate: true, source: true },
       { uid: true }
     );
     if (!msg)
@@ -58612,9 +58628,39 @@ async function imapGetMessage(id, preferHtml, deps = {}) {
     const subject = msg.envelope?.subject || "(no subject)";
     const src = msg.source ? msg.source.toString() : "";
     const body = (preferHtml ? extractHtmlBody(src) : extractTextBody(src)) ?? extractTextBody(src) ?? extractHtmlBody(src) ?? "(no readable body)";
-    return { success: true, info: `Subject: ${subject}
+    return {
+      success: true,
+      info: `Subject: ${subject}
 
-${body}` };
+${body}`,
+      meta: {
+        dateSent: isoOrUndefined(msg.envelope?.date),
+        dateReceived: isoOrUndefined(msg.internalDate),
+        // The envelope carries the Message-ID; `info` deliberately does not (it
+        // is subject + body), so the caller could never recover it from there.
+        rfcMessageId: msg.envelope?.messageId ? normalizeMessageId(msg.envelope.messageId) : ""
+      }
+    };
+  });
+}
+async function imapGetMessageHeaders(id, deps = {}) {
+  const ref = decodeImapId(id);
+  if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    const msg = await client.fetchOne(
+      String(ref.uid),
+      { envelope: true, internalDate: true, headers: true },
+      { uid: true }
+    );
+    if (!msg)
+      return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
+    const raw = msg.headers ? msg.headers.toString() : "";
+    if (!raw.trim()) return { success: false, error: "IMAP returned no header block." };
+    return {
+      success: true,
+      info: raw,
+      meta: { dateReceived: isoOrUndefined(msg.internalDate) }
+    };
   });
 }
 function normalizeMessageId(mid) {
@@ -59054,6 +59100,7 @@ var init_imapClient = __esm({
     init_smtpMailer();
     init_docsUrls();
     init_mimeParse();
+    init_headers();
     init_auditLog();
     init_attachmentLimits();
     IMAP_ENV = {

--- a/build/index.js
+++ b/build/index.js
@@ -65092,6 +65092,122 @@ var require_imap_flow = __commonJS({
   }
 });
 
+// src/utils/headers.ts
+function decodeEncodedWords(value) {
+  if (!value.includes("=?")) return value;
+  const joined = value.replace(/(\?=)\s+(=\?)/g, "$1$2");
+  return joined.replace(
+    /=\?([^?]+)\?([BbQq])\?([^?]*)\?=/g,
+    (whole, charset, enc, text) => {
+      try {
+        const bytes = enc.toUpperCase() === "B" ? Buffer.from(text, "base64") : Buffer.from(
+          text.replace(/_/g, " ").replace(
+            /=([0-9A-Fa-f]{2})/g,
+            (_m, h) => String.fromCharCode(parseInt(h, 16))
+          ),
+          "latin1"
+        );
+        return new TextDecoder(normalizeCharset(charset)).decode(bytes);
+      } catch {
+        return whole;
+      }
+    }
+  );
+}
+function normalizeCharset(charset) {
+  const bare = charset.split("*")[0].trim().toLowerCase();
+  try {
+    new TextDecoder(bare);
+    return bare;
+  } catch {
+    return "utf-8";
+  }
+}
+function bareId(raw) {
+  return raw.trim().replace(/^<+/, "").replace(/>+$/, "").trim();
+}
+function splitIds(raw) {
+  const bracketed = raw.match(/<[^>]+>/g);
+  if (bracketed) return bracketed.map(bareId).filter(Boolean);
+  return raw.split(/[\s,]+/).map(bareId).filter(Boolean);
+}
+function parseHeaderBlock(input) {
+  const text = (input ?? "").replace(/\r\n/g, "\n");
+  const blank = text.search(/\n\n/);
+  const raw = (blank === -1 ? text : text.slice(0, blank)).replace(/\n+$/, "");
+  const headers = [];
+  for (const line of raw.split("\n")) {
+    if (/^[ \t]/.test(line) && headers.length) {
+      headers[headers.length - 1].value += " " + line.trim();
+      continue;
+    }
+    const m = /^([!-9;-~]+):[ \t]?(.*)$/.exec(line);
+    if (!m) continue;
+    headers.push({ name: m[1], value: m[2].trim() });
+  }
+  const first = (name) => headers.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value;
+  const all = (name) => headers.filter((h) => h.name.toLowerCase() === name.toLowerCase()).map((h) => h.value);
+  const decoded = (name) => {
+    const v = first(name);
+    return v === void 0 ? void 0 : decodeEncodedWords(v);
+  };
+  const dateHeader = first("Date");
+  let date3;
+  if (dateHeader) {
+    const parsed = new Date(dateHeader.replace(/\s*\([^)]*\)\s*$/, ""));
+    if (!Number.isNaN(parsed.getTime())) date3 = parsed.toISOString();
+  }
+  const messageIdRaw = first("Message-ID") ?? first("Message-Id");
+  const inReplyToRaw = first("In-Reply-To");
+  const referencesRaw = first("References");
+  return {
+    raw,
+    headers,
+    date: date3,
+    dateHeader,
+    messageId: messageIdRaw ? bareId(messageIdRaw) || void 0 : void 0,
+    subject: decoded("Subject"),
+    from: decoded("From"),
+    to: decoded("To"),
+    cc: decoded("Cc"),
+    replyTo: decoded("Reply-To"),
+    inReplyTo: inReplyToRaw ? bareId(inReplyToRaw) || void 0 : void 0,
+    references: referencesRaw ? splitIds(referencesRaw) : [],
+    received: all("Received")
+  };
+}
+function headersStructured(id, parsed, dateReceived) {
+  const received = dateReceived instanceof Date ? Number.isNaN(dateReceived.getTime()) ? void 0 : dateReceived.toISOString() : dateReceived || void 0;
+  return {
+    id,
+    raw: parsed.raw,
+    headers: parsed.headers,
+    headerCount: parsed.headers.length,
+    ...parsed.date !== void 0 ? { date: parsed.date } : {},
+    ...parsed.dateHeader !== void 0 ? { dateHeader: parsed.dateHeader } : {},
+    ...received !== void 0 ? { dateReceived: received } : {},
+    ...parsed.messageId !== void 0 ? { messageId: parsed.messageId } : {},
+    ...parsed.subject !== void 0 ? { subject: parsed.subject } : {},
+    ...parsed.from !== void 0 ? { from: parsed.from } : {},
+    ...parsed.to !== void 0 ? { to: parsed.to } : {},
+    ...parsed.cc !== void 0 ? { cc: parsed.cc } : {},
+    ...parsed.replyTo !== void 0 ? { replyTo: parsed.replyTo } : {},
+    ...parsed.inReplyTo !== void 0 ? { inReplyTo: parsed.inReplyTo } : {},
+    references: parsed.references,
+    received: parsed.received
+  };
+}
+function isoOrUndefined(d) {
+  if (d === void 0 || d === "") return void 0;
+  const date3 = d instanceof Date ? d : new Date(d);
+  return Number.isNaN(date3.getTime()) ? void 0 : date3.toISOString();
+}
+var init_headers = __esm({
+  "src/utils/headers.ts"() {
+    "use strict";
+  }
+});
+
 // src/services/imapClient.ts
 var imapClient_exports = {};
 __export(imapClient_exports, {
@@ -65118,6 +65234,7 @@ __export(imapClient_exports, {
   imapFetchMessageId: () => imapFetchMessageId,
   imapFlagMessage: () => imapFlagMessage,
   imapGetMessage: () => imapGetMessage,
+  imapGetMessageHeaders: () => imapGetMessageHeaders,
   imapGetMessageSource: () => imapGetMessageSource,
   imapHealthCheck: () => imapHealthCheck,
   imapListAttachments: () => imapListAttachments,
@@ -65910,7 +66027,10 @@ async function imapGetMessage(id, preferHtml, deps = {}) {
   return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
     const msg = await client.fetchOne(
       String(ref.uid),
-      { envelope: true, source: true },
+      // INTERNALDATE rides along so the read can report the server's arrival
+      // time beside the author's `Date:` header (#224). The envelope's `date`
+      // IS the `Date:` header — imapflow builds ENVELOPE from the header block.
+      { envelope: true, internalDate: true, source: true },
       { uid: true }
     );
     if (!msg)
@@ -65918,9 +66038,39 @@ async function imapGetMessage(id, preferHtml, deps = {}) {
     const subject = msg.envelope?.subject || "(no subject)";
     const src = msg.source ? msg.source.toString() : "";
     const body = (preferHtml ? extractHtmlBody(src) : extractTextBody(src)) ?? extractTextBody(src) ?? extractHtmlBody(src) ?? "(no readable body)";
-    return { success: true, info: `Subject: ${subject}
+    return {
+      success: true,
+      info: `Subject: ${subject}
 
-${body}` };
+${body}`,
+      meta: {
+        dateSent: isoOrUndefined(msg.envelope?.date),
+        dateReceived: isoOrUndefined(msg.internalDate),
+        // The envelope carries the Message-ID; `info` deliberately does not (it
+        // is subject + body), so the caller could never recover it from there.
+        rfcMessageId: msg.envelope?.messageId ? normalizeMessageId(msg.envelope.messageId) : ""
+      }
+    };
+  });
+}
+async function imapGetMessageHeaders(id, deps = {}) {
+  const ref = decodeImapId(id);
+  if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    const msg = await client.fetchOne(
+      String(ref.uid),
+      { envelope: true, internalDate: true, headers: true },
+      { uid: true }
+    );
+    if (!msg)
+      return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
+    const raw = msg.headers ? msg.headers.toString() : "";
+    if (!raw.trim()) return { success: false, error: "IMAP returned no header block." };
+    return {
+      success: true,
+      info: raw,
+      meta: { dateReceived: isoOrUndefined(msg.internalDate) }
+    };
   });
 }
 function normalizeMessageId(mid) {
@@ -66360,6 +66510,7 @@ var init_imapClient = __esm({
     init_smtpMailer();
     init_docsUrls();
     init_mimeParse();
+    init_headers();
     init_auditLog();
     init_attachmentLimits();
     IMAP_ENV = {
@@ -81688,6 +81839,7 @@ var DIAG_FIELD_SEP = "F";
 var DIAG_ITEM_SEP = "M";
 var CONTENT_MARKER = "CONTENT";
 var MSGID_MARKER = "MSGID";
+var DATES_MARKER = "DATES";
 var HTML_MARKER = "HTML";
 var LOOKUP_ERROR_MARKER = "ERR";
 var BATCH_FATAL = "FATAL";
@@ -81819,6 +81971,26 @@ function buildAttachmentCommands(attachments) {
   return commands;
 }
 var AS_DATE_TO_STRING = `((year of d) as string) & "-" & ((month of d as integer) as string) & "-" & ((day of d) as string) & "-" & ((hours of d) as string) & "-" & ((minutes of d) as string) & "-" & ((seconds of d) as string)`;
+var AS_MESSAGE_DATES_FRAGMENT = `set msgDateSent to ""
+                try
+                  set d to date sent of msg
+                  set msgDateSent to ${AS_DATE_TO_STRING}
+                end try
+                set msgDateRecv to ""
+                try
+                  set d to date received of msg
+                  set msgDateRecv to ${AS_DATE_TO_STRING}
+                end try
+                set msgDates to msgDateSent & "|" & msgDateRecv`;
+function parseMessageDates(pair) {
+  const [sent = "", received = ""] = pair.split("|");
+  const parse3 = (v) => {
+    if (!v.trim()) return void 0;
+    const d = parseAppleScriptDate(v.trim());
+    return Number.isNaN(d.getTime()) ? void 0 : d;
+  };
+  return { dateSent: parse3(sent), dateReceived: parse3(received) };
+}
 function buildMessageRowLoop(opts) {
   const { collection, limit, dedup, dateFilter, trailing = "", offset, withAttachments } = opts;
   const dedupOpen = dedup ? `if seenIds does not contain msgId then
@@ -83306,6 +83478,55 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     };
   }
   /**
+   * The unscoped by-id resolution: walk every mailbox of every account, then the
+   * local store (#183), and run `innerAction` with `msg` bound when EXACTLY one
+   * mailbox holds the id — `{LOOKUP_ERROR_MARKER}` prefixes both the not-found
+   * and the ambiguous outcome. Shared by getMessageContent, getRawSource and
+   * getMessageHeaders so the three reads cannot drift apart (the pre-#224 code
+   * carried two byte-identical copies).
+   */
+  unscopedByIdScript(id, innerAction) {
+    return buildAppLevelScript(`
+      try
+        set _hits to {}
+        set _names to ""
+        repeat with acct in accounts
+          repeat with mb in mailboxes of acct
+            try
+              set matchingMsgs to (messages of mb whose id is ${Number(id)})
+              if (count of matchingMsgs) > 0 then
+                set end of _hits to item 1 of matchingMsgs
+                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
+              end if
+            end try
+          end repeat
+        end repeat
+        -- #183: local mailboxes belong to no account, so the walk above cannot
+        -- reach them. Collect into the SAME _hits/_names, which means an id
+        -- present both in an account and locally is now correctly reported as
+        -- ambiguous rather than silently resolving to the account copy.${localMailboxBindingFragment()}
+        repeat with mb in _mbs
+          try
+            set matchingMsgs to (messages of mb whose id is ${Number(id)})
+            if (count of matchingMsgs) > 0 then
+              set end of _hits to item 1 of matchingMsgs
+              set _names to _names & "${LOCAL_STORE_LABEL}/" & (name of mb) & ", "
+            end if
+          end try
+        end repeat
+        if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
+        if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
+        if (count of _hits) is 1 then
+          set msg to item 1 of _hits
+          ${innerAction}
+        end if
+        return ""
+      on error errMsg
+        return ""
+      end try
+    `);
+  }
+  /**
    * Build an app-level AppleScript that opens exactly one account+mailbox, finds
    * the message with numeric `id` in it, and runs `innerAction` (which may assume
    * `msg` is bound). Used by the by-id fast paths (getMessageContent/getRawSource)
@@ -83384,7 +83605,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
                 end try
                 set msgContent to content of msg
                 ${sourceFetch}
-                return msgSubject & "${MSGID_MARKER}" & msgRfcId & "${CONTENT_MARKER}" & msgContent & "${HTML_MARKER}" & htmlSource`;
+                ${AS_MESSAGE_DATES_FRAGMENT}
+                return msgSubject & "${MSGID_MARKER}" & msgRfcId & "${DATES_MARKER}" & msgDates & "${CONTENT_MARKER}" & msgContent & "${HTML_MARKER}" & htmlSource`;
     const loc = hint?.account && hint?.mailbox ? { account: hint.account, mailbox: hint.mailbox } : this.idLocationIndex.get(id.toString());
     if (loc) {
       const scopedScript = this.scopedByIdScript(loc.account, loc.mailbox, id, innerFetch);
@@ -83395,45 +83617,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       );
       if (scoped) return scoped;
     }
-    const script = buildAppLevelScript(`
-      try
-        set _hits to {}
-        set _names to ""
-        repeat with acct in accounts
-          repeat with mb in mailboxes of acct
-            try
-              set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set end of _hits to item 1 of matchingMsgs
-                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
-              end if
-            end try
-          end repeat
-        end repeat
-        -- #183: local mailboxes belong to no account, so the walk above cannot
-        -- reach them. Collect into the SAME _hits/_names, which means an id
-        -- present both in an account and locally is now correctly reported as
-        -- ambiguous rather than silently resolving to the account copy.${localMailboxBindingFragment()}
-        repeat with mb in _mbs
-          try
-            set matchingMsgs to (messages of mb whose id is ${Number(id)})
-            if (count of matchingMsgs) > 0 then
-              set end of _hits to item 1 of matchingMsgs
-              set _names to _names & "${LOCAL_STORE_LABEL}/" & (name of mb) & ", "
-            end if
-          end try
-        end repeat
-        if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
-        if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
-        if (count of _hits) is 1 then
-          set msg to item 1 of _hits
-          ${innerFetch}
-        end if
-        return ""
-      on error errMsg
-        return ""
-      end try
-    `);
+    const script = this.unscopedByIdScript(id, innerFetch);
     return this.parseMessageContent(
       id,
       executeAppleScript(script, { timeoutMs: 6e4 }),
@@ -83461,15 +83645,62 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     if (parts.length < 2) return null;
     const subjParts = parts[0].split(MSGID_MARKER);
     const subject = subjParts[0];
-    const rfcMessageId = normalizeRfcMessageId(subjParts.length > 1 ? subjParts[1] : "");
+    const idAndDates = (subjParts.length > 1 ? subjParts[1] : "").split(DATES_MARKER);
+    const rfcMessageId = normalizeRfcMessageId(idAndDates[0]);
+    const { dateSent, dateReceived } = parseMessageDates(idAndDates[1] ?? "");
     const htmlContent = includeHtml && rawSource ? extractHtmlBody(rawSource) || void 0 : void 0;
     return {
       id: id.toString(),
       subject,
       plainText: parts[1],
       htmlContent,
-      rfcMessageId
+      rfcMessageId,
+      ...dateSent ? { dateSent } : {},
+      ...dateReceived ? { dateReceived } : {}
     };
+  }
+  /**
+   * Fetch ONLY the raw RFC 5322 header block of a message (#224) — Mail's
+   * `all headers` property — plus its `date received`, so the caller can show the
+   * arrival timestamp beside the author's `Date:` header. Same scoped-fast-path /
+   * full-scan resolution as getMessageContent; never reads the body or source.
+   * Returns null (with `lastMessageLookupError` set when Mail said why) on a miss.
+   */
+  getMessageHeaders(id, hint) {
+    this.lastMessageLookupError = void 0;
+    const innerFetch = `
+                set msgHeaders to ""
+                try
+                  set msgHeaders to all headers of msg
+                end try
+                ${AS_MESSAGE_DATES_FRAGMENT}
+                return msgDates & "${DATES_MARKER}" & msgHeaders`;
+    const parse3 = (result) => {
+      if (!result.success || !result.output.trim()) {
+        if (!result.success) console.error(`Failed to get message headers: ${result.error}`);
+        return null;
+      }
+      if (result.output.startsWith(LOOKUP_ERROR_MARKER)) {
+        this.lastMessageLookupError = result.output.slice(LOOKUP_ERROR_MARKER.length).trim();
+        return null;
+      }
+      const idx = result.output.indexOf(DATES_MARKER);
+      if (idx === -1) return null;
+      const { dateReceived } = parseMessageDates(result.output.slice(0, idx));
+      const raw = result.output.slice(idx + DATES_MARKER.length);
+      if (!raw.trim()) return null;
+      return { raw, ...dateReceived ? { dateReceived } : {} };
+    };
+    const loc = hint?.account && hint?.mailbox ? { account: hint.account, mailbox: hint.mailbox } : this.idLocationIndex.get(id.toString());
+    if (loc) {
+      const scoped = parse3(
+        executeAppleScript(this.scopedByIdScript(loc.account, loc.mailbox, id, innerFetch), {
+          timeoutMs: 6e4
+        })
+      );
+      if (scoped) return scoped;
+    }
+    return parse3(executeAppleScript(this.unscopedByIdScript(id, innerFetch), { timeoutMs: 6e4 }));
   }
   /**
    * Get the raw MIME source of a message.
@@ -83498,45 +83729,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
         this.lastMessageLookupError = scoped.output.slice(LOOKUP_ERROR_MARKER.length).trim();
       }
     }
-    const script = buildAppLevelScript(`
-      try
-        set _hits to {}
-        set _names to ""
-        repeat with acct in accounts
-          repeat with mb in mailboxes of acct
-            try
-              set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set end of _hits to item 1 of matchingMsgs
-                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
-              end if
-            end try
-          end repeat
-        end repeat
-        -- #183: local mailboxes belong to no account, so the walk above cannot
-        -- reach them. Collect into the SAME _hits/_names, which means an id
-        -- present both in an account and locally is now correctly reported as
-        -- ambiguous rather than silently resolving to the account copy.${localMailboxBindingFragment()}
-        repeat with mb in _mbs
-          try
-            set matchingMsgs to (messages of mb whose id is ${Number(id)})
-            if (count of matchingMsgs) > 0 then
-              set end of _hits to item 1 of matchingMsgs
-              set _names to _names & "${LOCAL_STORE_LABEL}/" & (name of mb) & ", "
-            end if
-          end try
-        end repeat
-        if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
-        if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
-        if (count of _hits) is 1 then
-          set msg to item 1 of _hits
-          return source of msg
-        end if
-        return ""
-      on error errMsg
-        return ""
-      end try
-    `);
+    const script = this.unscopedByIdScript(id, "return source of msg");
     const result = executeAppleScript(script, { timeoutMs: 12e4 });
     if (!result.success || !result.output.trim()) {
       return null;
@@ -87082,6 +87275,7 @@ function subjectFromGetMessage(info) {
 
 // src/index.ts
 init_mimeParse();
+init_headers();
 
 // src/services/imapIdle.ts
 var import_imapflow2 = __toESM(require_imap_flow(), 1);
@@ -87635,9 +87829,9 @@ registerTool(
   "get-message",
   {
     description: `Use when: reading the full body of one message whose id you already have (numeric or imap:\u2026); set preferHtml to get the HTML body instead of plain text.
-Returns: the message subject, body (plain text by default, HTML when preferHtml is true), and its stable RFC Message-ID (rfcMessageId) for dedup/threading.
+Returns: the message subject, body (plain text by default, HTML when preferHtml is true), its stable RFC Message-ID (rfcMessageId) for dedup/threading, and two dates: dateSent (the author's Date: header \u2014 survives a migration/re-import) and dateReceived (arrival in the mailbox; this is the one a migration resets).
 Tip: pass the mailbox+account you got the id from (e.g. from search-messages) to fetch it directly \u2014 required for reliable reads of large folders like "Sent Items", which otherwise time out.
-Do not use when: you don't yet have an id (use search-messages or list-messages first), or you want the whole conversation (use get-thread).`,
+Do not use when: you don't yet have an id (use search-messages or list-messages first), you want the whole conversation (use get-thread), or you need the raw headers / Received: trace (use get-message-headers).`,
     inputSchema: {
       id: MESSAGE_ID_SCHEMA,
       preferHtml: external_exports.boolean().optional().describe("Return the HTML body (extracted from the message source) instead of plain text"),
@@ -87655,6 +87849,12 @@ Do not use when: you don't yet have an id (use search-messages or list-messages 
       isHtml: external_exports.boolean().optional(),
       rfcMessageId: external_exports.string().optional().describe(
         "Stable RFC 5322 Message-ID (angle brackets stripped); empty when the message has none"
+      ),
+      dateSent: external_exports.string().optional().describe(
+        "ISO 8601 send time from the message's Date: header (Mail's `date sent`). Absent when the message carries no parseable Date: header."
+      ),
+      dateReceived: external_exports.string().optional().describe(
+        "ISO 8601 arrival time in the mailbox (IMAP INTERNALDATE / Mail's `date received`). A migration or re-import resets this; compare with dateSent."
       )
     }
   },
@@ -87672,7 +87872,13 @@ Do not use when: you don't yet have an id (use search-messages or list-messages 
           subject: subjectFromGetMessage(r.info),
           body: sep3 >= 0 ? r.info.slice(sep3 + 2) : r.info,
           isHtml: preferHtml === true,
-          rfcMessageId: extractRfcMessageIdFromSource(r.info)
+          // Prefer the envelope's Message-ID (#224 fix): `info` is subject +
+          // body with no header block, so parsing it yielded "" for every
+          // IMAP-sourced message from 2.2.0 through 2.18.1.
+          rfcMessageId: r.meta?.rfcMessageId || extractRfcMessageIdFromSource(r.info),
+          // #224: envelope Date: header and INTERNALDATE, already ISO strings.
+          ...r.meta?.dateSent ? { dateSent: r.meta.dateSent } : {},
+          ...r.meta?.dateReceived ? { dateReceived: r.meta.dateReceived } : {}
         };
       },
       apple: () => {
@@ -87686,6 +87892,8 @@ Do not use when: you don't yet have an id (use search-messages or list-messages 
         }
         const isHtml = preferHtml === true && !!content.htmlContent;
         const body = isHtml ? content.htmlContent : content.plainText;
+        const dateSent = isoOrUndefined(content.dateSent);
+        const dateReceived = isoOrUndefined(content.dateReceived);
         return successResponse(`Subject: ${content.subject}
 
 ${body}`, {
@@ -87693,13 +87901,72 @@ ${body}`, {
           subject: content.subject,
           body,
           isHtml,
-          rfcMessageId: content.rfcMessageId ?? ""
+          rfcMessageId: content.rfcMessageId ?? "",
+          ...dateSent ? { dateSent } : {},
+          ...dateReceived ? { dateReceived } : {}
         });
       },
       ok: "",
       fail: `Message with ID "${id}" not found`
     }),
     "Error retrieving message"
+  )
+);
+var HEADER_FIELD_SCHEMA = external_exports.object({
+  name: external_exports.string().describe("Header name as written (case preserved)"),
+  value: external_exports.string().describe("Unfolded value; RFC 2047 encoded-words left as-is")
+});
+registerTool(
+  "get-message-headers",
+  {
+    description: "Use when: you need a message's raw RFC 5322 headers \u2014 the author's Date: header (not the mailbox arrival time), Message-ID, In-Reply-To/References, the Received: hop trace, or any custom X- header \u2014 for a message whose id you already have (numeric or imap:\u2026). Cheap: never downloads the body or attachments.\nReturns: the raw header block (text), every header as ordered {name, value} pairs with folding undone, and the decoded key fields: date (ISO 8601, from the Date: header), dateHeader (verbatim), dateReceived (mailbox arrival time \u2014 the value a migration or re-import resets, so compare it with date), messageId, subject, from, to, cc, replyTo, inReplyTo, references[], received[].\nTip: pass the mailbox+account you got the id from so a numeric id is fetched directly instead of scanning every mailbox.\nDo not use when: you want the body (use get-message), the conversation (use get-thread), or only the Message-ID (get-message already returns rfcMessageId).",
+    inputSchema: {
+      id: MESSAGE_ID_SCHEMA,
+      mailbox: external_exports.string().optional().describe(
+        "Mailbox that holds the message (numeric ids are unique per mailbox). With `account`, opens that mailbox directly instead of scanning every mailbox."
+      ),
+      account: external_exports.string().optional().describe("Account that holds the message. Pair with `mailbox` for a direct fetch.")
+    },
+    outputSchema: {
+      id: external_exports.string().optional(),
+      raw: external_exports.string().optional().describe("The raw header block, exactly as stored"),
+      headers: external_exports.array(HEADER_FIELD_SCHEMA).optional(),
+      headerCount: external_exports.number().optional(),
+      date: external_exports.string().optional().describe("ISO 8601 from the Date: header \u2014 the author's send time"),
+      dateHeader: external_exports.string().optional().describe("The Date: header verbatim"),
+      dateReceived: external_exports.string().optional().describe("ISO 8601 mailbox arrival time (INTERNALDATE / Mail's `date received`)"),
+      messageId: external_exports.string().optional().describe("Bare RFC 5322 Message-ID"),
+      subject: external_exports.string().optional().describe("RFC 2047-decoded Subject:"),
+      from: external_exports.string().optional(),
+      to: external_exports.string().optional(),
+      cc: external_exports.string().optional(),
+      replyTo: external_exports.string().optional(),
+      inReplyTo: external_exports.string().optional(),
+      references: external_exports.array(external_exports.string()).optional(),
+      received: external_exports.array(external_exports.string()).optional().describe("Every Received: header, as written (first = last hop)")
+    },
+    annotations: { readOnlyHint: true }
+  },
+  withErrorHandling(
+    ({ id, mailbox, account }) => routeMessage(id, {
+      // imap: id → BODY.PEEK[HEADER] + INTERNALDATE, no body download.
+      imap: () => imapGetMessageHeaders(id, { account }),
+      structuredFromResult: (r) => r.info ? headersStructured(id, parseHeaderBlock(r.info), r.meta?.dateReceived) : void 0,
+      apple: () => {
+        const h = mailManager.getMessageHeaders(id, { account, mailbox });
+        if (!h) {
+          const lookupError = mailManager.consumeLastMessageLookupError();
+          return errorResponse(lookupError ?? `Message with ID "${id}" not found`);
+        }
+        return successResponse(
+          h.raw,
+          headersStructured(id, parseHeaderBlock(h.raw), h.dateReceived)
+        );
+      },
+      ok: "",
+      fail: `Message with ID "${id}" not found`
+    }),
+    "Error retrieving message headers"
   )
 );
 registerTool(

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.18.1"
+        "apple-mail-mcp@2.19.0"
       ]
     }
   }

--- a/codex/skills/apple-mail/SKILL.md
+++ b/codex/skills/apple-mail/SKILL.md
@@ -30,6 +30,7 @@ Use this skill when the user:
 | `list-messages` | List messages in a mailbox (all mailboxes if omitted) |
 | `search-messages` | Find messages by sender, subject, or content |
 | `get-message` | Read the full content of a message |
+| `get-message-headers` | Read a message's raw RFC 5322 headers (author's `Date:`, Message-ID, threading ids, `Received:` trace) without the body |
 | `get-thread` | Get the full conversation thread for a message |
 | `send-email` | Send a new email immediately |
 | `send-serial-email` | Send personalized copies to many recipients (mail merge with `{{Key}}` placeholders) |

--- a/docs/IMAP-SETUP.md
+++ b/docs/IMAP-SETUP.md
@@ -28,7 +28,7 @@ When an account is IMAP-configured, these route to IMAP (otherwise AppleScript):
 | Capability | Tools |
 |------------|-------|
 | Server-side search / list | `search-messages`, `list-messages` |
-| Read a message | `get-message` |
+| Read a message | `get-message`, `get-message-headers` |
 | Message mutations | `mark-as-read`/`unread`, `flag`/`unflag-message`, `move-message`, `delete-message` |
 | Batch mutations | `batch-mark-as-read`/`unread`, `batch-flag`/`unflag-messages`, `batch-move-messages`, `batch-delete-messages` |
 | Folder ops | `create-mailbox`, `rename-mailbox`, `delete-mailbox` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/skills/apple-mail/SKILL.md
+++ b/skills/apple-mail/SKILL.md
@@ -30,6 +30,7 @@ Use this skill when the user:
 | `list-messages` | List messages in a mailbox (all mailboxes if omitted) |
 | `search-messages` | Find messages by sender, subject, or content |
 | `get-message` | Read the full content of a message |
+| `get-message-headers` | Read a message's raw RFC 5322 headers (author's `Date:`, Message-ID, threading ids, `Received:` trace) without the body |
 | `get-thread` | Get the full conversation thread for a message |
 | `send-email` | Send a new email immediately |
 | `send-serial-email` | Send personalized copies to many recipients (mail merge with `{{Key}}` placeholders) |

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ import {
   imapDeleteMailbox,
   imapRenameMailbox,
   imapGetMessage,
+  imapGetMessageHeaders,
   imapGetMessageSource,
   imapMarkRead,
   imapMarkUnread,
@@ -109,6 +110,7 @@ import {
 } from "@/schemas.js";
 import { normalizeSubject, subjectFromGetMessage } from "@/tools/thread.js";
 import { extractRfcMessageIdFromSource } from "@/utils/mimeParse.js";
+import { headersStructured, isoOrUndefined, parseHeaderBlock } from "@/utils/headers.js";
 import { ImapIdleWatcher } from "@/services/imapIdle.js";
 import { loadFileConfig } from "@/services/fileConfig.js";
 import { isOrphaned } from "@/utils/orphan.js";
@@ -638,7 +640,7 @@ registerTool(
   "get-message",
   {
     description:
-      'Use when: reading the full body of one message whose id you already have (numeric or imap:…); set preferHtml to get the HTML body instead of plain text.\nReturns: the message subject, body (plain text by default, HTML when preferHtml is true), and its stable RFC Message-ID (rfcMessageId) for dedup/threading.\nTip: pass the mailbox+account you got the id from (e.g. from search-messages) to fetch it directly — required for reliable reads of large folders like "Sent Items", which otherwise time out.\nDo not use when: you don\'t yet have an id (use search-messages or list-messages first), or you want the whole conversation (use get-thread).',
+      "Use when: reading the full body of one message whose id you already have (numeric or imap:…); set preferHtml to get the HTML body instead of plain text.\nReturns: the message subject, body (plain text by default, HTML when preferHtml is true), its stable RFC Message-ID (rfcMessageId) for dedup/threading, and two dates: dateSent (the author's Date: header — survives a migration/re-import) and dateReceived (arrival in the mailbox; this is the one a migration resets).\nTip: pass the mailbox+account you got the id from (e.g. from search-messages) to fetch it directly — required for reliable reads of large folders like \"Sent Items\", which otherwise time out.\nDo not use when: you don't yet have an id (use search-messages or list-messages first), you want the whole conversation (use get-thread), or you need the raw headers / Received: trace (use get-message-headers).",
     inputSchema: {
       id: MESSAGE_ID_SCHEMA,
       preferHtml: z
@@ -669,6 +671,18 @@ registerTool(
         .describe(
           "Stable RFC 5322 Message-ID (angle brackets stripped); empty when the message has none"
         ),
+      dateSent: z
+        .string()
+        .optional()
+        .describe(
+          "ISO 8601 send time from the message's Date: header (Mail's `date sent`). Absent when the message carries no parseable Date: header."
+        ),
+      dateReceived: z
+        .string()
+        .optional()
+        .describe(
+          "ISO 8601 arrival time in the mailbox (IMAP INTERNALDATE / Mail's `date received`). A migration or re-import resets this; compare with dateSent."
+        ),
     },
   },
   withErrorHandling(
@@ -686,7 +700,14 @@ registerTool(
             subject: subjectFromGetMessage(r.info),
             body: sep >= 0 ? r.info.slice(sep + 2) : r.info,
             isHtml: preferHtml === true,
-            rfcMessageId: extractRfcMessageIdFromSource(r.info),
+            // Prefer the envelope's Message-ID (#224 fix): `info` is subject +
+            // body with no header block, so parsing it yielded "" for every
+            // IMAP-sourced message from 2.2.0 through 2.18.1.
+            rfcMessageId:
+              (r.meta?.rfcMessageId as string | undefined) || extractRfcMessageIdFromSource(r.info),
+            // #224: envelope Date: header and INTERNALDATE, already ISO strings.
+            ...(r.meta?.dateSent ? { dateSent: r.meta.dateSent } : {}),
+            ...(r.meta?.dateReceived ? { dateReceived: r.meta.dateReceived } : {}),
           };
         },
         apple: () => {
@@ -704,18 +725,104 @@ registerTool(
           }
           const isHtml = preferHtml === true && !!content.htmlContent;
           const body = isHtml ? content.htmlContent! : content.plainText;
+          const dateSent = isoOrUndefined(content.dateSent);
+          const dateReceived = isoOrUndefined(content.dateReceived);
           return successResponse(`Subject: ${content.subject}\n\n${body}`, {
             id,
             subject: content.subject,
             body,
             isHtml,
             rfcMessageId: content.rfcMessageId ?? "",
+            ...(dateSent ? { dateSent } : {}),
+            ...(dateReceived ? { dateReceived } : {}),
           });
         },
         ok: "",
         fail: `Message with ID "${id}" not found`,
       }),
     "Error retrieving message"
+  )
+);
+
+// --- get-message-headers ---
+
+/** One zod shape for the header fields both backends return (#224). */
+const HEADER_FIELD_SCHEMA = z.object({
+  name: z.string().describe("Header name as written (case preserved)"),
+  value: z.string().describe("Unfolded value; RFC 2047 encoded-words left as-is"),
+});
+
+registerTool(
+  "get-message-headers",
+  {
+    description:
+      "Use when: you need a message's raw RFC 5322 headers — the author's Date: header (not the mailbox arrival time), Message-ID, In-Reply-To/References, the Received: hop trace, or any custom X- header — for a message whose id you already have (numeric or imap:…). Cheap: never downloads the body or attachments.\nReturns: the raw header block (text), every header as ordered {name, value} pairs with folding undone, and the decoded key fields: date (ISO 8601, from the Date: header), dateHeader (verbatim), dateReceived (mailbox arrival time — the value a migration or re-import resets, so compare it with date), messageId, subject, from, to, cc, replyTo, inReplyTo, references[], received[].\nTip: pass the mailbox+account you got the id from so a numeric id is fetched directly instead of scanning every mailbox.\nDo not use when: you want the body (use get-message), the conversation (use get-thread), or only the Message-ID (get-message already returns rfcMessageId).",
+    inputSchema: {
+      id: MESSAGE_ID_SCHEMA,
+      mailbox: z
+        .string()
+        .optional()
+        .describe(
+          "Mailbox that holds the message (numeric ids are unique per mailbox). With `account`, opens that mailbox directly instead of scanning every mailbox."
+        ),
+      account: z
+        .string()
+        .optional()
+        .describe("Account that holds the message. Pair with `mailbox` for a direct fetch."),
+    },
+    outputSchema: {
+      id: z.string().optional(),
+      raw: z.string().optional().describe("The raw header block, exactly as stored"),
+      headers: z.array(HEADER_FIELD_SCHEMA).optional(),
+      headerCount: z.number().optional(),
+      date: z
+        .string()
+        .optional()
+        .describe("ISO 8601 from the Date: header — the author's send time"),
+      dateHeader: z.string().optional().describe("The Date: header verbatim"),
+      dateReceived: z
+        .string()
+        .optional()
+        .describe("ISO 8601 mailbox arrival time (INTERNALDATE / Mail's `date received`)"),
+      messageId: z.string().optional().describe("Bare RFC 5322 Message-ID"),
+      subject: z.string().optional().describe("RFC 2047-decoded Subject:"),
+      from: z.string().optional(),
+      to: z.string().optional(),
+      cc: z.string().optional(),
+      replyTo: z.string().optional(),
+      inReplyTo: z.string().optional(),
+      references: z.array(z.string()).optional(),
+      received: z
+        .array(z.string())
+        .optional()
+        .describe("Every Received: header, as written (first = last hop)"),
+    },
+    annotations: { readOnlyHint: true },
+  },
+  withErrorHandling(
+    ({ id, mailbox, account }) =>
+      routeMessage(id, {
+        // imap: id → BODY.PEEK[HEADER] + INTERNALDATE, no body download.
+        imap: () => imapGetMessageHeaders(id, { account }),
+        structuredFromResult: (r) =>
+          r.info
+            ? headersStructured(id, parseHeaderBlock(r.info), r.meta?.dateReceived as string)
+            : undefined,
+        apple: () => {
+          const h = mailManager.getMessageHeaders(id, { account, mailbox });
+          if (!h) {
+            const lookupError = mailManager.consumeLastMessageLookupError();
+            return errorResponse(lookupError ?? `Message with ID "${id}" not found`);
+          }
+          return successResponse(
+            h.raw,
+            headersStructured(id, parseHeaderBlock(h.raw), h.dateReceived)
+          );
+        },
+        ok: "",
+        fail: `Message with ID "${id}" not found`,
+      }),
+    "Error retrieving message headers"
   )
 );
 

--- a/src/services/appleMailManager.ts
+++ b/src/services/appleMailManager.ts
@@ -138,6 +138,7 @@ const DIAG_FIELD_SEP = "\x1dF\x1d"; // between diagnostics fields
 const DIAG_ITEM_SEP = "\x1dM\x1d"; // between diagnostics list items
 const CONTENT_MARKER = "\x1dCONTENT\x1d"; // subject/plain-text boundary
 const MSGID_MARKER = "\x1dMSGID\x1d"; // subject/RFC-Message-ID boundary (get-message content)
+const DATES_MARKER = "\x1dDATES\x1d"; // RFC-Message-ID/dates boundary (get-message content, #224)
 const HTML_MARKER = "\x1dHTML\x1d"; // plain-text/source boundary
 const LOOKUP_ERROR_MARKER = "\x1dERR\x1d"; // GS-wrapped — by-id lookup failure; must not be a bare text prefix because the success payload of the same script leads with the sender-controlled subject
 const BATCH_FATAL = "\x1dFATAL\x1d"; // prefix for a whole-batch failure (e.g. bad destination)
@@ -492,6 +493,37 @@ function buildAttachmentCommands(attachments?: string[]): string {
  * Use: set d to date received of msg, then inline this snippet.
  */
 const AS_DATE_TO_STRING = `((year of d) as string) & "-" & ((month of d as integer) as string) & "-" & ((day of d) as string) & "-" & ((hours of d) as string) & "-" & ((minutes of d) as string) & "-" & ((seconds of d) as string)`;
+
+/**
+ * AppleScript fragment that reads a bound `msg`'s `date sent` (the `Date:`
+ * header) and `date received` (arrival in the mailbox) into `msgDates` as
+ * `"<sent>|<received>"`, each in the locale-independent numeric form above or
+ * empty when Mail cannot supply it. Each read is individually guarded — a
+ * message with no `Date:` header has no `date sent`, and that must not cost the
+ * caller the body (#224).
+ */
+const AS_MESSAGE_DATES_FRAGMENT = `set msgDateSent to ""
+                try
+                  set d to date sent of msg
+                  set msgDateSent to ${AS_DATE_TO_STRING}
+                end try
+                set msgDateRecv to ""
+                try
+                  set d to date received of msg
+                  set msgDateRecv to ${AS_DATE_TO_STRING}
+                end try
+                set msgDates to msgDateSent & "|" & msgDateRecv`;
+
+/** Parse the `"<sent>|<received>"` pair AS_MESSAGE_DATES_FRAGMENT emits. */
+function parseMessageDates(pair: string): { dateSent?: Date; dateReceived?: Date } {
+  const [sent = "", received = ""] = pair.split("|");
+  const parse = (v: string): Date | undefined => {
+    if (!v.trim()) return undefined;
+    const d = parseAppleScriptDate(v.trim());
+    return Number.isNaN(d.getTime()) ? undefined : d;
+  };
+  return { dateSent: parse(sent), dateReceived: parse(received) };
+}
 
 /**
  * Build the AppleScript loop that turns a message collection into delimited
@@ -2632,6 +2664,56 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
   }
 
   /**
+   * The unscoped by-id resolution: walk every mailbox of every account, then the
+   * local store (#183), and run `innerAction` with `msg` bound when EXACTLY one
+   * mailbox holds the id — `{LOOKUP_ERROR_MARKER}` prefixes both the not-found
+   * and the ambiguous outcome. Shared by getMessageContent, getRawSource and
+   * getMessageHeaders so the three reads cannot drift apart (the pre-#224 code
+   * carried two byte-identical copies).
+   */
+  private unscopedByIdScript(id: string, innerAction: string): string {
+    return buildAppLevelScript(`
+      try
+        set _hits to {}
+        set _names to ""
+        repeat with acct in accounts
+          repeat with mb in mailboxes of acct
+            try
+              set matchingMsgs to (messages of mb whose id is ${Number(id)})
+              if (count of matchingMsgs) > 0 then
+                set end of _hits to item 1 of matchingMsgs
+                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
+              end if
+            end try
+          end repeat
+        end repeat
+        -- #183: local mailboxes belong to no account, so the walk above cannot
+        -- reach them. Collect into the SAME _hits/_names, which means an id
+        -- present both in an account and locally is now correctly reported as
+        -- ambiguous rather than silently resolving to the account copy.${localMailboxBindingFragment()}
+        repeat with mb in _mbs
+          try
+            set matchingMsgs to (messages of mb whose id is ${Number(id)})
+            if (count of matchingMsgs) > 0 then
+              set end of _hits to item 1 of matchingMsgs
+              set _names to _names & "${LOCAL_STORE_LABEL}/" & (name of mb) & ", "
+            end if
+          end try
+        end repeat
+        if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
+        if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
+        if (count of _hits) is 1 then
+          set msg to item 1 of _hits
+          ${innerAction}
+        end if
+        return ""
+      on error errMsg
+        return ""
+      end try
+    `);
+  }
+
+  /**
    * Build an app-level AppleScript that opens exactly one account+mailbox, finds
    * the message with numeric `id` in it, and runs `innerAction` (which may assume
    * `msg` is bound). Used by the by-id fast paths (getMessageContent/getRawSource)
@@ -2731,7 +2813,8 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
                 end try
                 set msgContent to content of msg
                 ${sourceFetch}
-                return msgSubject & "${MSGID_MARKER}" & msgRfcId & "${CONTENT_MARKER}" & msgContent & "${HTML_MARKER}" & htmlSource`;
+                ${AS_MESSAGE_DATES_FRAGMENT}
+                return msgSubject & "${MSGID_MARKER}" & msgRfcId & "${DATES_MARKER}" & msgDates & "${CONTENT_MARKER}" & msgContent & "${HTML_MARKER}" & htmlSource`;
 
     // Fast path: when we know which account+mailbox holds this id (explicit hint
     // from the caller, or remembered from a prior search/list/by-id lookup), open
@@ -2756,45 +2839,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       // through to the full scan below rather than returning a false "not found".
     }
 
-    const script = buildAppLevelScript(`
-      try
-        set _hits to {}
-        set _names to ""
-        repeat with acct in accounts
-          repeat with mb in mailboxes of acct
-            try
-              set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set end of _hits to item 1 of matchingMsgs
-                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
-              end if
-            end try
-          end repeat
-        end repeat
-        -- #183: local mailboxes belong to no account, so the walk above cannot
-        -- reach them. Collect into the SAME _hits/_names, which means an id
-        -- present both in an account and locally is now correctly reported as
-        -- ambiguous rather than silently resolving to the account copy.${localMailboxBindingFragment()}
-        repeat with mb in _mbs
-          try
-            set matchingMsgs to (messages of mb whose id is ${Number(id)})
-            if (count of matchingMsgs) > 0 then
-              set end of _hits to item 1 of matchingMsgs
-              set _names to _names & "${LOCAL_STORE_LABEL}/" & (name of mb) & ", "
-            end if
-          end try
-        end repeat
-        if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
-        if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
-        if (count of _hits) is 1 then
-          set msg to item 1 of _hits
-          ${innerFetch}
-        end if
-        return ""
-      on error errMsg
-        return ""
-      end try
-    `);
+    const script = this.unscopedByIdScript(id, innerFetch);
 
     return this.parseMessageContent(
       id,
@@ -2834,7 +2879,11 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
     // (added for stable, session-independent dedup) back out of the subject.
     const subjParts = parts[0].split(MSGID_MARKER);
     const subject = subjParts[0];
-    const rfcMessageId = normalizeRfcMessageId(subjParts.length > 1 ? subjParts[1] : "");
+    // The Message-ID half may carry a trailing `{DATES_MARKER}sent|received` pair
+    // (#224); a script that predates the marker simply yields no dates.
+    const idAndDates = (subjParts.length > 1 ? subjParts[1] : "").split(DATES_MARKER);
+    const rfcMessageId = normalizeRfcMessageId(idAndDates[0]);
+    const { dateSent, dateReceived } = parseMessageDates(idAndDates[1] ?? "");
 
     // Extract the actual text/html body from the raw MIME source rather than
     // returning the whole source. Falls back to undefined when the message has
@@ -2848,7 +2897,62 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       plainText: parts[1],
       htmlContent,
       rfcMessageId,
+      ...(dateSent ? { dateSent } : {}),
+      ...(dateReceived ? { dateReceived } : {}),
     };
+  }
+
+  /**
+   * Fetch ONLY the raw RFC 5322 header block of a message (#224) — Mail's
+   * `all headers` property — plus its `date received`, so the caller can show the
+   * arrival timestamp beside the author's `Date:` header. Same scoped-fast-path /
+   * full-scan resolution as getMessageContent; never reads the body or source.
+   * Returns null (with `lastMessageLookupError` set when Mail said why) on a miss.
+   */
+  getMessageHeaders(
+    id: string,
+    hint?: { account?: string; mailbox?: string }
+  ): { raw: string; dateReceived?: Date } | null {
+    this.lastMessageLookupError = undefined;
+    const innerFetch = `
+                set msgHeaders to ""
+                try
+                  set msgHeaders to all headers of msg
+                end try
+                ${AS_MESSAGE_DATES_FRAGMENT}
+                return msgDates & "${DATES_MARKER}" & msgHeaders`;
+
+    const parse = (result: AppleScriptResult): { raw: string; dateReceived?: Date } | null => {
+      if (!result.success || !result.output.trim()) {
+        if (!result.success) console.error(`Failed to get message headers: ${result.error}`);
+        return null;
+      }
+      if (result.output.startsWith(LOOKUP_ERROR_MARKER)) {
+        this.lastMessageLookupError = result.output.slice(LOOKUP_ERROR_MARKER.length).trim();
+        return null;
+      }
+      const idx = result.output.indexOf(DATES_MARKER);
+      if (idx === -1) return null;
+      const { dateReceived } = parseMessageDates(result.output.slice(0, idx));
+      const raw = result.output.slice(idx + DATES_MARKER.length);
+      if (!raw.trim()) return null;
+      return { raw, ...(dateReceived ? { dateReceived } : {}) };
+    };
+
+    const loc =
+      hint?.account && hint?.mailbox
+        ? { account: hint.account, mailbox: hint.mailbox }
+        : this.idLocationIndex.get(id.toString());
+    if (loc) {
+      const scoped = parse(
+        executeAppleScript(this.scopedByIdScript(loc.account, loc.mailbox, id, innerFetch), {
+          timeoutMs: 60000,
+        })
+      );
+      if (scoped) return scoped;
+      // Scoped miss (stale index) → full scan, as getMessageContent does.
+    }
+    return parse(executeAppleScript(this.unscopedByIdScript(id, innerFetch), { timeoutMs: 60000 }));
   }
 
   /**
@@ -2891,45 +2995,7 @@ ${indent}end try${this.sanitizeFragment("_uacct", indent)}${this.sanitizeFragmen
       // Miss (stale index) → fall through to the full scan.
     }
 
-    const script = buildAppLevelScript(`
-      try
-        set _hits to {}
-        set _names to ""
-        repeat with acct in accounts
-          repeat with mb in mailboxes of acct
-            try
-              set matchingMsgs to (messages of mb whose id is ${Number(id)})
-              if (count of matchingMsgs) > 0 then
-                set end of _hits to item 1 of matchingMsgs
-                set _names to _names & (name of acct) & "/" & (name of mb) & ", "
-              end if
-            end try
-          end repeat
-        end repeat
-        -- #183: local mailboxes belong to no account, so the walk above cannot
-        -- reach them. Collect into the SAME _hits/_names, which means an id
-        -- present both in an account and locally is now correctly reported as
-        -- ambiguous rather than silently resolving to the account copy.${localMailboxBindingFragment()}
-        repeat with mb in _mbs
-          try
-            set matchingMsgs to (messages of mb whose id is ${Number(id)})
-            if (count of matchingMsgs) > 0 then
-              set end of _hits to item 1 of matchingMsgs
-              set _names to _names & "${LOCAL_STORE_LABEL}/" & (name of mb) & ", "
-            end if
-          end try
-        end repeat
-        if (count of _hits) is 0 then return "${LOOKUP_ERROR_MARKER}Message not found"
-        if (count of _hits) > 1 then return "${LOOKUP_ERROR_MARKER}${AMBIGUOUS_ID_PREFIX}${Number(id)} is present in more than one mailbox (" & _names & "); list or search that mailbox first so the read targets the right copy"
-        if (count of _hits) is 1 then
-          set msg to item 1 of _hits
-          return source of msg
-        end if
-        return ""
-      on error errMsg
-        return ""
-      end try
-    `);
+    const script = this.unscopedByIdScript(id, "return source of msg");
 
     const result = executeAppleScript(script, { timeoutMs: 120000 });
 

--- a/src/services/imapClient.test.ts
+++ b/src/services/imapClient.test.ts
@@ -16,6 +16,7 @@ import {
   imapFetchMessageId,
   normalizeMessageId,
   imapGetMessage,
+  imapGetMessageHeaders,
   imapGetMessageSource,
   MAX_COMPOSE_SOURCE_BYTES,
   imapMarkRead,
@@ -2161,6 +2162,111 @@ describe("#181 IMAP batch operations reconcile the source mailbox count", () => 
       connect: async () => countingClient(0),
     });
     expect(unflag.countDelta).toBeUndefined();
+  });
+});
+
+describe("get-message dates and get-message-headers (#224)", () => {
+  const RAW_HEADERS =
+    "Received: from a.example (a.example [10.0.0.1])\r\n\tby b.example; Mon, 1 Jun 2020 10:00:02 +0000\r\n" +
+    "Date: Mon, 1 Jun 2020 09:59:58 +0000\r\n" +
+    "From: Sender <s@example.org>\r\n" +
+    "Subject: Hello\r\n" +
+    "Message-ID: <hello@example.org>\r\n";
+  const internalDate = new Date("2026-03-04T05:06:07Z");
+  const envelopeDate = new Date("2020-06-01T09:59:58Z");
+
+  function headerClient(overrides: Partial<{ headers: Buffer | string; found: boolean }> = {}) {
+    const rec: MsgRec = {};
+    const fetchOne = vi.fn(async () =>
+      overrides.found === false
+        ? false
+        : {
+            uid: 1,
+            envelope: { subject: "Hello", date: envelopeDate, messageId: "<hello@example.org>" },
+            internalDate,
+            headers: overrides.headers ?? Buffer.from(RAW_HEADERS),
+            source: Buffer.from("Content-Type: text/plain\r\n\r\nbody"),
+          }
+    );
+    const client = { ...makeMsgClient(rec), fetchOne };
+    return { fetchOne, deps: { config: cfg, connect: async () => client } };
+  }
+
+  it("get-message asks for INTERNALDATE and reports both dates in meta", async () => {
+    const c = headerClient();
+    const r = await imapGetMessage(MID, false, c.deps);
+    expect(r.success).toBe(true);
+    expect(c.fetchOne).toHaveBeenCalledWith(
+      "1",
+      { envelope: true, internalDate: true, source: true },
+      { uid: true }
+    );
+    expect(r.meta).toEqual({
+      dateSent: "2020-06-01T09:59:58.000Z",
+      dateReceived: "2026-03-04T05:06:07.000Z",
+      rfcMessageId: "hello@example.org",
+    });
+  });
+
+  it("get-message leaves a date undefined rather than inventing one", async () => {
+    const c = headerClient();
+    c.fetchOne.mockResolvedValueOnce({
+      uid: 1,
+      envelope: { subject: "Hello" },
+      source: Buffer.from("Content-Type: text/plain\r\n\r\nbody"),
+    });
+    const r = await imapGetMessage(MID, false, c.deps);
+    expect(r.success).toBe(true);
+    expect(r.meta).toEqual({ dateSent: undefined, dateReceived: undefined, rfcMessageId: "" });
+  });
+
+  it("headers: fetches only the header block plus INTERNALDATE, never the source", async () => {
+    const c = headerClient();
+    const r = await imapGetMessageHeaders(MID, c.deps);
+    expect(r.success).toBe(true);
+    expect(c.fetchOne).toHaveBeenCalledWith(
+      "1",
+      { envelope: true, internalDate: true, headers: true },
+      { uid: true }
+    );
+    expect(r.info).toBe(RAW_HEADERS);
+    expect(r.meta).toEqual({ dateReceived: "2026-03-04T05:06:07.000Z" });
+  });
+
+  it("headers: accepts a string header block", async () => {
+    const c = headerClient({ headers: "Subject: s\r\n" });
+    const r = await imapGetMessageHeaders(MID, c.deps);
+    expect(r.success).toBe(true);
+    expect(r.info).toBe("Subject: s\r\n");
+  });
+
+  it("headers: reports a missing message", async () => {
+    const c = headerClient({ found: false });
+    const r = await imapGetMessageHeaders(MID, c.deps);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/UID 1 not found/);
+  });
+
+  it("headers: refuses an empty header block instead of returning success with nothing", async () => {
+    const c = headerClient({ headers: "" });
+    const r = await imapGetMessageHeaders(MID, c.deps);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/no header block/);
+  });
+
+  it("headers: rejects a non-IMAP id without connecting", async () => {
+    const c = headerClient();
+    const r = await imapGetMessageHeaders("12345", c.deps);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/Not an IMAP message id/);
+    expect(c.fetchOne).not.toHaveBeenCalled();
+  });
+
+  it("headers: rejects an account override that disagrees with the id", async () => {
+    const c = headerClient();
+    await expect(imapGetMessageHeaders(MID, { ...c.deps, account: "Work" })).rejects.toThrow(
+      /belongs to account/
+    );
   });
 });
 

--- a/src/services/imapClient.ts
+++ b/src/services/imapClient.ts
@@ -30,6 +30,7 @@ import { ImapFlow } from "imapflow";
 import { readKeychainPassword } from "@/services/smtpMailer.js";
 import { SETUP_HINT } from "@/utils/docsUrls.js";
 import { extractHtmlBody, extractTextBody } from "@/utils/mimeParse.js";
+import { isoOrUndefined } from "@/utils/headers.js";
 import { classifyCountStatus, type CountDelta } from "@/services/auditLog.js";
 import { MAX_IMAP_ATTACHMENT_BYTES } from "@/utils/attachmentLimits.js";
 
@@ -108,6 +109,8 @@ interface ImapMessage {
   source?: Buffer | string;
   bodyStructure?: ImapBodyStructure;
   headers?: Buffer | string;
+  /** Server arrival time (IMAP INTERNALDATE) — NOT the author's `Date:` header. */
+  internalDate?: Date | string;
 }
 interface ImapDownload {
   meta?: { filename?: string; contentType?: string };
@@ -1036,6 +1039,12 @@ export interface ImapOpResult {
   info?: string;
   /** Absent on operations that perform no post-condition check at all. */
   verification?: ImapVerification;
+  /**
+   * Backend facts that do not fit `info`'s prose — e.g. the message dates a read
+   * returns alongside its body (#224). Merged into `structuredContent` by the
+   * caller; never parsed back out of `info`.
+   */
+  meta?: Record<string, unknown>;
 }
 
 function errText(e: unknown): string {
@@ -1585,7 +1594,10 @@ export async function imapGetMessage(
   return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
     const msg = await client.fetchOne(
       String(ref.uid),
-      { envelope: true, source: true },
+      // INTERNALDATE rides along so the read can report the server's arrival
+      // time beside the author's `Date:` header (#224). The envelope's `date`
+      // IS the `Date:` header — imapflow builds ENVELOPE from the header block.
+      { envelope: true, internalDate: true, source: true },
       { uid: true }
     );
     if (!msg)
@@ -1597,7 +1609,48 @@ export async function imapGetMessage(
       extractTextBody(src) ??
       extractHtmlBody(src) ??
       "(no readable body)";
-    return { success: true, info: `Subject: ${subject}\n\n${body}` };
+    return {
+      success: true,
+      info: `Subject: ${subject}\n\n${body}`,
+      meta: {
+        dateSent: isoOrUndefined(msg.envelope?.date),
+        dateReceived: isoOrUndefined(msg.internalDate),
+        // The envelope carries the Message-ID; `info` deliberately does not (it
+        // is subject + body), so the caller could never recover it from there.
+        rfcMessageId: msg.envelope?.messageId ? normalizeMessageId(msg.envelope.messageId) : "",
+      },
+    };
+  });
+}
+
+/**
+ * Fetch ONLY the RFC 5322 header block of a message by composite IMAP id (#224):
+ * `BODY.PEEK[HEADER]` via imapflow's `headers: true`, plus INTERNALDATE so the
+ * caller can show the server's arrival time next to the author's `Date:`. Never
+ * downloads the body, so it is cheap even for a message with large attachments.
+ * Returns the raw block in `info` and `dateReceived` in `meta`.
+ */
+export async function imapGetMessageHeaders(
+  id: string,
+  deps: ImapDeps = {}
+): Promise<ImapOpResult> {
+  const ref = decodeImapId(id);
+  if (!ref) return { success: false, error: `Not an IMAP message id: "${id}".` };
+  return withMailbox(ref.path, depsForMessageRef(ref, deps), async (client) => {
+    const msg = await client.fetchOne(
+      String(ref.uid),
+      { envelope: true, internalDate: true, headers: true },
+      { uid: true }
+    );
+    if (!msg)
+      return { success: false, error: `IMAP message UID ${ref.uid} not found in "${ref.path}".` };
+    const raw = msg.headers ? msg.headers.toString() : "";
+    if (!raw.trim()) return { success: false, error: "IMAP returned no header block." };
+    return {
+      success: true,
+      info: raw,
+      meta: { dateReceived: isoOrUndefined(msg.internalDate) },
+    };
   });
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,16 @@ export interface MessageContent {
    * session-independent join key (e.g. sent-mail dedup logs).
    */
   rfcMessageId?: string;
+
+  /**
+   * Author's send time — Mail's `date sent`, i.e. the `Date:` header. Survives a
+   * migration/re-import that resets the arrival timestamp (#224). Undefined when
+   * Mail could not supply it.
+   */
+  dateSent?: Date;
+
+  /** Arrival time in the mailbox — Mail's `date received` (≈ IMAP INTERNALDATE). */
+  dateReceived?: Date;
 }
 
 /**

--- a/src/utils/headers.test.ts
+++ b/src/utils/headers.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import {
+  decodeEncodedWords,
+  headersStructured,
+  isoOrUndefined,
+  parseHeaderBlock,
+} from "./headers.js";
+
+const BLOCK = [
+  "Received: from mx2.example.net (mx2.example.net [10.0.0.2])",
+  "\tby imap.example.com with ESMTPS id abc123;",
+  "\tWed, 03 Jun 2020 14:05:00 +0000",
+  "Received: from sender.example.org ([10.0.0.9])",
+  " by mx2.example.net; Wed, 03 Jun 2020 14:04:58 +0000",
+  "Date: Wed, 3 Jun 2020 16:04:55 +0200 (CEST)",
+  "From: =?UTF-8?Q?Jos=C3=A9_Puertolas?= <jose@example.org>",
+  "To: Rob <rob@example.com>",
+  "Cc: =?utf-8?B?Sm9zw6k=?= Dos <dos@example.org>",
+  "Reply-To: list@example.org",
+  "Subject: =?UTF-8?B?SGVsbG8g?=",
+  " =?UTF-8?B?d29ybGQ=?=",
+  "Message-ID: <orig-id@example.org>",
+  "In-Reply-To: <parent@example.org>",
+  "References: <root@example.org>",
+  "\t<parent@example.org>",
+  "MIME-Version: 1.0",
+  "",
+  "Body text that must not be parsed as a header",
+  "X-Not-A-Header: in the body",
+].join("\r\n");
+
+describe("parseHeaderBlock", () => {
+  const p = parseHeaderBlock(BLOCK);
+
+  it("stops at the first blank line so body text is never read as a header", () => {
+    expect(p.headers.some((h) => h.name === "X-Not-A-Header")).toBe(false);
+    expect(p.raw.endsWith("MIME-Version: 1.0")).toBe(true);
+  });
+
+  it("unfolds continuation lines and keeps every header in wire order", () => {
+    expect(p.headers[0]).toEqual({
+      name: "Received",
+      value:
+        "from mx2.example.net (mx2.example.net [10.0.0.2]) by imap.example.com with ESMTPS id abc123; Wed, 03 Jun 2020 14:05:00 +0000",
+    });
+    expect(p.headers.map((h) => h.name).slice(0, 4)).toEqual([
+      "Received",
+      "Received",
+      "Date",
+      "From",
+    ]);
+  });
+
+  it("keeps every Received hop, last hop first", () => {
+    expect(p.received).toHaveLength(2);
+    expect(p.received[0]).toMatch(/^from mx2\.example\.net/);
+    expect(p.received[1]).toMatch(/^from sender\.example\.org/);
+  });
+
+  it("sources `date` from the Date: header, tolerating a trailing zone comment", () => {
+    expect(p.dateHeader).toBe("Wed, 3 Jun 2020 16:04:55 +0200 (CEST)");
+    expect(p.date).toBe("2020-06-03T14:04:55.000Z");
+  });
+
+  it("decodes RFC 2047 words in the display fields and joins adjacent words", () => {
+    expect(p.from).toBe("José Puertolas <jose@example.org>");
+    expect(p.cc).toBe("José Dos <dos@example.org>");
+    expect(p.subject).toBe("Hello world");
+    expect(p.replyTo).toBe("list@example.org");
+    expect(p.to).toBe("Rob <rob@example.com>");
+  });
+
+  it("leaves the raw header values undecoded", () => {
+    expect(p.headers.find((h) => h.name === "Subject")?.value).toBe(
+      "=?UTF-8?B?SGVsbG8g?= =?UTF-8?B?d29ybGQ=?="
+    );
+  });
+
+  it("strips angle brackets from the threading ids", () => {
+    expect(p.messageId).toBe("orig-id@example.org");
+    expect(p.inReplyTo).toBe("parent@example.org");
+    expect(p.references).toEqual(["root@example.org", "parent@example.org"]);
+  });
+
+  it("accepts LF-only input and a block with no body", () => {
+    const q = parseHeaderBlock("Subject: plain\nDate: not a date\nMessage-Id: <x@y>\n");
+    expect(q.subject).toBe("plain");
+    expect(q.date).toBeUndefined();
+    expect(q.dateHeader).toBe("not a date");
+    expect(q.messageId).toBe("x@y");
+    expect(q.references).toEqual([]);
+    expect(q.received).toEqual([]);
+  });
+
+  it("is lenient with malformed lines instead of aborting", () => {
+    const q = parseHeaderBlock("garbage line\nSubject: ok\n");
+    expect(q.headers).toEqual([{ name: "Subject", value: "ok" }]);
+  });
+
+  it("returns an empty result for empty input", () => {
+    const q = parseHeaderBlock("");
+    expect(q.headers).toEqual([]);
+    expect(q.raw).toBe("");
+    expect(q.date).toBeUndefined();
+  });
+});
+
+describe("decodeEncodedWords", () => {
+  it("passes through text without encoded-words untouched", () => {
+    expect(decodeEncodedWords("plain <a@b>")).toBe("plain <a@b>");
+  });
+
+  it("decodes Q encoding underscores as spaces and hex escapes", () => {
+    expect(decodeEncodedWords("=?iso-8859-1?Q?caf=E9_au_lait?=")).toBe("café au lait");
+  });
+
+  it("falls back to UTF-8 for an unknown charset rather than throwing", () => {
+    expect(decodeEncodedWords("=?x-unknown-cs?B?aGk=?=")).toBe("hi");
+  });
+
+  it("leaves an undecodable word in place", () => {
+    // `?=` with no text and a bad charset label still round-trips as text.
+    expect(decodeEncodedWords("=?utf-8?X?zzz?=")).toBe("=?utf-8?X?zzz?=");
+  });
+});
+
+describe("headersStructured", () => {
+  it("carries the backend arrival timestamp beside the Date: header", () => {
+    const s = headersStructured(
+      "imap:abc",
+      parseHeaderBlock(BLOCK),
+      new Date("2026-01-02T03:04:05Z")
+    );
+    expect(s.id).toBe("imap:abc");
+    expect(s.date).toBe("2020-06-03T14:04:55.000Z");
+    expect(s.dateReceived).toBe("2026-01-02T03:04:05.000Z");
+    expect(s.headerCount).toBe(12);
+    expect(s.messageId).toBe("orig-id@example.org");
+  });
+
+  it("omits dateReceived when the backend had none or it was invalid", () => {
+    expect(headersStructured("1", parseHeaderBlock("Subject: x"))).not.toHaveProperty(
+      "dateReceived"
+    );
+    expect(
+      headersStructured("1", parseHeaderBlock("Subject: x"), new Date("garbage"))
+    ).not.toHaveProperty("dateReceived");
+  });
+});
+
+describe("isoOrUndefined", () => {
+  it("handles Date, string, empty and invalid inputs", () => {
+    expect(isoOrUndefined(new Date("2020-01-01T00:00:00Z"))).toBe("2020-01-01T00:00:00.000Z");
+    expect(isoOrUndefined("2020-01-01T00:00:00Z")).toBe("2020-01-01T00:00:00.000Z");
+    expect(isoOrUndefined("")).toBeUndefined();
+    expect(isoOrUndefined(undefined)).toBeUndefined();
+    expect(isoOrUndefined(new Date("nope"))).toBeUndefined();
+  });
+});

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -1,0 +1,229 @@
+/**
+ * RFC 5322 header-block parsing for `get-message-headers` (#224).
+ *
+ * Both backends hand us the raw header text — IMAP via `FETCH (BODY.PEEK[HEADER])`
+ * (imapflow's `headers: true`), AppleScript via Mail's `all headers` property.
+ * This module turns that text into something an assistant can act on without
+ * re-implementing header folding and RFC 2047 encoded-words itself:
+ *
+ *   • the raw block, untouched (the forensic record);
+ *   • every header as an ordered `{ name, value }` pair, unfolded, duplicates kept
+ *     (`Received:` legitimately repeats — it is the hop trace);
+ *   • the handful of fields chronological and threading work actually needs,
+ *     decoded and pulled out by name.
+ *
+ * Why this exists: Mail's `date received` (and IMAP's `INTERNALDATE`) is the time
+ * the message ARRIVED in the mailbox, which a migration or re-import resets to the
+ * migration moment. The `Date:` header is the author's send time and survives
+ * such moves. A mailbox where `INTERNALDATE` is wrong by years is not hypothetical
+ * — it is the reporter's (#224) — so `date` here is always sourced from the
+ * `Date:` header, never from the backend's arrival timestamp.
+ *
+ * @module utils/headers
+ */
+
+export interface HeaderField {
+  /** Header name as written (`Message-ID`, `received`, …) — case preserved. */
+  name: string;
+  /** Unfolded value with the leading space trimmed; RFC 2047 words NOT decoded. */
+  value: string;
+}
+
+export interface ParsedHeaders {
+  /** The raw header block exactly as received, body (if any) stripped. */
+  raw: string;
+  /** Every field in wire order, folded continuation lines joined. */
+  headers: HeaderField[];
+  /**
+   * `Date:` header parsed to ISO 8601, or undefined when absent/unparseable. This
+   * is the author's send time — the value that survives a migration or re-import
+   * when the backend's arrival timestamp does not.
+   */
+  date?: string;
+  /** `Date:` header verbatim (so an unparseable one is still visible). */
+  dateHeader?: string;
+  /** Bare RFC 5322 Message-ID, angle brackets stripped. */
+  messageId?: string;
+  /** RFC 2047-decoded `Subject:`. */
+  subject?: string;
+  /** RFC 2047-decoded `From:`. */
+  from?: string;
+  /** RFC 2047-decoded `To:`. */
+  to?: string;
+  /** RFC 2047-decoded `Cc:`. */
+  cc?: string;
+  /** RFC 2047-decoded `Reply-To:`. */
+  replyTo?: string;
+  /** Bare `In-Reply-To:` id (angle brackets stripped). */
+  inReplyTo?: string;
+  /** Bare `References:` ids, in order. */
+  references: string[];
+  /** Every `Received:` header, first-written (= last hop) first, unfolded. */
+  received: string[];
+}
+
+/**
+ * Decode RFC 2047 encoded-words (`=?charset?B|Q?text?=`) in a header value.
+ * Adjacent encoded-words separated only by whitespace are concatenated, as the
+ * RFC requires. Unknown charsets fall back to UTF-8 rather than throwing — a
+ * header we cannot decode should still be returned, not turned into an error.
+ */
+export function decodeEncodedWords(value: string): string {
+  if (!value.includes("=?")) return value;
+  // Whitespace between two encoded-words is not part of the text (RFC 2047 §6.2).
+  const joined = value.replace(/(\?=)\s+(=\?)/g, "$1$2");
+  return joined.replace(
+    /=\?([^?]+)\?([BbQq])\?([^?]*)\?=/g,
+    (whole, charset: string, enc: string, text: string) => {
+      try {
+        const bytes =
+          enc.toUpperCase() === "B"
+            ? Buffer.from(text, "base64")
+            : Buffer.from(
+                text
+                  .replace(/_/g, " ")
+                  .replace(/=([0-9A-Fa-f]{2})/g, (_m, h: string) =>
+                    String.fromCharCode(parseInt(h, 16))
+                  ),
+                "latin1"
+              );
+        return new TextDecoder(normalizeCharset(charset)).decode(bytes);
+      } catch {
+        return whole;
+      }
+    }
+  );
+}
+
+function normalizeCharset(charset: string): string {
+  // RFC 2231 language suffix: `utf-8*en` → `utf-8`.
+  const bare = charset.split("*")[0].trim().toLowerCase();
+  try {
+    // TextDecoder throws RangeError on labels it does not know.
+    new TextDecoder(bare);
+    return bare;
+  } catch {
+    return "utf-8";
+  }
+}
+
+/** Strip angle brackets and whitespace from one message id. */
+function bareId(raw: string): string {
+  return raw.trim().replace(/^<+/, "").replace(/>+$/, "").trim();
+}
+
+/** Split a `References:` value into bare ids, tolerating missing brackets. */
+function splitIds(raw: string): string[] {
+  const bracketed = raw.match(/<[^>]+>/g);
+  if (bracketed) return bracketed.map(bareId).filter(Boolean);
+  return raw
+    .split(/[\s,]+/)
+    .map(bareId)
+    .filter(Boolean);
+}
+
+/**
+ * Parse a raw RFC 5322 header block. Accepts CRLF or LF line endings and a block
+ * that still carries a body (everything after the first blank line is dropped).
+ * Lines that are neither a `Name: value` field nor a folded continuation are
+ * skipped rather than aborting the parse — Mail's `all headers` can carry a
+ * trailing blank line and real-world mail is not always well-formed.
+ */
+export function parseHeaderBlock(input: string): ParsedHeaders {
+  const text = (input ?? "").replace(/\r\n/g, "\n");
+  const blank = text.search(/\n\n/);
+  const raw = (blank === -1 ? text : text.slice(0, blank)).replace(/\n+$/, "");
+
+  const headers: HeaderField[] = [];
+  for (const line of raw.split("\n")) {
+    if (/^[ \t]/.test(line) && headers.length) {
+      // Folded continuation: RFC 5322 §2.2.3 — unfold to a single space.
+      headers[headers.length - 1].value += " " + line.trim();
+      continue;
+    }
+    const m = /^([!-9;-~]+):[ \t]?(.*)$/.exec(line);
+    if (!m) continue;
+    headers.push({ name: m[1], value: m[2].trim() });
+  }
+
+  const first = (name: string): string | undefined =>
+    headers.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value;
+  const all = (name: string): string[] =>
+    headers.filter((h) => h.name.toLowerCase() === name.toLowerCase()).map((h) => h.value);
+  const decoded = (name: string): string | undefined => {
+    const v = first(name);
+    return v === undefined ? undefined : decodeEncodedWords(v);
+  };
+
+  const dateHeader = first("Date");
+  let date: string | undefined;
+  if (dateHeader) {
+    // RFC 5322 allows a trailing `(comment)` zone name, which Date.parse rejects.
+    const parsed = new Date(dateHeader.replace(/\s*\([^)]*\)\s*$/, ""));
+    if (!Number.isNaN(parsed.getTime())) date = parsed.toISOString();
+  }
+
+  const messageIdRaw = first("Message-ID") ?? first("Message-Id");
+  const inReplyToRaw = first("In-Reply-To");
+  const referencesRaw = first("References");
+
+  return {
+    raw,
+    headers,
+    date,
+    dateHeader,
+    messageId: messageIdRaw ? bareId(messageIdRaw) || undefined : undefined,
+    subject: decoded("Subject"),
+    from: decoded("From"),
+    to: decoded("To"),
+    cc: decoded("Cc"),
+    replyTo: decoded("Reply-To"),
+    inReplyTo: inReplyToRaw ? bareId(inReplyToRaw) || undefined : undefined,
+    references: referencesRaw ? splitIds(referencesRaw) : [],
+    received: all("Received"),
+  };
+}
+
+/**
+ * The `structuredContent` payload for `get-message-headers`: the parsed block
+ * plus the backend's own arrival timestamp, when it supplied one, so a caller
+ * can see the two dates side by side — which is the whole diagnostic for a
+ * migrated mailbox (#224).
+ */
+export function headersStructured(
+  id: string,
+  parsed: ParsedHeaders,
+  dateReceived?: Date | string
+): Record<string, unknown> {
+  const received =
+    dateReceived instanceof Date
+      ? Number.isNaN(dateReceived.getTime())
+        ? undefined
+        : dateReceived.toISOString()
+      : dateReceived || undefined;
+  return {
+    id,
+    raw: parsed.raw,
+    headers: parsed.headers,
+    headerCount: parsed.headers.length,
+    ...(parsed.date !== undefined ? { date: parsed.date } : {}),
+    ...(parsed.dateHeader !== undefined ? { dateHeader: parsed.dateHeader } : {}),
+    ...(received !== undefined ? { dateReceived: received } : {}),
+    ...(parsed.messageId !== undefined ? { messageId: parsed.messageId } : {}),
+    ...(parsed.subject !== undefined ? { subject: parsed.subject } : {}),
+    ...(parsed.from !== undefined ? { from: parsed.from } : {}),
+    ...(parsed.to !== undefined ? { to: parsed.to } : {}),
+    ...(parsed.cc !== undefined ? { cc: parsed.cc } : {}),
+    ...(parsed.replyTo !== undefined ? { replyTo: parsed.replyTo } : {}),
+    ...(parsed.inReplyTo !== undefined ? { inReplyTo: parsed.inReplyTo } : {}),
+    references: parsed.references,
+    received: parsed.received,
+  };
+}
+
+/** ISO 8601 for a Date that may be absent or invalid; undefined otherwise. */
+export function isoOrUndefined(d: Date | string | undefined): string | undefined {
+  if (d === undefined || d === "") return undefined;
+  const date = d instanceof Date ? d : new Date(d);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}


### PR DESCRIPTION
## What

Requested in #224 by @j5pu, whose iCloud mailbox had a migration overwrite `INTERNALDATE` for whole blocks of messages, leaving `search-messages`' `dateReceived` useless for chronology and `get-message` exposing no date at all.

- **New tool `get-message-headers`** — the raw RFC 5322 header block (never the body or attachments) plus parsed fields: `date` (ISO 8601, from the `Date:` header), `dateHeader` verbatim, `dateReceived` (arrival time), `messageId`, `subject`/`from`/`to`/`cc`/`replyTo` with RFC 2047 words decoded, `inReplyTo`, `references[]`, `received[]`, and every header as ordered `{name, value}` pairs with folding undone. IMAP: `BODY.PEEK[HEADER]` + INTERNALDATE. AppleScript: Mail's `all headers` + `date received`, with the same mailbox-scoped fast path as `get-message`.
- **`get-message` gains `dateSent` and `dateReceived`** in `structuredContent` on both backends. Either is omitted, never invented, when the backend cannot supply it.
- **Fix:** `get-message` over IMAP returned `rfcMessageId: ""` for every message since 2.2.0 — the branch parsed the Message-ID out of its own subject+body text. Now taken from the ENVELOPE. Found by the live probe below.
- Refactor: the three AppleScript by-id reads (`getMessageContent`, `getRawSource`, new `getMessageHeaders`) share one unscoped-scan script builder; the first two carried byte-identical copies.

## Docs / release

CHANGELOG under `## [2.19.0]`, `pnpm version minor`, bundle rebuilt (`build/index.js` + `build/cli.js`), README (feature row, Tool Reference entry, two-dates note on `get-message`), CLAUDE.md, `docs/IMAP-SETUP.md`, `skills/` + `sync:skills`. New tool registers a `Use when / Returns / Do not use when` description and `readOnlyHint`.

## Verification

- `lint` / `typecheck` / `format:check` / `test` green — 803 tests, 53 files, including `docsTruth` (boots the bundle, confirms the README Tool Reference matches the advertised 51 tools) and new unit coverage for the header parser and the IMAP header fetch.
- **Live IMAP**, worktree bundle, MCP stdio: Gmail INBOX and iCloud Archive. `get-message-headers` returned 31- and 37-header blocks with `date` ≠ `dateReceived` by the transit time (11 s / 21 s), the `Received:` hop trace, and threading ids; `get-message` returned matching `dateSent`/`dateReceived` and a populated `rfcMessageId`; a bad id returns "Message not found".
- **Not verified live:** the AppleScript branch (this session is over ssh, where an Automation prompt would stick as a silent TCC deny). `date sent`, `date received` and `all headers` are standard Mail.app `message` properties; the parse path is unit-tested.

Fixes #224.

https://claude.ai/code/session_01NLeBNwSSg7qGuHcdta1JzY