### PR TITLE
fix: parseHeaderBlock silently drops all headers on bare-CR AppleScript text

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.19.0",
+      "version": "2.19.1",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-mail",
-      "version": "2.19.0",
+      "version": "2.19.1",
       "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-mcp",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "Apple Mail integration for Claude Code and Codex via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -12,7 +12,7 @@
       "name": "apple-mail",
       "displayName": "Apple Mail",
       "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
-      "version": "2.19.0",
+      "version": "2.19.1",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "Manage Apple Mail through natural language - read, search, send, and organize emails (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## [Unreleased]
 
+## [2.19.1] - 2026-09-13
+
+### Fixed
+- `get-message-headers`' header-block parser (`parseHeaderBlock`) had no
+  handling for bare-CR (`\r`-only) line endings, a real quirk of Mail's
+  `all headers of msg` AppleScript property that this codebase already
+  normalizes on the write side (`escapeForAppleScriptBody`) but never on
+  read-back (#226, reported by @j5pu — follow-up to #224/#225). Left
+  unhandled, a bare-CR header block silently returned **zero** headers: JS's
+  `.split("\n")` never splits it, and the per-line header regex's `.` does not
+  match `\r` either, so every field was dropped rather than merged.
+  `parseHeaderBlock` now normalizes CRLF, CR, and LF alike before splitting.
+  Also added regression coverage pinning down that an unparseable, OS-locale
+  `Date:` header (e.g. old Entourage/Outlook-for-Mac's Spanish
+  `jue ago 30 13:55:12 2007`, from the `OUTLOOK2MACxxxxxxxx`-boundary era)
+  never drops or merges an adjacent header, across LF, CRLF, and CR input —
+  the mechanism the reporter suspected, now verified never to trigger.
+
 ## [2.19.0] - 2026-09-12
 
 ### Added

--- a/build/index.js
+++ b/build/index.js
@@ -65132,7 +65132,7 @@ function splitIds(raw) {
   return raw.split(/[\s,]+/).map(bareId).filter(Boolean);
 }
 function parseHeaderBlock(input) {
-  const text = (input ?? "").replace(/\r\n/g, "\n");
+  const text = (input ?? "").replace(/\r\n|\r/g, "\n");
   const blank = text.search(/\n\n/);
   const raw = (blank === -1 ? text : text.slice(0, blank)).replace(/\n+$/, "");
   const headers = [];

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "Manage Apple Mail through natural language - read, search, send, reply, forward, and organize emails and mailboxes, with diagnostics, attachments, templates, and mail-merge support (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.mcp.json
+++ b/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "apple-mail-mcp@2.19.0"
+        "apple-mail-mcp@2.19.1"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-mcp",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Mail - read, search, send, and manage emails via Claude and other AI assistants",
   "type": "module",

--- a/src/utils/headers.test.ts
+++ b/src/utils/headers.test.ts
@@ -97,6 +97,63 @@ describe("parseHeaderBlock", () => {
     expect(q.headers).toEqual([{ name: "Subject", value: "ok" }]);
   });
 
+  // #226 — old Entourage/Outlook-for-Mac (~2005-2011, MIME boundary
+  // OUTLOOK2MACxxxxxxxx) wrote Date: using the OS locale instead of RFC 5322
+  // (e.g. Spanish "jue ago 30 13:55:12 2007" — "jue" = Thursday, "ago" =
+  // August). The reporter's literal minimal repro turns out to already parse
+  // correctly today (this pins that down as a regression guard); the real,
+  // previously-unguarded gap was bare-CR line endings, below.
+  const outlook2macRepro = [
+    "From: Test Sender <test@example.com>",
+    "To: 'Test Recipient'",
+    "Date: jue ago 30 13:55:12 2007",
+    "Subject: diferencial",
+    "MIME-Version: 1.0",
+    'Content-Type: multipart/mixed; boundary="OUTLOOK2MAC8473928"',
+  ];
+
+  it.each([
+    ["LF", "\n"],
+    ["CRLF", "\r\n"],
+  ])(
+    "never drops or merges a header just because Date: is an unparseable locale string (%s)",
+    (_label, sep) => {
+      const q = parseHeaderBlock(outlook2macRepro.join(sep));
+      expect(q.dateHeader).toBe("jue ago 30 13:55:12 2007");
+      expect(q.date).toBeUndefined();
+      expect(q.subject).toBe("diferencial");
+      expect(q.headers.map((h) => h.name)).toEqual([
+        "From",
+        "To",
+        "Date",
+        "Subject",
+        "MIME-Version",
+        "Content-Type",
+      ]);
+    }
+  );
+
+  it("parses bare-CR line endings the same as LF/CRLF (#226 — AppleScript's `all headers of msg` can return \\r-only text; previously this silently dropped every header)", () => {
+    const q = parseHeaderBlock(outlook2macRepro.join("\r"));
+    expect(q.dateHeader).toBe("jue ago 30 13:55:12 2007");
+    expect(q.subject).toBe("diferencial");
+    expect(q.headers).toHaveLength(6);
+  });
+
+  it("stops at the first blank line under bare-CR endings too (CRCR, not just LFLF)", () => {
+    const q = parseHeaderBlock(
+      [...outlook2macRepro, "", "Body text that must not be parsed as a header"].join("\r")
+    );
+    expect(q.headers.map((h) => h.name)).toEqual([
+      "From",
+      "To",
+      "Date",
+      "Subject",
+      "MIME-Version",
+      "Content-Type",
+    ]);
+  });
+
   it("returns an empty result for empty input", () => {
     const q = parseHeaderBlock("");
     expect(q.headers).toEqual([]);

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -123,14 +123,25 @@ function splitIds(raw: string): string[] {
 }
 
 /**
- * Parse a raw RFC 5322 header block. Accepts CRLF or LF line endings and a block
- * that still carries a body (everything after the first blank line is dropped).
- * Lines that are neither a `Name: value` field nor a folded continuation are
- * skipped rather than aborting the parse — Mail's `all headers` can carry a
- * trailing blank line and real-world mail is not always well-formed.
+ * Parse a raw RFC 5322 header block. Accepts CRLF, LF, or bare-CR line endings
+ * and a block that still carries a body (everything after the first blank line
+ * is dropped). Lines that are neither a `Name: value` field nor a folded
+ * continuation are skipped rather than aborting the parse — Mail's `all
+ * headers` can carry a trailing blank line and real-world mail is not always
+ * well-formed.
+ *
+ * Bare CR (`\r` with no following `\n`) is a real, previously-unhandled case
+ * (#226): Mail's `all headers of msg` AppleScript property is a multi-line
+ * text value, and this codebase already normalizes `\r\n|\r|\n` uniformly on
+ * the *write* side for exactly this quirk (see `escapeForAppleScriptBody`) —
+ * nothing did the equivalent on read-back. Left unhandled, a bare-CR block
+ * silently produced ZERO headers: `.split("\n")` never splits it (there is no
+ * `\n` to split on), so the whole block is treated as one "line", and JS's
+ * regex `.` does not match `\r` either, so the per-line header regex fails to
+ * match at all and every field is dropped — not merged, just gone.
  */
 export function parseHeaderBlock(input: string): ParsedHeaders {
-  const text = (input ?? "").replace(/\r\n/g, "\n");
+  const text = (input ?? "").replace(/\r\n|\r/g, "\n");
   const blank = text.search(/\n\n/);
   const raw = (blank === -1 ? text : text.slice(0, blank)).replace(/\n+$/, "");
 


### PR DESCRIPTION
## Summary

Follow-up to #224/#225 (`get-message-headers`, dateSent/dateReceived split).

`@j5pu` reported (#226) that on old Entourage/Outlook-for-Mac messages
(~2005-2011, MIME boundary `OUTLOOK2MACxxxxxxxx`) whose `Date:` header was
written in the OS locale instead of RFC 5322 (e.g. Spanish
`jue ago 30 13:55:12 2007`), `get-message-headers` returned
`dateHeader: "Subject: diferencial"` — the Subject line apparently merged
into the Date value and dropped from the output.

**What I found:** the reporter's literal minimal-repro text, tested directly
against `parseHeaderBlock` in both LF and CRLF form, already parses
correctly on current `main` — `Date:` and `Subject:` both come out intact,
unmerged. So the exact byte-for-byte mechanism they hit couldn't be pinned
down from the repro as given.

**What I did find, and fixed:** `parseHeaderBlock` has zero handling for
bare-CR (`\r`-only) line endings. Mail's `all headers of msg` AppleScript
property (the backend this exact tool call goes through for a numeric id) is
a multi-line text value, and this codebase already works around exactly this
line-ending quirk on the *write* side (`escapeForAppleScriptBody` normalizes
`\r\n|\r|\n` uniformly) — nothing did the equivalent on read-back. Left
unhandled, a bare-CR header block doesn't just merge two headers, it's worse:
`.split("\n")` never splits (there's no `\n` to split on), and JS's regex `.`
excludes `\r` too, so the whole per-line header match fails and **every**
header is silently dropped — a strictly worse, completely unguarded failure
mode in the exact code path #226 is about.

## Changes
- `src/utils/headers.ts`: `parseHeaderBlock` now normalizes CRLF, CR, and LF
  uniformly (`replace(/\r\n|\r/g, "\n")`) before splitting into lines.
- `src/utils/headers.test.ts`: regression coverage —
  - the reporter's OS-locale Date: repro (LF and CRLF) pinned down as
    already-passing: Date and Subject both survive, `date` is correctly
    `undefined` for the unparseable locale string, no header drops/merges;
  - the same repro under bare-CR line endings, previously returning zero
    headers, now parses identically to LF/CRLF;
  - blank-line (body) truncation still works correctly under CR-only input.

## Verification
- `pnpm run lint && pnpm run typecheck && pnpm test && pnpm run format:check`
  — all green (807 tests passing, lint has only pre-existing `no-explicit-any`
  warnings, 0 errors).
- `pnpm run build` — esbuild bundle rebuilt and committed.
- **Not verified:** live Mail.app / a real Outlook-for-Mac-era message over
  AppleScript. This is a headless/scheduled run with no way to drive Mail.app
  or answer a TCC prompt, so the fix is validated by unit test only. If bare-CR
  wasn't the exact mechanism the reporter hit, I've said as much on the issue
  and asked for a raw byte dump (e.g. `od -c` on an exported `.eml`, or the
  literal escaped bytes) to pin down anything more exotic.

## Release
- Version bumped 2.19.0 → 2.19.1 (`pnpm version patch --no-git-tag-version`).
- CHANGELOG.md entry filed under a real `## [2.19.1] - 2026-09-13` heading.
- Docs (README/CLAUDE.md `dateHeader`/"Two dates" sections) reviewed — no
  changes needed, output shape and semantics are unaffected by this fix.

Fixes #226.